### PR TITLE
Agregar enlace de Instagram clickable

### DIFF
--- a/public/help.html
+++ b/public/help.html
@@ -15,7 +15,7 @@
     .footer-links a{color:#fff;font-size:.875rem;}
     .footer-logo{height:40px;}
     .lang-select{background:#000;color:#fff;border:1px solid #fff;padding:.3rem;}
-    .footer-social{display:flex;gap:.5rem;align-items:center;font-size:.875rem;}
+    .footer-social{display:flex;flex-direction:column;gap:.5rem;align-items:center;font-size:.875rem;}
     .social-icon{height:20px;}
   </style>
 </head>
@@ -106,10 +106,11 @@
           <option value="es">Español</option>
           <option value="en">English</option>
         </select>
-        <div class="footer-social">
-          Síguenos en <img src="instagram.png" alt="Instagram" class="social-icon">
+          <div class="footer-social">
+            <div>Síguenos en <a href="https://www.instagram.com/plan0525/" target="_blank"><img src="instagram.png" alt="Instagram" class="social-icon"></a></div>
+            <a href="https://www.instagram.com/plan0525/" target="_blank" style="color:#fff">https://www.instagram.com/plan0525/</a>
+          </div>
         </div>
-      </div>
       <p>© 2025 Plan</p>
     </div>
   </footer>
@@ -200,9 +201,10 @@
           <option value="es">Español</option>
           <option value="en">English</option>
         </select>
-        <div class="footer-social">
-          Síguenos en <img src="instagram.png" alt="Instagram" class="social-icon">
-        </div>
+          <div class="footer-social">
+            <div>Síguenos en <a href="https://www.instagram.com/plan0525/" target="_blank"><img src="instagram.png" alt="Instagram" class="social-icon"></a></div>
+            <a href="https://www.instagram.com/plan0525/" target="_blank" style="color:#fff">https://www.instagram.com/plan0525/</a>
+          </div>
       </div>
       <p>© 2025 Plan</p>
       </div>

--- a/public/index.html
+++ b/public/index.html
@@ -471,6 +471,7 @@
 
     .footer-social {
       display: flex;
+      flex-direction: column;
       gap: .5rem;
       align-items: center;
       font-size: .875rem;
@@ -570,7 +571,8 @@
           <option value="en">English</option>
         </select>
         <div class="footer-social">
-          Síguenos en <img src="instagram.png" alt="Instagram" class="social-icon">
+          <div>Síguenos en <a href="https://www.instagram.com/plan0525/" target="_blank"><img src="instagram.png" alt="Instagram" class="social-icon"></a></div>
+          <a href="https://www.instagram.com/plan0525/" target="_blank" style="color:#fff">https://www.instagram.com/plan0525/</a>
         </div>
       </div>
       <p>© 2025 Plan</p>

--- a/public/privacy_policy.html
+++ b/public/privacy_policy.html
@@ -16,7 +16,7 @@
         .footer-links a{color:#fff;font-size:.875rem;}
         .footer-logo{height:40px;}
         .lang-select{background:#000;color:#fff;border:1px solid #fff;padding:.3rem;}
-        .footer-social{display:flex;gap:.5rem;align-items:center;font-size:.875rem;}
+        .footer-social{display:flex;flex-direction:column;gap:.5rem;align-items:center;font-size:.875rem;}
         .social-icon{height:20px;}
     </style>
 </head>
@@ -136,9 +136,10 @@
                     <option value="en">English</option>
                 </select>
                 <div class="footer-social">
-                    Síguenos en <img src="instagram.png" alt="Instagram" class="social-icon">
+                    <div>Síguenos en <a href="https://www.instagram.com/plan0525/" target="_blank"><img src="instagram.png" alt="Instagram" class="social-icon"></a></div>
+                    <a href="https://www.instagram.com/plan0525/" target="_blank" style="color:#fff">https://www.instagram.com/plan0525/</a>
                 </div>
-            </div>
+                </div>
             <p>© 2025 Plan</p>
         </div>
     </footer>
@@ -214,7 +215,8 @@
                     <option value="en">English</option>
                 </select>
                 <div class="footer-social">
-                    Síguenos en <img src="instagram.png" alt="Instagram" class="social-icon">
+                    <div>Síguenos en <a href="https://www.instagram.com/plan0525/" target="_blank"><img src="instagram.png" alt="Instagram" class="social-icon"></a></div>
+                    <a href="https://www.instagram.com/plan0525/" target="_blank" style="color:#fff">https://www.instagram.com/plan0525/</a>
                 </div>
             </div>
             <p>© 2025 Plan</p>

--- a/public/terms_and_conditions.html
+++ b/public/terms_and_conditions.html
@@ -16,7 +16,7 @@
         .footer-links a{color:#fff;font-size:.875rem;}
         .footer-logo{height:40px;}
         .lang-select{background:#000;color:#fff;border:1px solid #fff;padding:.3rem;}
-        .footer-social{display:flex;gap:.5rem;align-items:center;font-size:.875rem;}
+        .footer-social{display:flex;flex-direction:column;gap:.5rem;align-items:center;font-size:.875rem;}
         .social-icon{height:20px;}
     </style>
 </head>
@@ -110,7 +110,8 @@
                     <option value="en">English</option>
                 </select>
                 <div class="footer-social">
-                    Síguenos en <img src="instagram.png" alt="Instagram" class="social-icon">
+                    <div>Síguenos en <a href="https://www.instagram.com/plan0525/" target="_blank"><img src="instagram.png" alt="Instagram" class="social-icon"></a></div>
+                    <a href="https://www.instagram.com/plan0525/" target="_blank" style="color:#fff">https://www.instagram.com/plan0525/</a>
                 </div>
             </div>
             <p>© 2025 Plan</p>
@@ -160,7 +161,8 @@
                     <option value="en">English</option>
                 </select>
                 <div class="footer-social">
-                    Síguenos en <img src="instagram.png" alt="Instagram" class="social-icon">
+                    <div>Síguenos en <a href="https://www.instagram.com/plan0525/" target="_blank"><img src="instagram.png" alt="Instagram" class="social-icon"></a></div>
+                    <a href="https://www.instagram.com/plan0525/" target="_blank" style="color:#fff">https://www.instagram.com/plan0525/</a>
                 </div>
             </div>
             <p>© 2025 Plan</p>


### PR DESCRIPTION
## Resumen
- el icono de Instagram ahora abre la cuenta oficial
- el enlace completo aparece debajo del icono en todos los HTML

## Testing
- `grep -R "instagram.png" -n public/*.html`
