### PR TITLE
Actualizar menú lateral y ajustes

### DIFF
--- a/app_src/lib/explore_screen/menu_side_bar/menu_side_bar_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/menu_side_bar_screen.dart
@@ -30,6 +30,7 @@ class MainSideBarScreen extends StatefulWidget {
 class MainSideBarScreenState extends State<MainSideBarScreen> {
   bool isOpen = false;
   final String? currentUserId = FirebaseAuth.instance.currentUser?.uid;
+  int _pressedIndex = -1;
 
   void toggleMenu() {
     setState(() {
@@ -104,6 +105,7 @@ class MainSideBarScreenState extends State<MainSideBarScreen> {
                         destination: const MyPlansScreen(),
                         iconColor: Colors.white,
                         textColor: Colors.white,
+                        index: 0,
                         stream: FirebaseFirestore.instance
                             .collection('plans')
                             .where('createdBy', isEqualTo: currentUserId)
@@ -117,6 +119,7 @@ class MainSideBarScreenState extends State<MainSideBarScreen> {
                         ),
                         iconColor: Colors.white,
                         textColor: Colors.white,
+                        index: 1,
                         stream: FirebaseFirestore.instance
                             .collection('subscriptions')
                             .where('userId', isEqualTo: currentUserId)
@@ -128,6 +131,7 @@ class MainSideBarScreenState extends State<MainSideBarScreen> {
                         destination: const FavouritesScreen(),
                         iconColor: Colors.white,
                         textColor: Colors.white,
+                        index: 2,
                         stream: FirebaseFirestore.instance
                             .collection('users')
                             .doc(currentUserId)
@@ -139,6 +143,7 @@ class MainSideBarScreenState extends State<MainSideBarScreen> {
                         destination: const SettingsScreen(),
                         iconColor: Colors.white,
                         textColor: Colors.white,
+                        index: 3,
                       ),
                       _buildMenuItem(
                         icon: 'assets/icono-cerrar-sesion.svg',
@@ -146,6 +151,7 @@ class MainSideBarScreenState extends State<MainSideBarScreen> {
                         destination: const CloseSessionScreen(),
                         iconColor: Colors.red,
                         textColor: Colors.red,
+                        index: 4,
                       ),
                     ],
                   ),
@@ -292,25 +298,13 @@ class MainSideBarScreenState extends State<MainSideBarScreen> {
     required Widget destination,
     required Color iconColor,
     required Color textColor,
+    required int index,
   }) {
-    return ListTile(
-      dense: true,
-      leading: icon is String
-          ? SvgPicture.asset(
-              icon,
-              width: 28,
-              height: 28,
-              color: iconColor,
-              colorBlendMode: BlendMode.srcIn,
-            )
-          : Icon(icon, color: iconColor, size: 24),
-      title: Text(
-        title,
-        style: GoogleFonts.roboto(
-          color: textColor,
-          fontSize: 16,
-        ),
-      ),
+    final bool isPressed = _pressedIndex == index;
+    return GestureDetector(
+      onTapDown: (_) => setState(() => _pressedIndex = index),
+      onTapUp: (_) => setState(() => _pressedIndex = -1),
+      onTapCancel: () => setState(() => _pressedIndex = -1),
       onTap: () {
         toggleMenu();
         Navigator.push(
@@ -318,6 +312,26 @@ class MainSideBarScreenState extends State<MainSideBarScreen> {
           MaterialPageRoute(builder: (context) => destination),
         );
       },
+      child: ListTile(
+        dense: true,
+        leading: icon is String
+            ? SvgPicture.asset(
+                icon,
+                width: 28,
+                height: 28,
+                color: isPressed ? AppColors.planColor : iconColor,
+                colorBlendMode: BlendMode.srcIn,
+              )
+            : Icon(icon,
+                color: isPressed ? AppColors.planColor : iconColor, size: 24),
+        title: Text(
+          title,
+          style: GoogleFonts.roboto(
+            color: isPressed ? AppColors.planColor : textColor,
+            fontSize: 16,
+          ),
+        ),
+      ),
     );
   }
 
@@ -328,6 +342,7 @@ class MainSideBarScreenState extends State<MainSideBarScreen> {
     required Color iconColor,
     required Color textColor,
     required Stream stream,
+    required int index,
   }) {
     return StreamBuilder(
       stream: stream,
@@ -342,25 +357,35 @@ class MainSideBarScreenState extends State<MainSideBarScreen> {
             count = (snapshot.data as QuerySnapshot?)?.docs.length ?? 0;
           }
         }
-        return ListTile(
-          dense: true,
-          leading: icon is String
-              ? SvgPicture.asset(
-                  icon,
-                  width: 28,
-                  height: 28,
-                  color: iconColor,
-                  colorBlendMode: BlendMode.srcIn,
-                )
-              : Icon(icon, color: iconColor, size: 24),
-          title: Text(
-            title,
-            style: GoogleFonts.roboto(
-              color: textColor,
-              fontSize: 16,
+        final bool isPressed = _pressedIndex == index;
+        return GestureDetector(
+          onTapDown: (_) => setState(() => _pressedIndex = index),
+          onTapUp: (_) => setState(() => _pressedIndex = -1),
+          onTapCancel: () => setState(() => _pressedIndex = -1),
+          child: ListTile(
+            dense: true,
+            leading: icon is String
+                ? SvgPicture.asset(
+                    icon,
+                    width: 28,
+                    height: 28,
+                    color:
+                        isPressed ? AppColors.planColor : iconColor,
+                    colorBlendMode: BlendMode.srcIn,
+                  )
+                : Icon(icon,
+                    color:
+                        isPressed ? AppColors.planColor : iconColor,
+                    size: 24),
+            title: Text(
+              title,
+              style: GoogleFonts.roboto(
+                color:
+                    isPressed ? AppColors.planColor : textColor,
+                fontSize: 16,
+              ),
             ),
-          ),
-          trailing: count > 0
+            trailing: count > 0
               ? Container(
                   padding: const EdgeInsets.all(6),
                   decoration: const BoxDecoration(
@@ -377,10 +402,10 @@ class MainSideBarScreenState extends State<MainSideBarScreen> {
                   ),
                 )
               : const SizedBox(),
-          onTap: () {
-            if (title == 'Mis Planes') {
-              showDialog(
-                context: context,
+            onTap: () {
+              if (title == 'Mis Planes') {
+                showDialog(
+                  context: context,
                 builder: (context) => Dialog(
                   backgroundColor: const Color.fromARGB(0, 255, 255, 255),
                   insetPadding: const EdgeInsets.all(16.0),

--- a/app_src/lib/explore_screen/menu_side_bar/settings/settings_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/settings/settings_screen.dart
@@ -205,7 +205,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                       title: const Text('Acerca de Plan'),
                       trailing: const Icon(Icons.chevron_right),
                       onTap: () async {
-                        final uri = Uri.parse('https://plansocialapp.es//');
+                        final uri = Uri.parse('https://plansocialapp.es/#menu');
                         try {
                           await launchUrl(
                             uri,

--- a/public/index.html
+++ b/public/index.html
@@ -94,12 +94,14 @@
 
     nav ul li a {
       font-weight: 500;
-      color: var(--gray-dark);
+      color: #fff;
       transition: color .2s;
     }
 
-    nav ul li a:hover {
-      color: var(--green);
+    nav ul li a:hover,
+    nav ul li a:active,
+    nav ul li a:focus {
+      color: var(--brand);
     }
 
     .nav-toggle {
@@ -591,6 +593,9 @@
     const navToggle = document.querySelector('.nav-toggle');
     const navList = document.querySelector('nav ul');
     navToggle.addEventListener('click', () => navList.classList.toggle('open'));
+    if (window.location.hash === '#menu') {
+      navList.classList.add('open');
+    }
 
     // Modal registro eliminado
 


### PR DESCRIPTION
## Summary
- cambiar a blanco el texto del menú de la landing y resaltar con el color de la marca al interactuar
- abrir automáticamente el menú de la landing usando `#menu`
- redirigir a `https://plansocialapp.es/#menu` desde *Acerca de Plan*
- resaltar los elementos del menú lateral de Flutter al presionarlos

## Testing
- `flutter --version` *(falla: comando no encontrado)*