### PR TITLE
Add language selection option

### DIFF
--- a/app_src/lib/explore_screen/menu_side_bar/settings/language_selector.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/settings/language_selector.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../../services/language_service.dart';
+
+class LanguageSelectorScreen extends StatefulWidget {
+  const LanguageSelectorScreen({Key? key}) : super(key: key);
+
+  @override
+  State<LanguageSelectorScreen> createState() => _LanguageSelectorScreenState();
+}
+
+class _LanguageSelectorScreenState extends State<LanguageSelectorScreen> {
+  final TextEditingController _controller = TextEditingController();
+  final List<String> _languages = ['English', 'Español'];
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context);
+    final query = _controller.text.toLowerCase();
+    final filtered = _languages
+        .where((l) => l.toLowerCase().contains(query))
+        .toList()
+      ..sort((a, b) => a.compareTo(b));
+
+    return Scaffold(
+      appBar: AppBar(title: Text(t.languages)),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: TextField(
+              controller: _controller,
+              decoration: InputDecoration(
+                hintText: t.search,
+                prefixIcon: const Icon(Icons.search),
+                border: const OutlineInputBorder(),
+              ),
+              onChanged: (_) => setState(() {}),
+            ),
+          ),
+          Expanded(
+            child: ListView.builder(
+              itemCount: filtered.length,
+              itemBuilder: (context, index) {
+                final lang = filtered[index];
+                return ListTile(
+                  title: Text(lang),
+                  onTap: () {
+                    final code = lang.startsWith('English') ? 'en' : 'es';
+                    LanguageService.updateLocale(code);
+                    Navigator.pop(context);
+                  },
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app_src/lib/explore_screen/menu_side_bar/settings/settings_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/settings/settings_screen.dart
@@ -10,6 +10,8 @@ import 'account.dart';
 import 'privacy.dart';
 import 'general_notifications.dart';
 import 'help_center.dart';
+import 'language_selector.dart';
+import '../../../l10n/app_localizations.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({Key? key}) : super(key: key);
@@ -67,9 +69,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
     return Scaffold(
       backgroundColor: backgroundColor,
       appBar: AppBar(
-        title: const Text(
-          'Ajustes',
-          style: TextStyle(color: Colors.black),
+        title: Text(
+          AppLocalizations.of(context).settings,
+          style: const TextStyle(color: Colors.black),
         ),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: Colors.black),
@@ -87,9 +89,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               // Sección: Configuración general
-              const Text(
-                'Configuración general',
-                style: TextStyle(
+              Text(
+                AppLocalizations.of(context).general,
+                style: const TextStyle(
                   fontSize: 14,
                   fontWeight: FontWeight.w600,
                   color: Colors.black54,
@@ -110,7 +112,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                         width: 24,
                         height: 24,
                       ),
-                      title: const Text('Cuenta'),
+                      title: Text(AppLocalizations.of(context).account),
                       trailing: const Icon(Icons.chevron_right),
                       onTap: () {
                         Navigator.push(
@@ -127,7 +129,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                         width: 24,
                         height: 24,
                       ),
-                      title: const Text('Privacidad'),
+                      title: Text(AppLocalizations.of(context).privacy),
                       trailing: const Icon(Icons.chevron_right),
                       onTap: () {
                         Navigator.push(
@@ -144,7 +146,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                         width: 24,
                         height: 24,
                       ),
-                      title: const Text('Notificaciones'),
+                      title: Text(AppLocalizations.of(context).notifications),
                       trailing: const Icon(Icons.chevron_right),
                       onTap: () {
                         Navigator.push(
@@ -155,6 +157,23 @@ class _SettingsScreenState extends State<SettingsScreen> {
                         );
                       },
                     ),
+                    const Divider(height: 1),
+                    ListTile(
+                      leading: SvgPicture.asset(
+                        'assets/icono-languages.svg',
+                        width: 24,
+                        height: 24,
+                      ),
+                      title: Text(AppLocalizations.of(context).languages),
+                      trailing: const Icon(Icons.chevron_right),
+                      onTap: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                              builder: (_) => const LanguageSelectorScreen()),
+                        );
+                      },
+                    ),
                   ],
                 ),
               ),
@@ -162,9 +181,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
               const SizedBox(height: 20),
 
               // Sección: Soporte
-              const Text(
-                'Soporte',
-                style: TextStyle(
+              Text(
+                AppLocalizations.of(context).support,
+                style: const TextStyle(
                   fontSize: 14,
                   fontWeight: FontWeight.w600,
                   color: Colors.black54,
@@ -185,7 +204,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                         width: 24,
                         height: 24,
                       ),
-                      title: const Text('Centro de ayuda'),
+                      title: Text(AppLocalizations.of(context).helpCenter),
                       trailing: const Icon(Icons.chevron_right),
                       onTap: () {
                         Navigator.push(
@@ -202,7 +221,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                         width: 24,
                         height: 24,
                       ),
-                      title: const Text('Acerca de Plan'),
+                      title: Text(AppLocalizations.of(context).aboutPlan),
                       trailing: const Icon(Icons.chevron_right),
                       onTap: () async {
                         final uri = Uri.parse('https://plansocialapp.es/#menu');
@@ -227,7 +246,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                         width: 24,
                         height: 24,
                       ),
-                      title: const Text('Valora Plan'),
+                      title: Text(AppLocalizations.of(context).ratePlan),
                       trailing: const Icon(Icons.chevron_right),
                       onTap: () {
                         // TODO: Navegar a valora_plan.dart
@@ -258,8 +277,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
                         Expanded(
                           // <- clave
                           child: Text(
-                            'Reportar fallos de la aplicación',
-                            style: TextStyle(
+                            AppLocalizations.of(context).reportFailures,
+                            style: const TextStyle(
                                 fontSize: 16, fontWeight: FontWeight.w600),
                             softWrap: true,
                           ),
@@ -288,7 +307,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                       width: double.infinity,
                       child: ElevatedButton(
                         onPressed: _sendFailureReport,
-                        child: const Text('Enviar'),
+                        child: Text(AppLocalizations.of(context).send),
                       ),
                     ),
                   ],

--- a/app_src/lib/l10n/app_localizations.dart
+++ b/app_src/lib/l10n/app_localizations.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+
+class AppLocalizations {
+  final Locale locale;
+  AppLocalizations(this.locale);
+
+  static const _localizedValues = <String, Map<String, String>>{
+    'es': {
+      'settings': 'Ajustes',
+      'general': 'Configuración general',
+      'account': 'Cuenta',
+      'privacy': 'Privacidad',
+      'notifications': 'Notificaciones',
+      'languages': 'Idiomas',
+      'support': 'Soporte',
+      'help_center': 'Centro de ayuda',
+      'about_plan': 'Acerca de Plan',
+      'rate_plan': 'Valora Plan',
+      'report_failures': 'Reportar fallos de la aplicación',
+      'send': 'Enviar',
+      'search': 'Buscar',
+    },
+    'en': {
+      'settings': 'Settings',
+      'general': 'General settings',
+      'account': 'Account',
+      'privacy': 'Privacy',
+      'notifications': 'Notifications',
+      'languages': 'Languages',
+      'support': 'Support',
+      'help_center': 'Help center',
+      'about_plan': 'About Plan',
+      'rate_plan': 'Rate Plan',
+      'report_failures': 'Report app failures',
+      'send': 'Send',
+      'search': 'Search',
+    },
+  };
+
+  String _t(String key) {
+    return _localizedValues[locale.languageCode]?[key] ??
+        _localizedValues['es']![key] ??
+        key;
+  }
+
+  String get settings => _t('settings');
+  String get general => _t('general');
+  String get account => _t('account');
+  String get privacy => _t('privacy');
+  String get notifications => _t('notifications');
+  String get languages => _t('languages');
+  String get support => _t('support');
+  String get helpCenter => _t('help_center');
+  String get aboutPlan => _t('about_plan');
+  String get ratePlan => _t('rate_plan');
+  String get reportFailures => _t('report_failures');
+  String get send => _t('send');
+  String get search => _t('search');
+
+  static const LocalizationsDelegate<AppLocalizations> delegate =
+      _AppLocalizationsDelegate();
+
+  static AppLocalizations of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
+  }
+}
+
+class _AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) => ['en', 'es'].contains(locale.languageCode);
+
+  @override
+  Future<AppLocalizations> load(Locale locale) async {
+    return AppLocalizations(locale);
+  }
+
+  @override
+  bool shouldReload(covariant LocalizationsDelegate<AppLocalizations> old) =>
+      false;
+}

--- a/app_src/lib/main.dart
+++ b/app_src/lib/main.dart
@@ -15,6 +15,10 @@ import 'package:intl/date_symbol_data_local.dart';
 import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'l10n/app_localizations.dart';
+import 'services/language_service.dart';
+
 import 'firebase_options.dart';
 import 'services/notification_service.dart';
 import 'explore_screen/users_managing/presence_service.dart';
@@ -47,6 +51,7 @@ Future<void> main() async {
   final prefs = await SharedPreferences.getInstance();
   final enabled = prefs.getBool('notificationsEnabled') ?? true;
   await NotificationService.instance.init(enabled: enabled);
+  await LanguageService.loadLocale();
 
   // 4 ▸ Mostrar notificaciones en foreground
   await FirebaseMessaging.instance.setForegroundNotificationPresentationOptions(
@@ -180,10 +185,21 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Plan',
-      theme: ThemeData(primarySwatch: Colors.pink),
-      home: StreamBuilder<User?>(
+    return ValueListenableBuilder<Locale>(
+      valueListenable: LanguageService.locale,
+      builder: (context, locale, _) {
+        return MaterialApp(
+          locale: locale,
+          supportedLocales: const [Locale('es'), Locale('en')],
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          title: 'Plan',
+          theme: ThemeData(primarySwatch: Colors.pink),
+          home: StreamBuilder<User?>(
         stream: FirebaseAuth.instance.authStateChanges(),
         builder: (context, snap) {
           if (snap.connectionState == ConnectionState.waiting) {
@@ -215,6 +231,8 @@ class _MyAppState extends State<MyApp> {
           return user == null ? const WelcomeScreen() : const ExploreScreen();
         },
       ),
+    );
+      },
     );
   }
 }

--- a/app_src/lib/services/language_service.dart
+++ b/app_src/lib/services/language_service.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class LanguageService {
+  static final ValueNotifier<Locale> locale =
+      ValueNotifier(const Locale('es'));
+
+  static Future<void> loadLocale() async {
+    final prefs = await SharedPreferences.getInstance();
+    final code = prefs.getString('languageCode') ?? 'es';
+    locale.value = Locale(code);
+  }
+
+  static Future<void> updateLocale(String code) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('languageCode', code);
+    locale.value = Locale(code);
+  }
+}


### PR DESCRIPTION
## Summary
- add a simple localization system with `AppLocalizations`
- store selected language in `LanguageService`
- allow choosing language from a new LanguageSelectorScreen
- integrate locale switching in `main.dart`
- add Languages option in Settings

## Testing
- `dart format` *(fails: `dart: command not found`)*