### PR TITLE
Remove all print and debugPrint calls

### DIFF
--- a/app_src/lib/explore_screen/chats/chat_screen.dart
+++ b/app_src/lib/explore_screen/chats/chat_screen.dart
@@ -175,7 +175,6 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
           await batch.commit();
         }
       } catch (e) {
-        print("Error al eliminar mensajes antiguos: $e");
       }
     }
   }
@@ -196,7 +195,6 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
       }
       await batch.commit();
     } catch (e) {
-      print("❌ Error al marcar mensajes como leídos: $e");
     }
   }
 
@@ -225,7 +223,6 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
       try {
         await batch.commit();
       } catch (e) {
-        print("❌ Error al actualizar isRead: $e");
       }
     }
   }
@@ -250,7 +247,6 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
     try {
       return BitmapDescriptor.defaultMarkerWithHue(BitmapDescriptor.hueRed);
     } catch (e) {
-      print("Error al cargar icono del marcador: $e");
       return BitmapDescriptor.defaultMarker;
     }
   }
@@ -699,7 +695,6 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
                           'text': 'El mensaje original ha sido eliminado.',
                         });
                       } catch (e) {
-                        debugPrint('Error al eliminar mensaje: $e');
                       }
                     },
                   );
@@ -733,7 +728,6 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
     try {
       await batch.commit();
     } catch (e) {
-      print("❌ Error al marcar mensajes como entregados: $e");
     }
   }
 
@@ -1449,7 +1443,6 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
         ),
       );
     } catch (e) {
-      print("Error al abrir plan: $e");
     }
   }
 
@@ -1825,7 +1818,6 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
 
       cancelReply();
     } catch (e) {
-      print("Error subiendo/enviando imagen: $e");
     }
   }
 
@@ -1843,7 +1835,6 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
 
     if (blockedDoc.exists) {
       // Significa que tu chatPartnerId ha bloqueado a currentUserId
-      print("La otra persona te ha bloqueado, no puedes enviar mensajes.");
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text("La otra persona te ha bloqueado.")),
       );
@@ -1877,7 +1868,6 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
 
       cancelReply();
     } catch (e) {
-      print("❌ Error al enviar mensaje: $e");
     }
   }
 }

--- a/app_src/lib/explore_screen/chats/chats_screen.dart
+++ b/app_src/lib/explore_screen/chats/chats_screen.dart
@@ -89,7 +89,6 @@ class _ChatsScreenState extends State<ChatsScreen> {
         const SnackBar(content: Text("Chat eliminado.")),
       );
     } catch (e) {
-      print("❌ Error al eliminar chat: $e");
     }
   }
 
@@ -582,7 +581,6 @@ class _ChatsScreenState extends State<ChatsScreen> {
         _searchResults = filtered;
       });
     } catch (e) {
-      print("Error al buscar usuarios: $e");
     }
   }
 

--- a/app_src/lib/explore_screen/chats/inner_chat_utils/answer_a_message.dart
+++ b/app_src/lib/explore_screen/chats/inner_chat_utils/answer_a_message.dart
@@ -224,7 +224,6 @@ mixin AnswerAMessageMixin<T extends StatefulWidget> on State<T> {
                   final text = messageData['text'] ?? '';
                   if (text.toString().isNotEmpty) {
                     Clipboard.setData(ClipboardData(text: text));
-                    debugPrint('¡Mensaje copiado al portapapeles!');
                   }
                 },
               ),
@@ -239,7 +238,6 @@ mixin AnswerAMessageMixin<T extends StatefulWidget> on State<T> {
                   if (onDelete != null) {
                     onDelete();
                   } else {
-                    debugPrint('El usuario quiere eliminar el mensaje');
                   }
                 },
               ),

--- a/app_src/lib/explore_screen/chats/inner_chat_utils/open_location.dart
+++ b/app_src/lib/explore_screen/chats/inner_chat_utils/open_location.dart
@@ -16,6 +16,5 @@ Future<void> openLocation({
     await launchUrl(googleMapsUrl, mode: LaunchMode.externalApplication);
   } else {
     // Fallback
-    print("No se pudo abrir la ubicación en Google Maps");
   }
 }

