### PR TITLE
Add amber plan type in card

### DIFF
--- a/app_src/lib/explore_screen/plans_managing/plan_card.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_card.dart
@@ -1300,9 +1300,9 @@ class PlanCardState extends State<PlanCard> {
                           Text(
                             plan.type.isNotEmpty ? plan.type : 'Plan',
                             style: const TextStyle(
-                              color: Colors.white,
+                              color: Colors.amber,
                               fontWeight: FontWeight.bold,
-                              fontSize: 14,
+                              fontSize: 18,
                             ),
                           ),
                           Text(


### PR DESCRIPTION
## Summary
- show plan type in amber within plan cards
- bump plan type font size for emphasis

## Testing
- `flutter --version` *(fails: command not found)*