### PR TITLE
Integrar Crashlytics

### DIFF
--- a/app_src/README.md
+++ b/app_src/README.md
@@ -2,6 +2,19 @@
 
 A new Flutter project.
 
+## Crashlytics
+
+Esta app está lista para usar Firebase Crashlytics. Tras instalar las
+dependencias y configurar los archivos de Google, asegúrate de ejecutar
+
+```bash
+flutterfire configure
+flutter pub get
+```
+
+Luego ejecuta la aplicación con `flutter run` y genera un fallo para
+verlo reflejado en la consola de Firebase.
+
 ## Getting Started
 
 This project is a starting point for a Flutter application.

--- a/app_src/android/app/build.gradle
+++ b/app_src/android/app/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id "kotlin-android"
     id "dev.flutter.flutter-gradle-plugin"
     id "com.google.gms.google-services"
+    id "com.google.firebase.crashlytics"
 }
 
 android {
@@ -34,6 +35,7 @@ android {
 dependencies {
     implementation platform('com.google.firebase:firebase-bom:33.7.0')
     implementation 'com.google.firebase:firebase-analytics'
+    implementation 'com.google.firebase:firebase-crashlytics'
     implementation 'com.google.android.material:material:1.9.0'
 
     // ⚠️  AÑADE ESTA LÍNEA para que el task l8DexDesugarLibDebug tenga algo que procesar

--- a/app_src/android/build.gradle
+++ b/app_src/android/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.2.1'
         classpath 'com.google.gms:google-services:4.3.15'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.9'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.0"
     }
 }

--- a/app_src/lib/main.dart
+++ b/app_src/lib/main.dart
@@ -2,14 +2,16 @@
  *  lib/main.dart  ·  FCM multi-usuario / multi-dispositivo
  * ────────────────────────────────────────────────────────*/
 import 'dart:async';
+import 'dart:ui';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart' show kIsWeb, kDebugMode;
 
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:receive_sharing_intent/receive_sharing_intent.dart';
@@ -43,6 +45,13 @@ Future<void> main() async {
   // 1 ▸ Firebase
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
   FirebaseMessaging.onBackgroundMessage(_firebaseBgHandler);
+  FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterFatalError;
+  PlatformDispatcher.instance.onError = (error, stack) {
+    FirebaseCrashlytics.instance.recordError(error, stack, fatal: true);
+    return true;
+  };
+  await FirebaseCrashlytics.instance
+      .setCrashlyticsCollectionEnabled(!kDebugMode);
 
   // 2 ▸ Fechas ES
   await initializeDateFormatting('es');

--- a/app_src/lib/start/welcome_screen.dart
+++ b/app_src/lib/start/welcome_screen.dart
@@ -1,6 +1,8 @@
 // welcome_screen.dart
 import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart' show kDebugMode;
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
@@ -264,6 +266,12 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
           ),
         ],
       ),
+      floatingActionButton: kDebugMode
+          ? FloatingActionButton(
+              onPressed: () => FirebaseCrashlytics.instance.crash(),
+              child: const Icon(Icons.warning),
+            )
+          : null,
     );
   }
 }

--- a/app_src/pubspec.yaml
+++ b/app_src/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   firebase_storage: ^12.3.6
   cloud_firestore: ^5.5.0
   firebase_database: ^11.3.5
+  firebase_crashlytics: ^3.5.4
   geolocator: ^10.0.3
   image_picker: ^0.8.7+5
   google_fonts: ^4.0.3


### PR DESCRIPTION
## Summary
- añade `firebase_crashlytics` en pubspec
- configura Crashlytics en Android
- inicializa Crashlytics al arrancar la app
- botón para provocar fallo en modo debug
- notas breves en README

## Testing
- `flutter test` *(falló: `flutter` no está instalado)*