### PR TITLE
Añadir filtro de seguidos en mapa

### DIFF
--- a/app_src/lib/explore_screen/main_screen/explore_screen_filter.dart
+++ b/app_src/lib/explore_screen/main_screen/explore_screen_filter.dart
@@ -32,6 +32,8 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
   List<String> _selectedPlans = [];
   String? _customPlan;
 
+  bool _onlyFollowed = false;
+
   String regionBusqueda = '';
   final TextEditingController _regionController = TextEditingController();
   final FocusNode _regionFocusNode = FocusNode();
@@ -59,6 +61,7 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
       if (init['selectedPlans'] != null) {
         _selectedPlans = List<String>.from(init['selectedPlans']);
       }
+      _onlyFollowed = init['onlyFollowed'] ?? false;
       regionBusqueda = init['regionBusqueda'] ?? '';
       edadRange = RangeValues(
         (init['edadMin'] ?? 18).toDouble(),
@@ -248,6 +251,7 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
       'edadMin': edadRange.start,
       'edadMax': edadRange.end,
       'genero': generoSeleccionado,
+      'onlyFollowed': _onlyFollowed,
       'userCoordinates': _userPosition != null
           ? {
               'lat': _userPosition!.latitude,
@@ -267,6 +271,7 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
       _regionController.clear();
       edadRange = const RangeValues(18, 60);
       _selectedDate = null;
+      _onlyFollowed = false;
     });
   }
 
@@ -325,7 +330,36 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
                     Wrap(
                       spacing: 6,
                       runSpacing: 6,
-                      children: plans.map((plan) {
+                      children: [
+                        InkWell(
+                          onTap: () {
+                            setState(() {
+                              _onlyFollowed = !_onlyFollowed;
+                            });
+                          },
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 12, vertical: 8),
+                            decoration: BoxDecoration(
+                              color: _onlyFollowed
+                                  ? AppColors.planColor
+                                  : AppColors.lightLilac,
+                              borderRadius: BorderRadius.circular(20),
+                              border: Border.all(color: AppColors.greyBorder),
+                            ),
+                            child: Text(
+                              'Planes de personas que sigo',
+                              style: TextStyle(
+                                color:
+                                    _onlyFollowed ? Colors.white : Colors.black,
+                                fontFamily: 'Inter-Regular',
+                                fontSize: 14,
+                                decoration: TextDecoration.none,
+                              ),
+                            ),
+                          ),
+                        ),
+                        ...plans.map((plan) {
                         final String name = plan['name'];
                         final bool selected = _selectedPlans.contains(name);
                         return InkWell(
@@ -360,6 +394,7 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
                           ),
                         );
                       }).toList(),
+                    ],
                     ),
                     const SizedBox(height: 10),
                     const Text(

--- a/app_src/lib/explore_screen/map/plans_in_map_screen.dart
+++ b/app_src/lib/explore_screen/map/plans_in_map_screen.dart
@@ -37,6 +37,7 @@ class PlansInMapScreen {
     // Identificamos a qué usuarios sigue el usuario actual
     final User? currentUser = FirebaseAuth.instance.currentUser;
     final Set<String> followedUids = {};
+    final bool onlyFollowed = filters?['onlyFollowed'] == true;
     if (currentUser != null) {
       final snap = await FirebaseFirestore.instance
           .collection('followed')
@@ -70,6 +71,9 @@ class PlansInMapScreen {
       final type = data['type'] as String?;
       final uid = data['createdBy'] as String?;
       if (lat == null || lng == null || type == null || uid == null) continue;
+      if (onlyFollowed && !followedUids.contains(uid)) {
+        continue;
+      }
       final String visibility = data['visibility']?.toString() ?? 'Público';
       if (visibility.toLowerCase() == 'privado') {
         continue;
@@ -178,6 +182,9 @@ class PlansInMapScreen {
             (filters['planBusqueda'] ?? '').toString().toLowerCase();
         final String type = data['type']?.toString() ?? '';
         final String visibility = data['visibility']?.toString() ?? 'Público';
+        if (onlyFollowed && !followedUids.contains(data['createdBy'])) {
+          return;
+        }
         if (selected.isNotEmpty) {
           if (!selected.contains(type.toLowerCase())) return;
         } else if (searchText.isNotEmpty) {


### PR DESCRIPTION
## Summary
- agregar booleano `onlyFollowed` en el diálogo de filtros
- permitir seleccionar "Planes de personas que sigo" en el diálogo
- propagar el filtro a `PlansInMapScreen` para mostrar solo los planes de los seguidos

## Testing
- `flutter format app_src/lib/explore_screen/main_screen/explore_screen_filter.dart app_src/lib/explore_screen/map/plans_in_map_screen.dart` *(falló: command not found)*