### PR TITLE
Center chat header

### DIFF
--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -664,6 +664,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
           padding: const EdgeInsets.all(8.0),
           child: Row(
             children: [
+              const SizedBox(width: 48),
               const Expanded(
                 child: Text(
                   "Chat del Plan",

--- a/app_src/lib/explore_screen/plans_managing/plan_card.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_card.dart
@@ -322,6 +322,7 @@ class PlanCardState extends State<PlanCard> {
           padding: const EdgeInsets.all(8.0),
           child: Row(
             children: [
+              const SizedBox(width: 48),
               const Expanded(
                 child: Text(
                   "Chat del Plan",


### PR DESCRIPTION
## Summary
- adjust chat header layout in PlanCard
- do the same in FrostedPlanDialogState

## Testing
- `flutter analyze` *(fails: command not found)*