### PR TITLE
Implement substring search and UI improvements

### DIFF
--- a/app_src/lib/explore_screen/main_screen/explore_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/explore_screen.dart
@@ -45,6 +45,7 @@ class ExploreScreenState extends State<ExploreScreen> {
 
   String _searchQuery = '';
   bool _showSearchResults = false;
+  final TextEditingController _searchController = TextEditingController();
 
   @override
   void initState() {
@@ -57,6 +58,12 @@ class ExploreScreenState extends State<ExploreScreen> {
     ];
     _currentIndex = 0;
     _selectedIconIndex = 0;
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
   }
 
   void _setStatusBarDark() {
@@ -125,13 +132,15 @@ class ExploreScreenState extends State<ExploreScreen> {
             notificationCountStream: _notificationCountStream(),
           ),
           _buildSearchContainer(),
-          if (_showSearchResults)
-            Searcher(
-              query: _searchQuery,
-              maxHeight: 300,
-              isVisible: true,
-            ),
-          Expanded(child: _buildNearbySection()),
+          Expanded(
+            child: _showSearchResults
+                ? Searcher(
+                    query: _searchQuery,
+                    maxHeight: double.infinity,
+                    isVisible: true,
+                  )
+                : _buildNearbySection(),
+          ),
         ],
       ),
     );
@@ -170,16 +179,41 @@ class ExploreScreenState extends State<ExploreScreen> {
               ),
             ),
             Expanded(
-              child: TextField(
-                onChanged: (value) {
-                  setState(() {
-                    _searchQuery = value;
-                    _showSearchResults = value.isNotEmpty;
-                  });
-                },
-                decoration: const InputDecoration(
-                  hintText: 'Buscar...',
-                  border: InputBorder.none,
+              child: Container(
+                decoration: BoxDecoration(
+                  color: const Color.fromARGB(255, 230, 230, 230),
+                  borderRadius: BorderRadius.circular(30),
+                ),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: TextField(
+                        controller: _searchController,
+                        onChanged: (value) {
+                          setState(() {
+                            _searchQuery = value;
+                            _showSearchResults = value.isNotEmpty;
+                          });
+                        },
+                        decoration: const InputDecoration(
+                          hintText: 'Buscar...',
+                          border: InputBorder.none,
+                          contentPadding: EdgeInsets.symmetric(horizontal: 8),
+                        ),
+                      ),
+                    ),
+                    if (_searchController.text.isNotEmpty)
+                      IconButton(
+                        icon: const Icon(Icons.close, size: 20, color: Colors.black54),
+                        onPressed: () {
+                          setState(() {
+                            _searchController.clear();
+                            _searchQuery = '';
+                            _showSearchResults = false;
+                          });
+                        },
+                      ),
+                  ],
                 ),
               ),
             ),

--- a/app_src/lib/main/colors.dart
+++ b/app_src/lib/main/colors.dart
@@ -32,6 +32,7 @@ class AppColors {
 
   // Nuevos colores para filtros
   static const Color lightLilac = Color(0xFFF2E6FF);
+  static const Color searchLilac = Color(0xFFE6D3FF);
   static const Color lightTurquoise = Color(0xFFCCF1F0);
   static const Color greyBorder = Color(0xFFCCCCCC);
 


### PR DESCRIPTION
## Summary
- add `searchLilac` color constant
- support substring search for users and plans
- color search results background and make search results replace grid
- enhance explore search field with clear button
- manage search field controller lifecycle

## Testing
- `dart format` *(fails: `bash: dart: command not found`)*