### PR TITLE
Fix avatar persistence and adjust marker visuals

### DIFF
--- a/app_src/lib/explore_screen/map/plans_in_map_screen.dart
+++ b/app_src/lib/explore_screen/map/plans_in_map_screen.dart
@@ -198,8 +198,8 @@ class PlansInMapScreen {
       const double mw = 140,
           padding = 4,
           fs = 20,
-          tm = 10,
-          avatarArea = 130;
+          tm = 29,
+          avatarArea = 140;
       double textH = 0;
       TextPainter? tp;
       if (showText) {
@@ -236,14 +236,14 @@ class PlansInMapScreen {
         tp.paint(canvas, Offset(tx, ty));
       }
       final cy = (showText ? textH : 0) + avatarArea / 2;
-      const cr = 50.0;
+      const cr = 45.0;
       final center = Offset(mw / 2, cy);
       final clipPath = Path()
         ..addOval(Rect.fromCircle(center: center, radius: cr));
       canvas.save();
       canvas.clipPath(clipPath);
       final imgRect =
-          Rect.fromCenter(center: center, width: cr * 2, height: cr * 2);
+          Rect.fromCenter(center: center, width: cr * 2, height: cr * 2 + 10);
       paintImage(
         canvas: canvas,
         rect: imgRect,
@@ -273,7 +273,7 @@ class PlansInMapScreen {
     try {
       // Aumentamos el tamaño base del marcador de usuario sin plan para que la
       // imagen no se muestre achatada en vertical.
-      const double sz = 120, r = 50;
+      const double sz = 120, r = 45;
       Uint8List? bytes;
       if (photoUrl.isNotEmpty) {
         bytes = await _downloadImageAsBytes(photoUrl);

--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -1253,7 +1253,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
         final currentUid = FirebaseAuth.instance.currentUser?.uid;
         if (creatorUid.isNotEmpty && creatorUid != currentUid) {
           await UserInfoCheck.open(context, creatorUid);
-          if (mounted) setState(() {});
+          if (mounted) await _fetchCreatorInfo();
         }
       },
       child: Padding(


### PR DESCRIPTION
## Summary
- refresh plan creator info when coming back from user profile
- tweak marker drawing to reduce radius and stretch avatar height

## Testing
- `flutter analyze` *(fails: `flutter` not found)*