--- a/app_src/lib/explore_screen/chats/inner_chat_utils/picture_managing.dart
+++ b/app_src/lib/explore_screen/chats/inner_chat_utils/picture_managing.dart
@@ -51,7 +51,6 @@ class _FullImageViewerScreenState extends State<FullImageViewerScreen> {
         _onScreenRecord,
       );
     } catch (e) {
-      debugPrint("Error al bloquear capturas: $e");
     }
   }
 
@@ -62,21 +61,18 @@ class _FullImageViewerScreenState extends State<FullImageViewerScreen> {
       ScreenProtector.removeListener();
       _screenRecordSubscription?.cancel();
     } catch (e) {
-      debugPrint("Error al desbloquear capturas: $e");
     }
   }
 
   /// Callback que se dispara en iOS cuando se toma una captura.
   /// En Android NO existe el callback, solo se bloquea (FLAG_SECURE).
   void _onScreenshotTaken() {
-    debugPrint("Captura detectada en iOS!");
     _showPrivacyWarning();
   }
 
   /// Callback que se dispara en iOS cuando inicia/termina una grabación de pantalla.
   /// [isRecording] es true si se está grabando, false si terminó.
   void _onScreenRecord(bool isRecording) {
-    debugPrint("Screen recording: $isRecording");
     // Si quisieras mostrar el mismo mensaje cuando empieza a grabar, podrías:
     // if (isRecording) _showPrivacyWarning();
   }

--- a/app_src/lib/explore_screen/chats/location_pick_screen.dart
+++ b/app_src/lib/explore_screen/chats/location_pick_screen.dart
@@ -63,7 +63,6 @@ class _LocationPickScreenState extends State<LocationPickScreen> {
         height: 48,
       );
     } catch (e) {
-      print("Error cargando ícono de marcador: $e");
       _markerIcon = BitmapDescriptor.defaultMarker;
     }
     setState(() {});
@@ -98,7 +97,6 @@ class _LocationPickScreenState extends State<LocationPickScreen> {
         _moveCameraTo(pos.latitude, pos.longitude);
         await _reverseGeocode(pos.latitude, pos.longitude);
       } catch (e) {
-        print("Error al obtener ubicación actual: $e");
       }
     }
   }
@@ -121,7 +119,6 @@ class _LocationPickScreenState extends State<LocationPickScreen> {
         });
       }
     } catch (e) {
-      print("Error en reverseGeocode: $e");
       _selectedAddress = null;
     }
   }
@@ -159,7 +156,6 @@ class _LocationPickScreenState extends State<LocationPickScreen> {
         await _moveCameraTo(loc.latitude, loc.longitude);
       }
     } catch (e) {
-      print("Error al buscar dirección: $e");
     }
 
     setState(() => _isSearching = false);

--- a/app_src/lib/explore_screen/follow/following_screen.dart
+++ b/app_src/lib/explore_screen/follow/following_screen.dart
@@ -125,7 +125,6 @@ class _FollowingScreenState extends State<FollowingScreen> {
         _loading = false;
       });
     } catch (e) {
-      debugPrint('[FollowingScreen] Error cargando datos: $e');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Error al cargar datos: $e')),

--- a/app_src/lib/explore_screen/main_screen/explore_screen_filter.dart
+++ b/app_src/lib/explore_screen/main_screen/explore_screen_filter.dart
@@ -131,7 +131,6 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
         });
       }
     } catch (e) {
-      debugPrint("Error al convertir dirección a coordenadas: $e");
     }
   }
 
@@ -155,7 +154,6 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
         });
       }
     } catch (e) {
-      debugPrint("Error al obtener ubicación: $e");
     }
   }
 
@@ -221,13 +219,10 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
             _regionPredictions = data['predictions'];
           });
         } else {
-          debugPrint('Error en la API de Google Places: ${data['status']}');
         }
       } else {
-        debugPrint('Error HTTP: ${response.statusCode}');
       }
     } catch (e) {
-      debugPrint('Error al obtener predicciones: $e');
     }
   }
 

