### PR TITLE
Add language switch for help and legal pages

### DIFF
--- a/public/help.html
+++ b/public/help.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="es">
+<html>
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Ayuda - Plan Social</title>
+  <title>Plan Social</title>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700&display=swap" rel="stylesheet">
   <style>
     body{font-family:'Poppins',sans-serif;padding:1em;line-height:1.5;color:#444;}
@@ -18,13 +18,14 @@
   </style>
 </head>
 <body>
-  <header>
-    <img src="plan-sin-fondo.png" alt="Plan Social" style="height:40px;">
-    <h1>Ayuda</h1>
-  </header>
-  <main>
-    <h2>Preguntas frecuentes</h2>
-    <div>
+  <div data-lang="es">
+    <header>
+      <img src="plan-sin-fondo.png" alt="Plan Social" style="height:40px;">
+      <h1>Ayuda</h1>
+    </header>
+    <main>
+      <h2>Preguntas frecuentes</h2>
+      <div>
       <h3>¿Cómo creo un nuevo plan?</h3>
       <ol>
         <li>Toca el botón “+” para abrir el formulario de creación de plan.</li>
@@ -107,5 +108,112 @@
       <p>© 2025 Plan Social</p>
     </div>
   </footer>
+  </div>
+  <div data-lang="en">
+    <header>
+      <img src="plan-sin-fondo.png" alt="Plan Social" style="height:40px;">
+      <h1>Help</h1>
+    </header>
+    <main>
+      <h2>Frequently Asked Questions</h2>
+      <div>
+        <h3>How do I create a new plan?</h3>
+        <ol>
+          <li>Tap the “+” button to open the plan creation form.</li>
+          <li>Select or type the plan type in the selector.</li>
+          <li>Add up to 3 pictures or 1 video by tapping “Media content” and choose from gallery or camera (max 15 s video).</li>
+          <li>Press “Plan date and time” to pick date(s) and time(s); mark “All day” or “Include end date” if you want.</li>
+          <li>Select the meeting point on the map.</li>
+          <li>Adjust age restriction with the slider and set the maximum number of participants.</li>
+          <li>Write a brief description of the plan.</li>
+          <li>Choose visibility (Public, Private or Followers only).</li>
+          <li>Finally tap “Finish Plan” and your plan will be published. You can see it in “My plans” and share it with friends.</li>
+        </ol>
+
+        <h3>How do I search for plans near me?</h3>
+        <ol>
+          <li>Open the Explore section by tapping the house icon in the bottom bar.</li>
+          <li>The user list is ordered by proximity using your location and the computeDistance function.</li>
+          <li>Adjust filters: tap the funnel icon to filter by age or distance.</li>
+          <li>If you prefer a map, tap the map icon in the bottom bar to see markers of users with public plans.</li>
+          <li>Tap a marker or a profile in the list to see their plans (PlanCard) and join.</li>
+        </ol>
+
+        <h3>How do I invite someone to a plan?</h3>
+        <ol>
+          <li>In the profile of a user without plans, tap “Invite to a Plan”.</li>
+          <li>Choose “Existing” to select one of your active plans or “New” to create a private plan.</li>
+          <li>If you choose Existing, select a plan from the list and confirm the invitation in the dialog.</li>
+          <li>If you choose New, fill in the quick private plan form (type, date, location and description) and finish.</li>
+          <li>When confirmed, a notification is sent to the invited user and you will see a success message.</li>
+        </ol>
+
+        <h3>What is a private plan?</h3>
+        <p>A private plan is only visible to you and the people you share it with. Nobody else can see or join it.</p>
+
+        <h3>How does the map work?</h3>
+        <p>The map shows all public plans you can interact with and join if you like. You can see the location of the plans on the map and tap markers for more details. You can also filter plans according to your interests and preferences. Zoom in, out and move the map to see plans around the world.</p>
+
+        <h3>How do privilege levels work?</h3>
+        <p>Levels define perks and additional tools according to your activity in the app:</p>
+        <p><strong>Basic</strong><br>
+        • Create 1 active plan at a time.<br>
+        • Join public plans without limit.<br>
+        • Basic chat inside the plan.<br>
+        • Support via FAQ and email.</p>
+        <p><strong>Premium</strong><br>
+        • Everything above plus more features to enhance your experience:<br>
+        • Create up to 3 active plans at once and recurring plans (e.g. every Friday).<br>
+        • Add up to 10 photos + 1 long video (30 s) to promote your plans.<br>
+        • Co-organizers: assign 1 person to help manage the plan.<br>
+        • Custom push notifications (choose when reminders are sent).</p>
+        <p><strong>Golden</strong><br>
+        • Create paid events (in-app ticketing); the app charges the standard fee.<br>
+        • Combine your account as regular user and business creating plans/events.<br>
+        • Create unlimited active plans at once.<br>
+        • Configure participant admission based on their privilege level (e.g. only Golden/VIP users can join).<br>
+        • Boost your plan once a week to appear on top of the list with a golden pin on the map.<br>
+        • Analytics: see who visited your plans, confirmation rate and heat map of interests.<br>
+        • Customer service by chat with reply in less than 24 hours.</p>
+        <p><strong>VIP</strong><br>
+        • All previous benefits without limits + top priority in the discovery algorithm.<br>
+        • Verified badge and unique short URL to share plans.<br>
+        • Option to sponsor plans (your logo visible on Explore section cover).<br>
+        • Multiple co-organizers and custom roles (moderator, photographer, etc.).<br>
+        • Advanced dashboard with CSV export and monthly reports.<br>
+        • Real-time customer service and early access to beta features.</p>
+      </div>
+    </main>
+    <footer class="site-footer">
+      <div class="footer-container">
+        <img class="footer-logo" src="plan-sin-fondo.png" alt="Plan Social">
+        <div class="footer-links">
+          <a href="help.html">Help</a>
+          <a href="privacy_policy.html">Privacy</a>
+          <a href="terms_and_conditions.html">Terms</a>
+          <select class="lang-select">
+            <option value="es">Español</option>
+            <option value="en">English</option>
+          </select>
+        </div>
+        <p>© 2025 Plan Social</p>
+      </div>
+    </footer>
+  </div>
+  <script>
+    (function(){
+      const select=document.querySelector('.lang-select');
+      function setLang(l){
+        document.documentElement.lang=l;
+        document.querySelectorAll('[data-lang]').forEach(el=>{
+          el.style.display=el.getAttribute('data-lang')===l?'':'none';
+        });
+        select.value=l;
+      }
+      const initial=((navigator.language||navigator.userLanguage)||'en').startsWith('es')?'es':'en';
+      setLang(initial);
+      select.addEventListener('change',e=>setLang(e.target.value));
+    })();
+  </script>
 </body>
 </html>

--- a/public/privacy_policy.html
+++ b/public/privacy_policy.html
@@ -20,6 +20,7 @@
 </head>
 
 <body>
+  <div data-lang="en">
     <strong>Privacy Policy</strong>
     <p>This privacy policy applies to the Plan app (hereby referred to as "Application") for mobile devices that was
         created by Inan Ilik Ilik (hereby referred to as "Service Provider") as a Freemium service. This service is
@@ -131,6 +132,92 @@
             <p>© 2025 Plan Social</p>
         </div>
     </footer>
+  </div>
+  <div data-lang="es">
+    <strong>Política de Privacidad</strong>
+    <p>Esta política de privacidad se aplica a la app Plan (en adelante, "Aplicación") para dispositivos móviles creada por Inan Ilik Ilik (en adelante, "Proveedor del Servicio") como servicio Freemium. Este servicio se ofrece "TAL CUAL".</p><br><strong>Recopilación y Uso de Información</strong>
+    <p>La Aplicación recopila información cuando la descargas y la utilizas. Esta información puede incluir datos como </p>
+    <ul>
+        <li>La dirección IP de tu dispositivo</li>
+        <li>Las páginas de la Aplicación que visitas, la fecha y hora de la visita y el tiempo en cada página</li>
+        <li>El tiempo que pasas en la Aplicación</li>
+        <li>El sistema operativo de tu dispositivo móvil</li>
+    </ul>
+    <p style="display: none;">La Aplicación no recopila información precisa sobre la ubicación de tu dispositivo móvil.</p>
+    <div>
+        <p>La Aplicación recopila la ubicación de tu dispositivo para que el Proveedor del Servicio determine tu localización aproximada y la use de las siguientes maneras:</p>
+        <ul>
+            <li>Servicios de geolocalización para ofrecer contenido personalizado, recomendaciones y servicios basados en ubicación.</li>
+            <li>Analítica y mejoras: los datos de ubicación agregados y anonimizados ayudan al Proveedor del Servicio a analizar el comportamiento de los usuarios y mejorar el rendimiento y la funcionalidad de la Aplicación.</li>
+            <li>Servicios de terceros: periódicamente, el Proveedor del Servicio puede transmitir datos de ubicación anonimizados a servicios externos que le ayudan a mejorar la Aplicación y optimizar sus ofertas.</li>
+        </ul>
+    </div><br>
+    <p>El Proveedor del Servicio puede utilizar la información que proporcionas para ponerse en contacto contigo ocasionalmente con información importante, avisos y promociones de marketing.</p><br>
+    <p>Para una mejor experiencia, mientras utilizas la Aplicación, el Proveedor del Servicio puede requerirte que proporciones cierta información personal identificable, incluidos, entre otros, correo electrónico, nombre, edad, imágenes, teléfono y ubicación. La información solicitada será conservada y utilizada según se describe en esta política.</p><br><strong>Acceso de Terceros</strong>
+    <p>Solo se transmiten periódicamente datos agregados y anonimizados a servicios externos para ayudar al Proveedor del Servicio a mejorar la Aplicación y su servicio. El Proveedor del Servicio puede compartir tu información con terceros tal y como se describe en esta política de privacidad.</p>
+    <div><br>
+        <p>Ten en cuenta que la Aplicación utiliza servicios de terceros que tienen su propia Política de Privacidad acerca del tratamiento de datos. A continuación se muestran los enlaces a la Política de Privacidad de los proveedores de servicios utilizados por la Aplicación:</p>
+        <ul>
+            <li><a href="https://www.google.com/policies/privacy/" target="_blank" rel="noopener noreferrer">Google Play Services</a></li>
+            <li>Firebase (Authentication, Firestore, Realtime Database, Storage, Cloud Functions y Firebase Analytics)</li>
+            <li>Google Sign-In y Firebase Messaging</li>
+            <li>Google Maps Platform (API de Places/Geocoding) y Geolocator</li>
+            <li>Google Fonts (fonts.googleapis.com)</li>
+            <li>Hostinger (SMTP para restablecimiento de contraseñas con Nodemailer)</li>
+            <li>Firebase Hosting</li>
+        </ul>
+    </div><br>
+    <p>El Proveedor del Servicio puede revelar Información proporcionada por el usuario y recopilada automáticamente:</p>
+    <ul>
+        <li>cuando la ley lo requiera, para cumplir con una citación u otro proceso legal similar;</li>
+        <li>cuando crea de buena fe que la divulgación es necesaria para proteger sus derechos, tu seguridad o la de otros, investigar el fraude o responder a una solicitud gubernamental;</li>
+        <li>con proveedores de servicios de confianza que trabajan en su nombre, no tienen un uso independiente de la información que les revelamos y han aceptado cumplir las reglas establecidas en esta política de privacidad.</li>
+    </ul>
+    <p></p><br><strong>Derechos de Exclusión</strong>
+    <p>Puedes detener fácilmente toda la recopilación de información por parte de la Aplicación desinstalándola. Puedes utilizar los procesos de desinstalación estándar que puedan estar disponibles como parte de tu dispositivo móvil o mediante el mercado de aplicaciones móviles o la red.</p><br><strong>Política de Retención de Datos</strong>
+    <p>El Proveedor del Servicio conservará los datos proporcionados por el usuario mientras utilices la Aplicación y durante un tiempo razonable después. Si deseas que eliminen los datos proporcionados a través de la Aplicación, ponte en contacto con soporte@plansocialapp.es y responderán en un tiempo razonable.</p>
+    <br><strong>Menores</strong>
+    <p>El Proveedor del Servicio no utiliza la Aplicación para solicitar datos conscientemente ni para comercializar a menores de 13 años.</p>
+    <div><br>
+        <p>La Aplicación no está dirigida a menores de 13 años. El Proveedor del Servicio no recopila conscientemente información personal de niños menores de 13 años. En caso de que el Proveedor del Servicio descubra que un niño menor de 13 años ha proporcionado información personal, la eliminará de sus servidores de inmediato. Si eres padre, madre o tutor y sabes que tu hijo nos ha proporcionado información personal, ponte en contacto con el Proveedor del Servicio (soporte@plansocialapp.es) para que pueda tomar las medidas necesarias.</p>
+    </div><br><strong>Seguridad</strong>
+    <p>El Proveedor del Servicio se preocupa por salvaguardar la confidencialidad de tu información. Proporciona salvaguardas físicas, electrónicas y procedimentales para proteger la información que procesa y mantiene.</p><br><strong>Cambios</strong>
+    <p>Esta Política de Privacidad puede actualizarse de vez en cuando por cualquier motivo. El Proveedor del Servicio te notificará cualquier cambio actualizando esta página con la nueva Política de Privacidad. Se recomienda consultar esta Política regularmente para conocer cualquier cambio, ya que el uso continuado se considera aprobación de todos los cambios.</p><br>
+    <p>Esta política de privacidad es efectiva a partir del 26-05-2025</p><br><strong>Tu Consentimiento</strong>
+    <p>Al utilizar la Aplicación, consientes el procesamiento de tu información según lo establecido en esta Política de Privacidad ahora y según la enmendemos.</p><br><strong>Contáctanos</strong>
+    <p>Si tienes preguntas sobre la privacidad mientras usas la Aplicación, o preguntas sobre nuestras prácticas, ponte en contacto con el Proveedor del Servicio mediante el correo soporte@plansocialapp.es.</p>
+    <hr>
+    <footer class="site-footer">
+        <div class="footer-container">
+            <img class="footer-logo" src="plan-sin-fondo.png" alt="Plan Social">
+            <div class="footer-links">
+                <a href="help.html">Ayuda</a>
+                <a href="privacy_policy.html">Privacidad</a>
+                <a href="terms_and_conditions.html">Condiciones</a>
+                <select class="lang-select">
+                    <option value="es">Español</option>
+                    <option value="en">English</option>
+                </select>
+            </div>
+            <p>© 2025 Plan Social</p>
+        </div>
+    </footer>
+  </div>
+  <script>
+    (function(){
+      const select=document.querySelector('.lang-select');
+      function setLang(l){
+        document.documentElement.lang=l;
+        document.querySelectorAll('[data-lang]').forEach(el=>{
+          el.style.display=el.getAttribute('data-lang')===l?'':'none';
+        });
+        select.value=l;
+      }
+      const initial=((navigator.language||navigator.userLanguage)||'en').startsWith('es')?'es':'en';
+      setLang(initial);
+      select.addEventListener('change',e=>setLang(e.target.value));
+    })();
+  </script>
 </body>
 
 </html>

--- a/public/terms_and_conditions.html
+++ b/public/terms_and_conditions.html
@@ -20,6 +20,7 @@
 </head>
 
 <body>
+  <div data-lang="en">
     <strong>Terms &amp; Conditions</strong><br>
     <p>These terms and conditions apply to the Plan app (hereby referred to as "Application") for mobile devices that
         was created by Inan Ilik Ilik (hereby referred to as "Service Provider") as a Freemium service.</p><br>
@@ -101,6 +102,58 @@
             <p>© 2025 Plan Social</p>
         </div>
     </footer>
+  </div>
+  <div data-lang="es">
+    <strong>Términos y Condiciones</strong><br>
+    <p>Estos términos y condiciones se aplican a la app Plan (en adelante, "Aplicación") para dispositivos móviles creada por Inan Ilik Ilik (en adelante, "Proveedor del Servicio") como servicio Freemium.</p><br>
+    <p>Al descargar o utilizar la Aplicación aceptas automáticamente los siguientes términos. Se recomienda leerlos detenidamente antes de usar la Aplicación. Queda estrictamente prohibido copiar o modificar la Aplicación, cualquier parte de ella o nuestras marcas. Tampoco está permitido extraer el código fuente de la Aplicación, traducirla a otros idiomas ni crear versiones derivadas. Todas las marcas, derechos de autor, derechos sobre bases de datos y demás derechos de propiedad intelectual relacionados con la Aplicación siguen siendo propiedad del Proveedor del Servicio.</p><br>
+    <p>El Proveedor del Servicio se esfuerza por que la Aplicación sea lo más útil y eficiente posible, por lo que se reserva el derecho de modificarla o cobrar por sus servicios en cualquier momento y por cualquier motivo. Cualquier cargo por la Aplicación o sus servicios será claramente comunicado.</p><br>
+    <p>La Aplicación almacena y procesa los datos personales que proporcionas al Proveedor del Servicio para prestar el Servicio. Es tu responsabilidad mantener la seguridad de tu teléfono y el acceso a la Aplicación. Se desaconseja hacer jailbreak o root a tu teléfono, ya que podría exponerlo a malware, virus y programas maliciosos, comprometer las funciones de seguridad y provocar que la Aplicación no funcione correctamente o deje de funcionar.</p>
+    <div>
+        <p>Ten en cuenta que la Aplicación utiliza servicios de terceros que tienen sus propios Términos y Condiciones. A continuación se muestran los enlaces a los Términos y Condiciones de los proveedores de servicios utilizados por la Aplicación:</p>
+        <ul>
+            <li><a href="https://policies.google.com/terms" target="_blank" rel="noopener noreferrer">Google Play Services</a></li>
+        </ul>
+    </div><br>
+    <p>Ten en cuenta que algunas funciones de la Aplicación requieren conexión a Internet, ya sea Wi-Fi o datos móviles. El Proveedor del Servicio no se hace responsable si la Aplicación no funciona a pleno rendimiento por falta de acceso a Wi-Fi o por haber agotado tu tarifa de datos.</p><br>
+    <p>Si utilizas la Aplicación fuera de una zona Wi-Fi, recuerda que los términos del proveedor de tu red móvil siguen vigentes. Por ello podrías incurrir en cargos por datos durante el uso de la Aplicación u otros cargos de terceros. Al utilizar la Aplicación aceptas la responsabilidad de dichos cargos, incluido el roaming si no desactivas los datos en el extranjero. Si no eres el titular del dispositivo, asumimos que cuentas con su permiso.</p><br>
+    <p>De igual manera, el Proveedor del Servicio no siempre puede responsabilizarse de tu uso de la Aplicación. Por ejemplo, debes asegurarte de que tu dispositivo permanezca cargado; si se agota la batería y no puedes acceder al Servicio, el Proveedor del Servicio no puede responsabilizarse.</p><br>
+    <p>El Proveedor del Servicio puede actualizar la Aplicación en algún momento. Los requisitos para el sistema operativo (y para cualquier sistema adicional al que se extienda la disponibilidad) pueden cambiar, y deberás descargar las actualizaciones si deseas seguir usando la Aplicación. El Proveedor del Servicio no garantiza actualizar siempre la Aplicación para que sea relevante para ti y/o sea compatible con la versión concreta de tu sistema operativo. Sin embargo, aceptas recibir actualizaciones cuando se ofrezcan. El Proveedor del Servicio también puede dejar de proporcionar la Aplicación y terminar su uso en cualquier momento sin avisarte. Salvo que se indique lo contrario, al finalizarse (a) los derechos y licencias otorgados en estos términos terminarán y (b) deberás dejar de usar la Aplicación y eliminarla de tu dispositivo si es necesario.</p><br><strong>Cambios en estos Términos y Condiciones</strong>
+    <p>El Proveedor del Servicio puede actualizar periódicamente estos Términos y Condiciones. Por ello se recomienda revisar esta página con regularidad para ver posibles cambios. El Proveedor del Servicio notificará cualquier cambio publicando los nuevos Términos y Condiciones en esta página.</p><br>
+    <p>Estos términos y condiciones están vigentes desde el 26-05-2025</p><br><strong>Contacto</strong>
+    <p>Si tienes preguntas o sugerencias sobre estos Términos y Condiciones, no dudes en contactar al Proveedor del Servicio en soporte@plansocialapp.es.</p>
+    <hr>
+    <footer class="site-footer">
+        <div class="footer-container">
+            <img class="footer-logo" src="plan-sin-fondo.png" alt="Plan Social">
+            <div class="footer-links">
+                <a href="help.html">Ayuda</a>
+                <a href="privacy_policy.html">Privacidad</a>
+                <a href="terms_and_conditions.html">Condiciones</a>
+                <select class="lang-select">
+                    <option value="es">Español</option>
+                    <option value="en">English</option>
+                </select>
+            </div>
+            <p>© 2025 Plan Social</p>
+        </div>
+    </footer>
+  </div>
+  <script>
+    (function(){
+      const select=document.querySelector('.lang-select');
+      function setLang(l){
+        document.documentElement.lang=l;
+        document.querySelectorAll('[data-lang]').forEach(el=>{
+          el.style.display=el.getAttribute('data-lang')===l?'':'none';
+        });
+        select.value=l;
+      }
+      const initial=((navigator.language||navigator.userLanguage)||'en').startsWith('es')?'es':'en';
+      setLang(initial);
+      select.addEventListener('change',e=>setLang(e.target.value));
+    })();
+  </script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- integrate Spanish and English versions in help, privacy policy and terms pages
- detect browser language and allow user selection

## Testing
- `flutter --version` *(fails: command not found)*