### PR TITLE
Fix plan views

### DIFF
--- a/app_src/lib/explore_screen/chats/chat_screen.dart
+++ b/app_src/lib/explore_screen/chats/chat_screen.dart
@@ -17,6 +17,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import '../../main/colors.dart';
 import '../../models/plan_model.dart';
 import '../plans_managing/frosted_plan_dialog_state.dart';
+import '../plans_managing/firebase_services.dart';
 import '../users_managing/user_info_check.dart';
 import 'select_plan_screen.dart';
 import 'location_pick_screen.dart';
@@ -1432,6 +1433,9 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
 
       final planData = planDoc.data()!;
       final plan = PlanModel.fromMap(planData);
+
+      // Increment unique views ignoring the creator
+      incrementPlanViewIfNeeded(plan.id, plan.createdBy);
 
       Navigator.push(
         context,

--- a/app_src/lib/explore_screen/plans_managing/plan_card.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_card.dart
@@ -13,6 +13,7 @@ import '../users_grid/users_grid_helpers.dart'; // buildPlaceholder, buildProfil
 import 'plan_share_sheet.dart';
 import '../users_managing/user_info_check.dart';
 import 'frosted_plan_dialog_state.dart';
+import 'firebase_services.dart';
 
 // Importamos el widget de estado de actividad:
 import '../users_managing/user_activity_status.dart';
@@ -279,15 +280,11 @@ class PlanCardState extends State<PlanCard> {
   // ─────────────────────────────────────────────────────────────
   // (5) Abrir detalles del plan
   // ─────────────────────────────────────────────────────────────
-  void _openPlanDetails(BuildContext context, PlanModel plan, {bool openChat = false}) {
-    FirebaseFirestore.instance.collection('plans').doc(plan.id).update({
-      'views': FieldValue.increment(1),
-    }).catchError((_) {
-      FirebaseFirestore.instance
-          .collection('plans')
-          .doc(plan.id)
-          .set({'views': 1}, SetOptions(merge: true));
-    });
+  Future<void> _openPlanDetails(BuildContext context, PlanModel plan,
+      {bool openChat = false}) async {
+    // Increment view count only once per user and ignore creator views
+    incrementPlanViewIfNeeded(plan.id, plan.createdBy);
+
     Navigator.push(
       context,
       MaterialPageRoute(


### PR DESCRIPTION
## Summary
- add helper to count plan views once per user
- use the helper when opening plan details from a card or chat

## Testing
- `flutter test` *(fails: `flutter: command not found`)*