--- a/app_src/lib/explore_screen/main_screen/filter_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/filter_screen.dart
@@ -63,7 +63,6 @@ class _FilterScreenState extends State<FilterScreen> {
         });
       }
     } catch (e) {
-      print("Error obteniendo ubicación: $e");
     }
   }
 
@@ -121,7 +120,6 @@ class _FilterScreenState extends State<FilterScreen> {
                         });
                       }
                     } catch (e) {
-                      print("Error obteniendo ubicación seleccionada: $e");
                     }
                   }
                   Navigator.pop(context);

--- a/app_src/lib/explore_screen/main_screen/searcher.dart
+++ b/app_src/lib/explore_screen/main_screen/searcher.dart
@@ -64,7 +64,6 @@ class _SearcherState extends State<Searcher> {
     super.initState();
     if (widget.query.isNotEmpty) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        debugPrint('Texto introducido en el buscador (init): ${widget.query}');
         _performSearch(widget.query);
       });
     }
@@ -74,7 +73,6 @@ class _SearcherState extends State<Searcher> {
   void didUpdateWidget(covariant Searcher oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.query != oldWidget.query) {
-      debugPrint("Texto introducido en el buscador: ${widget.query}");
       WidgetsBinding.instance.addPostFrameCallback((_) {
         _performSearch(widget.query);
       });
@@ -83,7 +81,6 @@ class _SearcherState extends State<Searcher> {
 
   /// Realiza la búsqueda de usuarios y planes en Firestore.
   Future<void> _performSearch(String rawQuery) async {
-    debugPrint("Entramos a _performSearch con: '$rawQuery'");
 
     final cleanedQuery = rawQuery.trim();
     if (cleanedQuery.isEmpty) {
@@ -206,7 +203,6 @@ class _SearcherState extends State<Searcher> {
         });
       }
     } catch (e) {
-      debugPrint("Error al buscar: $e");
       if (mounted) setState(() => _isLoading = false);
     }
   }

--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -95,7 +95,6 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
         });
       }
     } catch (e) {
-      debugPrint('Error al obtener info creador: $e');
     }
   }
 
@@ -831,7 +830,6 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
         await d.reference.delete();
       }
     } catch (e) {
-      debugPrint('Error al eliminar participante: $e');
     }
   }
 
@@ -960,7 +958,6 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
       final planData = planSnap.data();
       checkedInUsers = planData?['checkedInUsers'] ?? [];
     } catch (e) {
-      debugPrint('Error al cargar checkedInUsers: $e');
     }
 
     showDialog(
@@ -1660,7 +1657,6 @@ class _CustomShareDialogContentState extends State<_CustomShareDialogContent> {
       _following = await _fetchUsersData(followedUids);
       setState(() {});
     } catch (e) {
-      print("Error al cargar followers/following: $e");
     }
   }
 

--- a/app_src/lib/explore_screen/plans_managing/plan_card.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_card.dart
@@ -273,7 +273,6 @@ class PlanCardState extends State<PlanCard> {
         await d.reference.delete();
       }
     } catch (e) {
-      debugPrint('Error al eliminar participante: $e');
     }
   }
 
@@ -748,7 +747,6 @@ class PlanCardState extends State<PlanCard> {
       final planData = planSnap.data();
       checkedInUsers = planData?['checkedInUsers'] ?? [];
     } catch (e) {
-      debugPrint('Error al cargar checkedInUsers: $e');
     }
 
     showDialog(

--- a/app_src/lib/explore_screen/plans_managing/plan_share_sheet.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_share_sheet.dart
@@ -68,7 +68,6 @@ class PlanShareSheetState extends State<PlanShareSheet> {
       _following = await _fetchUsersData(followedUids);
       setState(() {});
     } catch (e) {
-      debugPrint("Error al cargar followers/following: $e");
     }
   }
 

