### PR TITLE
Fix avatar loss in plan dialog

### DIFF
--- a/app_src/lib/explore_screen/map/plans_in_map_screen.dart
+++ b/app_src/lib/explore_screen/map/plans_in_map_screen.dart
@@ -70,6 +70,8 @@ class PlansInMapScreen {
               transitionDuration: const Duration(milliseconds: 300),
               pageBuilder: (context, animation, secondaryAnimation) {
                 final size = MediaQuery.of(context).size;
+                final plan = PlanModel.fromMap(data)
+                  ..creatorProfilePic = photoUrl;
                 return Align(
                   alignment: Alignment.center,
                   child: Material(
@@ -78,7 +80,7 @@ class PlansInMapScreen {
                       width: size.width,
                       height: size.height,
                       child: FrostedPlanDialog(
-                        plan: PlanModel.fromMap(data),
+                        plan: plan,
                         fetchParticipants: _fetchPlanParticipants,
                       ),
                     ),
@@ -198,8 +200,8 @@ class PlansInMapScreen {
       const double mw = 140,
           padding = 4,
           fs = 20,
-          tm = 10,
-          avatarArea = 130;
+          tm = 29,
+          avatarArea = 140;
       double textH = 0;
       TextPainter? tp;
       if (showText) {
@@ -236,14 +238,14 @@ class PlansInMapScreen {
         tp.paint(canvas, Offset(tx, ty));
       }
       final cy = (showText ? textH : 0) + avatarArea / 2;
-      const cr = 50.0;
+      const cr = 45.0;
       final center = Offset(mw / 2, cy);
       final clipPath = Path()
         ..addOval(Rect.fromCircle(center: center, radius: cr));
       canvas.save();
       canvas.clipPath(clipPath);
       final imgRect =
-          Rect.fromCenter(center: center, width: cr * 2, height: cr * 2);
+          Rect.fromCenter(center: center, width: cr * 2, height: cr * 2 + 10);
       paintImage(
         canvas: canvas,
         rect: imgRect,
@@ -273,7 +275,7 @@ class PlansInMapScreen {
     try {
       // Aumentamos el tamaño base del marcador de usuario sin plan para que la
       // imagen no se muestre achatada en vertical.
-      const double sz = 120, r = 50;
+      const double sz = 120, r = 45;
       Uint8List? bytes;
       if (photoUrl.isNotEmpty) {
         bytes = await _downloadImageAsBytes(photoUrl);

--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -39,6 +39,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
   final User? _currentUser = FirebaseAuth.instance.currentUser;
 
   String? _creatorAge;
+  String? _creatorPhotoUrl;
   bool _liked = false;
   int _likeCount = 0;
 
@@ -50,6 +51,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
     super.initState();
     _futureParticipants = widget.fetchParticipants(widget.plan);
     _likeCount = widget.plan.likes;
+    _creatorPhotoUrl = widget.plan.creatorProfilePic;
     _checkIfLiked();
     _fetchCreatorInfo();
     _pageController = PageController();
@@ -88,6 +90,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
         setState(() {
           widget.plan.creatorName = data['name'] ?? 'Creador';
           widget.plan.creatorProfilePic = data['photoUrl'] ?? '';
+          _creatorPhotoUrl = widget.plan.creatorProfilePic;
           _creatorAge = ageCreador;
         });
       }
@@ -851,7 +854,10 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
       }
 
       return GestureDetector(
-        onTap: () => _showParticipantsModal(participants),
+        onTap: () async {
+          await _showParticipantsModal(participants);
+          if (mounted) setState(() {});
+        },
         child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
           decoration: BoxDecoration(
@@ -887,7 +893,10 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
           : (avatarSize + overlapOffset);
 
       return GestureDetector(
-        onTap: () => _showParticipantsModal(participants),
+        onTap: () async {
+          await _showParticipantsModal(participants);
+          if (mounted) setState(() {});
+        },
         child: SizedBox(
           width: containerWidth,
           height: avatarSize,
@@ -1253,7 +1262,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
         final currentUid = FirebaseAuth.instance.currentUser?.uid;
         if (creatorUid.isNotEmpty && creatorUid != currentUid) {
           await UserInfoCheck.open(context, creatorUid);
-          if (mounted) setState(() {});
+          if (mounted) await _fetchCreatorInfo();
         }
       },
       child: Padding(
@@ -1264,15 +1273,18 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
               radius: 20,
               backgroundColor: Colors.blueGrey[400],
               child: ClipOval(
-                child: (widget.plan.creatorProfilePic?.isNotEmpty ?? false)
+                child: (_creatorPhotoUrl?.isNotEmpty ?? false)
                     ? CachedNetworkImage(
-                        imageUrl: widget.plan.creatorProfilePic!,
+                        imageUrl: _creatorPhotoUrl!,
                         width: 40,
                         height: 40,
                         fit: BoxFit.cover,
-                        placeholder: (context, url) =>
-                            const SizedBox(width: 20, height: 20, child: CircularProgressIndicator(strokeWidth: 2)),
-                        errorWidget: (context, url, error) => const Icon(Icons.person, color: Colors.white),
+                        placeholder: (context, url) => const SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator(strokeWidth: 2)),
+                        errorWidget: (context, url, error) =>
+                            const Icon(Icons.person, color: Colors.white),
                       )
                     : const Icon(Icons.person, color: Colors.white),
               ),


### PR DESCRIPTION
## Summary
- retain creator avatar inside plan dialog
- pass the avatar url from map marker to plan dialog
- refresh participants corner after closing the modal

## Testing
- `flutter analyze` *(fails: `flutter` not found)*