### PR TITLE
Arreglar sticky solo en escritorio

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -84,7 +84,10 @@
     .img3 {transform: rotate(-10deg);margin-top: 5px;}
     .img4 {transform: rotate(8deg);margin-top: 5px;}
 
-    .cta-text {text-align: center;padding: 2rem 1rem;}
+    .cta-text {
+      text-align: center;
+      padding: 2rem 1rem;
+    }
 
     /* SECCIÓN 4: imágenes que actúan como botones */
     .download-section {


### PR DESCRIPTION
## Resumen
- quitar `position: sticky` de `.cta-text` para móviles
- mantener sticky en pantallas grandes mediante media query

## Testing
- `npm test` *(falla: falta `package.json`)*