### PR TITLE
Center chat title

### DIFF
--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -662,21 +662,24 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
       children: [
         Padding(
           padding: const EdgeInsets.all(8.0),
-          child: Row(
+          child: Stack(
+            alignment: Alignment.center,
             children: [
-              const Expanded(
-                child: Text(
-                  "Chat del Plan",
-                  style: TextStyle(
-                    color: AppColors.planColor,
-                    fontSize: 18,
-                    fontWeight: FontWeight.bold,
-                  ),
+              const Text(
+                "Chat del Plan",
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: AppColors.planColor,
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
                 ),
               ),
-              IconButton(
-                icon: const Icon(Icons.close, color: AppColors.planColor),
-                onPressed: () => Navigator.pop(context),
+              Positioned(
+                right: 0,
+                child: IconButton(
+                  icon: const Icon(Icons.close, color: AppColors.planColor),
+                  onPressed: () => Navigator.pop(context),
+                ),
               ),
             ],
           ),

--- a/app_src/lib/explore_screen/plans_managing/plan_card.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_card.dart
@@ -320,21 +320,24 @@ class PlanCardState extends State<PlanCard> {
         // Header
         Padding(
           padding: const EdgeInsets.all(8.0),
-          child: Row(
+          child: Stack(
+            alignment: Alignment.center,
             children: [
-              const Expanded(
-                child: Text(
-                  "Chat del Plan",
-                  style: TextStyle(
-                    color: AppColors.planColor,
-                    fontSize: 18,
-                    fontWeight: FontWeight.bold,
-                  ),
+              const Text(
+                "Chat del Plan",
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: AppColors.planColor,
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
                 ),
               ),
-              IconButton(
-                icon: const Icon(Icons.close, color: AppColors.planColor),
-                onPressed: () => Navigator.pop(context),
+              Positioned(
+                right: 0,
+                child: IconButton(
+                  icon: const Icon(Icons.close, color: AppColors.planColor),
+                  onPressed: () => Navigator.pop(context),
+                ),
               ),
             ],
           ),


### PR DESCRIPTION
## Summary
- center `Chat del Plan` header across full width by overlaying close icon

## Testing
- `flutter test` *(fails: command not found)*