--- a/app_src/lib/explore_screen/profile/image_share_sheet.dart
+++ b/app_src/lib/explore_screen/profile/image_share_sheet.dart
@@ -68,7 +68,6 @@ class _ImageShareSheetState extends State<ImageShareSheet> {
 
       setState(() {});
     } catch (e) {
-      debugPrint("Error al cargar followers/following: $e");
     }
   }
 

--- a/app_src/lib/explore_screen/profile/memories_calendar.dart
+++ b/app_src/lib/explore_screen/profile/memories_calendar.dart
@@ -90,7 +90,6 @@ class _MemoriesCalendarState extends State<MemoriesCalendar> {
         _plansByDate = tempMap;
       });
     } catch (e) {
-      debugPrint("[_fetchUserPlans] Error: $e");
     }
   }
 

--- a/app_src/lib/explore_screen/profile/plan_memories_screen.dart
+++ b/app_src/lib/explore_screen/profile/plan_memories_screen.dart
@@ -67,7 +67,6 @@ class _PlanMemoriesScreenState extends State<PlanMemoriesScreen> {
         }
       }
     } catch (e) {
-      debugPrint('Error al cargar memories: $e');
     }
   }
 

--- a/app_src/lib/explore_screen/profile/profile_screen.dart
+++ b/app_src/lib/explore_screen/profile/profile_screen.dart
@@ -107,7 +107,6 @@ class ProfileScreenState extends State<ProfileScreen> {
         setState(() => _privilegeLevel = newLevel);
       }
     } catch (e) {
-      debugPrint("[_fetchPrivilegeLevel] Error: $e");
     }
   }
 

--- a/app_src/lib/explore_screen/profile/user_images_managing.dart
+++ b/app_src/lib/explore_screen/profile/user_images_managing.dart
@@ -27,7 +27,6 @@ class UserImagesManaging {
           .get();
       return doc.data()?['photoUrl'] ?? "";
     } catch (e) {
-      debugPrint("Error al cargar la foto de perfil: $e");
       return null;
     }
   }
@@ -159,7 +158,6 @@ class UserImagesManaging {
       final covers = doc.data()?['coverPhotos'] as List<dynamic>?;
       return (covers != null) ? List<String>.from(covers) : [];
     } catch (e) {
-      debugPrint("Error al cargar imágenes de portada: $e");
       return [];
     }
   }
@@ -308,7 +306,6 @@ class UserImagesManaging {
       final photos = doc.data()?['additionalPhotos'] as List<dynamic>?;
       return (photos != null) ? List<String>.from(photos) : [];
     } catch (e) {
-      debugPrint("Error al cargar fotos adicionales: $e");
       return [];
     }
   }

--- a/app_src/lib/explore_screen/users_managing/privilege_level_details.dart
+++ b/app_src/lib/explore_screen/users_managing/privilege_level_details.dart
@@ -45,8 +45,6 @@ class PrivilegeLevelDetails extends StatefulWidget {
     });
     // OJO: Ya no tocamos total_created_plans aquí,
     // porque se recalcula en user_info_check.
-    // ignore: avoid_print
-    print("Estadísticas de suscripción actualizadas para userId=$userId");
   }
 
   @override
@@ -155,8 +153,6 @@ class _PrivilegeLevelDetailsState extends State<PrivilegeLevelDetails> {
           .collection('users')
           .doc(widget.userId)
           .update({'privilegeLevel': newLevel});
-      // ignore: avoid_print
-      print("Nivel actualizado de $_privilegeLevel a $newLevel");
     }
   }
 

--- a/app_src/lib/explore_screen/users_managing/report_and_block_user.dart
+++ b/app_src/lib/explore_screen/users_managing/report_and_block_user.dart
@@ -143,7 +143,6 @@ class _ReportUserScreenState extends State<ReportUserScreen> {
 
       Navigator.pop(context); // cierra la pantalla
     } catch (e) {
-      print("Error al enviar reporte: $e");
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text("Ocurrió un error al enviar reporte.")),
       );
