### PR TITLE
Fix map markers to show only users with upcoming plans

### DIFF
--- a/app_src/lib/explore_screen/map/map_screen.dart
+++ b/app_src/lib/explore_screen/map/map_screen.dart
@@ -92,8 +92,9 @@ class MapScreenState extends State<MapScreen> {
   Future<void> _loadMarkers() async {
     final plansLoader = PlansInMapScreen();
     final planMarkers = await plansLoader.loadPlansMarkers(context);
-    final userNoPlanMarkers = await plansLoader.loadUsersWithoutPlansMarkers(context);
-    _allMarkers = [...planMarkers, ...userNoPlanMarkers];
+    // Only display markers for users that have upcoming plans. Users without
+    // future plans should not appear on the map.
+    _allMarkers = [...planMarkers];
     _updateVisibleMarkers(_currentZoom);
   }
 


### PR DESCRIPTION
## Summary
- hide markers for users without future plans

## Testing
- `flutter analyze` *(fails: `flutter: command not found`)*