### PR TITLE
Centrar logo en barra de navegación

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -54,18 +54,17 @@
       max-width: 1200px;
       margin: auto;
       height: 100%;
-      display: flex;
+      display: grid;
+      grid-template-columns: 1fr auto 1fr;
       align-items: center;
       padding: 0 1rem;
       position: relative;
     }
 
     .nav-logo {
-      margin-left: 2rem;
-      margin-right: 1rem;
-      position: absolute;
-      left: 50%;
-      transform: translateX(-50%);
+      margin: 0;
+      position: static;
+      justify-self: center;
     }
 
     .nav-logo img {
@@ -80,7 +79,7 @@
       border-radius: 24px;
       font-weight: 600;
       transition: background .2s, transform .2s, box-shadow .2s;
-      margin-left: auto;
+      justify-self: end;
       box-shadow: 0 8px 16px rgba(0, 0, 0, .15);
     }
 
@@ -114,6 +113,7 @@
       border: none;
       font-size: 1.5rem;
       cursor: pointer;
+      justify-self: start;
     }
 
     @media(min-width:768px) {
@@ -381,7 +381,7 @@
 
     @media(max-width:768px) {
       .nav-container {
-        justify-content: space-between;
+        grid-template-columns: 1fr auto 1fr;
       }
 
       .nav-toggle {
@@ -403,12 +403,9 @@
 
       .nav-logo {
         order: 2;
-        flex: 1;
-        display: flex;
-        justify-content: center;
-        margin-left: 0;
+        margin: 0;
         position: static;
-        transform: none;
+        justify-self: center;
       }
 
       .nav-logo img {
@@ -418,6 +415,7 @@
       .btn-download {
         order: 3;
         margin: 0;
+        justify-self: end;
       }
 
       nav {


### PR DESCRIPTION
## Summary
- usar grid en `.nav-container` para distribuir icono, logo y botón
- centrar el logo y ajustar sus márgenes y posición
- ubicar icono de menú y botón con `justify-self`
- actualizar reglas para pantallas pequeñas

## Testing
- `git status --short`