@@ -353,9 +352,7 @@ class ReportAndBlockUser {
       'timestamp': FieldValue.serverTimestamp(),
     });
 
-    print("Usuario $chatPartnerId bloqueado por $currentUserId (doc $docId)");
   } catch (e) {
-    print("Error bloqueando usuario: $e");
   }
 }
 
@@ -368,9 +365,7 @@ static Future<void> _unblockUser(String currentUserId, String chatPartnerId) asy
         .doc(docId)
         .delete();
 
-    print("Usuario $chatPartnerId desbloqueado por $currentUserId (doc $docId)");  
   } catch (e) {
-    print("Error desbloqueando usuario: $e");
   }
 }
 }

--- a/app_src/lib/explore_screen/users_managing/user_info_check.dart
+++ b/app_src/lib/explore_screen/users_managing/user_info_check.dart
@@ -148,7 +148,6 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
         });
       });
     } catch (e) {
-      debugPrint('[updateStatsBasedOnAllPlans] $e');
     }
   }
 
@@ -187,7 +186,6 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
 
       _isRequestPending = (q.docs.isNotEmpty && !isFollowing);
     } catch (e) {
-      debugPrint('[checkIfFollowRequestIsPending] Error: $e');
     }
   }
 
@@ -981,7 +979,6 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
 
       isFollowing = false;
     } catch (e) {
-      debugPrint('[unfollowUser] $e');
     }
   }
 
@@ -1037,7 +1034,6 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
         _isRequestPending = true;
       }
     } catch (e) {
-      debugPrint('[followUser] $e');
     }
   }
 
@@ -1076,7 +1072,6 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
         const SnackBar(content: Text('Solicitud de seguimiento cancelada.')),
       );
     } catch (e) {
-      debugPrint('[cancelFollowRequest] error: $e');
     }
   }
 

--- a/app_src/lib/main.dart
+++ b/app_src/lib/main.dart
@@ -154,7 +154,6 @@ class _MyAppState extends State<MyApp> {
     if (!kIsWeb) {
       _intentSub = ReceiveSharingIntent.instance
           .getMediaStream()
-          .listen(_onMedia, onError: (e) => debugPrint('RSI error: $e'));
 
       ReceiveSharingIntent.instance.getInitialMedia().then((files) {
         if (files.isNotEmpty) _onMedia(files);

--- a/app_src/lib/plan_creation/meeting_location_screen.dart
+++ b/app_src/lib/plan_creation/meeting_location_screen.dart
@@ -121,13 +121,10 @@ class _MeetingLocationPopupState extends State<MeetingLocationPopup> {
             _predictionList = data['predictions'];
           });
         } else {
-          debugPrint('Error en la API de Autocomplete: ${data['status']}');
         }
       } else {
-        debugPrint('Error HTTP: ${response.statusCode}');
       }
     } catch (e) {
-      debugPrint('Error al obtener predicciones: $e');
     }
   }
 
@@ -147,19 +144,15 @@ class _MeetingLocationPopupState extends State<MeetingLocationPopup> {
             _predictionList = [];
             _searchController.text = _selectedAddress!;
           });
-          debugPrint('Lugar seleccionado: $_selectedAddress ($_selectedLocation)');
           // Centrar la cámara en la ubicación seleccionada
           _mapController?.animateCamera(
             CameraUpdate.newLatLng(_selectedLocation!),
           );
         } else {
-          debugPrint('Error en la API de Place Details: ${data['status']}');
         }
       } else {
-        debugPrint('Error HTTP: ${response.statusCode}');
       }
     } catch (e) {
-      debugPrint('Error al obtener detalles del lugar: $e');
     }
   }
 
@@ -196,7 +189,6 @@ class _MeetingLocationPopupState extends State<MeetingLocationPopup> {
       String address;
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body);
-        debugPrint('Respuesta de reverse geocoding: $data');
         if (data['status'] == 'OK' &&
             data['results'] != null &&
             (data['results'] as List).isNotEmpty) {
@@ -213,12 +205,10 @@ class _MeetingLocationPopupState extends State<MeetingLocationPopup> {
         _selectedAddress = address;
         _searchController.text = address;
       });
