### PR TITLE
Display chat timestamps under messages

### DIFF
--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -808,17 +808,18 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
         children: [
           if (!isMe) avatar,
           if (!isMe) const SizedBox(width: 8),
-          if (isMe) timeWidget,
-          if (isMe) const SizedBox(width: 4),
           Expanded(
             child: Column(
               crossAxisAlignment:
                   isMe ? CrossAxisAlignment.end : CrossAxisAlignment.start,
-              children: [nameWidget, msgWidget],
+              children: [
+                nameWidget,
+                msgWidget,
+                const SizedBox(height: 2),
+                timeWidget,
+              ],
             ),
           ),
-          if (!isMe) const SizedBox(width: 4),
-          if (!isMe) timeWidget,
           if (isMe) const SizedBox(width: 8),
           if (isMe) avatar,
         ],

--- a/app_src/lib/explore_screen/plans_managing/plan_card.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_card.dart
@@ -469,17 +469,18 @@ class PlanCardState extends State<PlanCard> {
         children: [
           if (!isMe) avatar,
           if (!isMe) const SizedBox(width: 8),
-          if (isMe) timeWidget,
-          if (isMe) const SizedBox(width: 4),
           Expanded(
             child: Column(
               crossAxisAlignment:
                   isMe ? CrossAxisAlignment.end : CrossAxisAlignment.start,
-              children: [nameWidget, msgWidget],
+              children: [
+                nameWidget,
+                msgWidget,
+                const SizedBox(height: 2),
+                timeWidget,
+              ],
             ),
           ),
-          if (!isMe) const SizedBox(width: 4),
-          if (!isMe) timeWidget,
           if (isMe) const SizedBox(width: 8),
           if (isMe) avatar,
         ],


### PR DESCRIPTION
## Summary
- adjust message item layouts so timestamps appear below each message text

## Testing
- `flutter analyze` *(fails: command not found)*