### PR TITLE
Implement activity status privacy

### DIFF
--- a/app_src/lib/explore_screen/chats/chat_screen.dart
+++ b/app_src/lib/explore_screen/chats/chat_screen.dart
@@ -66,6 +66,8 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
   // Para saber si yo tengo bloqueado a mi chatPartner
   bool _isPartnerBlocked = false;
 
+  bool _partnerActivityPublic = true;
+
   // Carga futuro con icono de marcador (para ubicaciones)
   late Future<BitmapDescriptor> _markerIconFuture;
 
@@ -127,6 +129,8 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
           theirData['deletedChats'][currentUserId] != null) {
         _theirDeletedAt = theirData['deletedChats'][currentUserId];
       }
+      _partnerActivityPublic =
+          theirData['activityStatusPublic'] != false;
     }
   }
 
@@ -345,9 +349,10 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
                                 ),
                                 overflow: TextOverflow.ellipsis,
                               ),
-                              UserActivityStatus(
-                                userId: widget.chatPartnerId,
-                              ),
+                              if (_partnerActivityPublic)
+                                UserActivityStatus(
+                                  userId: widget.chatPartnerId,
+                                ),
                             ],
                           ),
                         ),

--- a/app_src/lib/explore_screen/plans_managing/plan_card.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_card.dart
@@ -484,6 +484,7 @@ class PlanCardState extends State<PlanCard> {
   // ─────────────────────────────────────────────────────────────
   Widget _buildCreatorFrosted(String name, String? photoUrl) {
     final creatorUid = widget.plan.createdBy;
+    final bool showActivity = widget.userData['activityStatusPublic'] != false;
 
     return ClipRRect(
       borderRadius: BorderRadius.circular(30),
@@ -529,7 +530,7 @@ class PlanCardState extends State<PlanCard> {
                   ),
 
                   // Solo el estado de actividad
-                  if (creatorUid.isNotEmpty)
+                  if (creatorUid.isNotEmpty && showActivity)
                     UserActivityStatus(userId: creatorUid),
                 ],
               ),

--- a/app_src/lib/explore_screen/users_grid/users_grid.dart
+++ b/app_src/lib/explore_screen/users_grid/users_grid.dart
@@ -239,6 +239,7 @@ class _UsersGridState extends State<UsersGrid> {
     final String name = userData['name']?.toString().trim() ?? 'Usuario';
     final String? uid = userData['uid']?.toString();
     final String? fallbackPhotoUrl = userData['photoUrl']?.toString();
+    final bool showActivity = userData['activityStatusPublic'] != false;
 
     return Center(
       child: Container(
@@ -311,7 +312,7 @@ class _UsersGridState extends State<UsersGrid> {
                                 ],
                               ),
                               // AQUI LLAMAMOS AL WIDGET DE PRESENCIA
-                              if (uid != null)
+                              if (uid != null && showActivity)
                                 UserActivityStatus(
                                   userId: uid,
                                 ),

--- a/app_src/lib/explore_screen/users_managing/user_activity_status.dart
+++ b/app_src/lib/explore_screen/users_managing/user_activity_status.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 // Cambiamos esta import:
 import 'package:firebase_database/firebase_database.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 // Widget que muestra la actividad de un usuario usando Realtime Database.
 class UserActivityStatus extends StatefulWidget {
@@ -21,16 +22,20 @@ class _UserActivityStatusState extends State<UserActivityStatus> {
   bool _isOnline = false;
   DateTime? _lastSeen;
   StreamSubscription<DatabaseEvent>? _rtdbSubscription;
+  StreamSubscription<DocumentSnapshot>? _userDocSub;
+  bool _showStatus = true;
 
   @override
   void initState() {
     super.initState();
     _listenToUserStatus(widget.userId);
+    _listenToPrivacy(widget.userId);
   }
 
   @override
   void dispose() {
     _rtdbSubscription?.cancel();
+    _userDocSub?.cancel();
     super.dispose();
   }
 
@@ -71,6 +76,25 @@ class _UserActivityStatusState extends State<UserActivityStatus> {
     });
   }
 
+  void _listenToPrivacy(String uid) {
+    _userDocSub = FirebaseFirestore.instance
+        .collection('users')
+        .doc(uid)
+        .snapshots()
+        .listen((snapshot) {
+      final data = snapshot.data();
+      if (data != null && data['activityStatusPublic'] is bool) {
+        setState(() {
+          _showStatus = data['activityStatusPublic'] as bool;
+        });
+      } else {
+        setState(() {
+          _showStatus = true;
+        });
+      }
+    });
+  }
+
   /// Retorna un string estilo "Hace 5 minuto/s", etc.
   String _formatLastActive(DateTime? dt) {
     if (dt == null) return "Desconectado";
@@ -89,6 +113,7 @@ class _UserActivityStatusState extends State<UserActivityStatus> {
 
   @override
   Widget build(BuildContext context) {
+    if (!_showStatus) return const SizedBox.shrink();
     if (_isOnline) {
       // Usuario conectado
       return Row(


### PR DESCRIPTION
## Summary
- add Firestore-driven privacy toggle for activity status
- hide activity status via `UserActivityStatus` when user disables it
- respect the new setting on user cards, plan cards and chat screen

## Testing
- `git status --short`