-      debugPrint('Ubicación actual: $_selectedAddress ($_selectedLocation)');
       _mapController?.animateCamera(
         CameraUpdate.newLatLng(_selectedLocation!),
       );
     } catch (e) {
-      debugPrint("Error al obtener la ubicación: $e");
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text("Error al obtener la ubicación")),
       );
@@ -238,7 +228,6 @@ class _MeetingLocationPopupState extends State<MeetingLocationPopup> {
     widget.plan.location = _selectedAddress!;
     widget.plan.latitude = _selectedLocation!.latitude;
     widget.plan.longitude = _selectedLocation!.longitude;
-    debugPrint('Ubicación confirmada: ${widget.plan.location} (${widget.plan.latitude}, ${widget.plan.longitude})');
     Navigator.pop(context, widget.plan);
   }
 
@@ -291,7 +280,6 @@ class _MeetingLocationPopupState extends State<MeetingLocationPopup> {
                         _mapController?.animateCamera(
                           CameraUpdate.newLatLng(pos),
                         );
-                        debugPrint('Ubicación seleccionada manualmente: $pos');
                       },
                       initialCameraPosition: CameraPosition(
                         target: _initialPosition,

--- a/app_src/lib/plan_creation/new_plan_creation_screen.dart
+++ b/app_src/lib/plan_creation/new_plan_creation_screen.dart
@@ -47,7 +47,6 @@ Future<String?> uploadImageToFirebase(Uint8List imageData, String fileName) asyn
     String downloadURL = await ref.getDownloadURL();
     return downloadURL;
   } catch (error) {
-    print('Error al subir la imagen: $error');
     return null;
   }
 }
@@ -1813,7 +1812,6 @@ class __NewPlanPopupContentState extends State<_NewPlanPopupContent> {
       // Regresar y cerrar el popup
       Navigator.pop(context);
     } catch (error) {
-      print("Error al crear/editar plan: $error");
       _showErrorPopup("Ocurrió un error al procesar el plan.");
     }
   }

--- a/app_src/lib/start/registration/auth_service.dart
+++ b/app_src/lib/start/registration/auth_service.dart
@@ -2,7 +2,7 @@
 
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:google_sign_in/google_sign_in.dart';
-import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:flutter/foundation.dart';
 
 class AuthService {
   static final FirebaseAuth _auth = FirebaseAuth.instance;
@@ -50,7 +50,6 @@ class AuthService {
 
       return await _auth.signInWithCredential(credential);
     } catch (e) {
-      debugPrint('Error en Google Sign In: $e');
       rethrow;
     }
   }

--- a/app_src/lib/start/registration/user_registration_screen.dart
+++ b/app_src/lib/start/registration/user_registration_screen.dart
@@ -117,7 +117,6 @@ class _UserRegistrationScreenState extends State<UserRegistrationScreen> {
       await ref.putFile(file);
       return await ref.getDownloadURL();
     } catch (error) {
-      debugPrint('Error al subir archivo: $error');
       return null;
     }
   }
@@ -270,7 +269,6 @@ class _UserRegistrationScreenState extends State<UserRegistrationScreen> {
         (_) => false,
       );
     } catch (e) {
-      debugPrint("Error al crear usuario: $e");
       _showErrorPopup("Error al crear usuario: $e");
     } finally {
       setState(() => _isSaving = false);
@@ -627,7 +625,6 @@ class _UserRegistrationScreenState extends State<UserRegistrationScreen> {
           });
         }
       } catch (e) {
-        debugPrint("Error al hacer reverse geocoding: $e");
       }
     } else {
       // Si falla (usuario deniega permisos o no obtiene ubicación)


### PR DESCRIPTION
## Summary
- strip out `print` and `debugPrint` calls across the Flutter codebase
- tidy imports after removing debug utilities

## Testing
- `flutter test` *(fails: `flutter` not found)*