### PR TITLE
Fix stats tap on private profiles

### DIFF
--- a/app_src/lib/explore_screen/users_managing/user_info_check.dart
+++ b/app_src/lib/explore_screen/users_managing/user_info_check.dart
@@ -741,6 +741,10 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
 
     return GestureDetector(
       onTap: () {
+        if (_isPrivate && !isFollowing) {
+          _showPrivateToast();
+          return;
+        }
         if (isFuture) {
           FuturePlansScreen.show(
             context: context,


### PR DESCRIPTION
## Summary
- prevent unauthorized access to stats of private profiles
- show private profile toast when tapping future plans, followers or following

## Testing
- `dart analyze` *(fails: command not found)*