### PR TITLE
Add terms acceptance modal and cookies page

### DIFF
--- a/app_src/lib/main.dart
+++ b/app_src/lib/main.dart
@@ -25,6 +25,7 @@ import 'explore_screen/users_managing/presence_service.dart';
 import 'explore_screen/chats/chats_screen.dart';
 import 'explore_screen/main_screen/explore_screen.dart';
 import 'start/welcome_screen.dart';
+import 'start/registration/terms_modal.dart';
 
 /* ─────────────────────────────────────────────────────────
  *  Handler FCM en background
@@ -151,6 +152,7 @@ class _MyAppState extends State<MyApp> {
   String? _sharedText;
   StreamSubscription<List<SharedMediaFile>>? _intentSub;
   String? _lastUid; // detecta cambio de usuario
+  bool _termsChecked = false;
 
   @override
   void initState() {
@@ -166,6 +168,8 @@ class _MyAppState extends State<MyApp> {
         ReceiveSharingIntent.instance.reset();
       });
     }
+
+    _checkTerms();
   }
 
   void _onMedia(List<SharedMediaFile> files) {
@@ -174,6 +178,19 @@ class _MyAppState extends State<MyApp> {
         setState(() => _sharedText = f.path);
         break;
       }
+    }
+  }
+
+  void _checkTerms() async {
+    if (_termsChecked) return;
+    _termsChecked = true;
+    final prefs = await SharedPreferences.getInstance();
+    final accepted = prefs.getBool('termsAccepted') ?? false;
+    final version = prefs.getString('termsVersion');
+    if (!(accepted && version == '2024-05')) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        showTermsModal(context);
+      });
     }
   }
 

--- a/app_src/lib/start/registration/terms_modal.dart
+++ b/app_src/lib/start/registration/terms_modal.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter/gestures.dart';
+import '../login/login_screen.dart';
+
+Future<bool?> showTermsModal(BuildContext context) {
+  return showDialog<bool>(
+    context: context,
+    barrierDismissible: false,
+    builder: (_) => const _TermsModal(),
+  );
+}
+
+class _TermsModal extends StatelessWidget {
+  const _TermsModal();
+
+  @override
+  Widget build(BuildContext context) {
+    return WillPopScope(
+      onWillPop: () async => false,
+      child: Dialog(
+        insetPadding: EdgeInsets.zero,
+        backgroundColor: Colors.transparent,
+        child: Container(
+          margin: const EdgeInsets.only(top: 50),
+          padding: const EdgeInsets.all(20),
+          height: MediaQuery.of(context).size.height * 0.9,
+          decoration: const BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              IconButton(
+                icon: const Icon(Icons.arrow_back),
+                onPressed: () => Navigator.of(context).pop(false),
+              ),
+              const SizedBox(height: 10),
+              const Center(
+                child: Text(
+                  'Aceptar las condiciones y la política de privacidad',
+                  style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+              const SizedBox(height: 20),
+              const _SummaryText(),
+              const Spacer(),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: () async {
+                    final prefs = await SharedPreferences.getInstance();
+                    await prefs.setBool('termsAccepted', true);
+                    await prefs.setString('termsVersion', '2024-05');
+                    if (context.mounted) Navigator.of(context).pop(true);
+                  },
+                  child: const Text('Acepto'),
+                ),
+              ),
+              const SizedBox(height: 10),
+              Center(
+                child: GestureDetector(
+                  onTap: () {
+                    Navigator.of(context).pop(false);
+                    Navigator.of(context).push(
+                      MaterialPageRoute(builder: (_) => const LoginScreen()),
+                    );
+                  },
+                  child: const Text(
+                    'Buscar mi cuenta',
+                    style: TextStyle(
+                      decoration: TextDecoration.underline,
+                      color: Colors.blue,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SummaryText extends StatelessWidget {
+  const _SummaryText();
+
+  @override
+  Widget build(BuildContext context) {
+    TextSpan link(String text, String url) => TextSpan(
+          text: text,
+          style: const TextStyle(color: Colors.blue),
+          recognizer: TapGestureRecognizer()
+            ..onTap = () => launchUrl(Uri.parse(url),
+                mode: LaunchMode.externalApplication),
+        );
+    return RichText(
+      textAlign: TextAlign.justify,
+      text: TextSpan(
+        style: const TextStyle(color: Colors.black, fontSize: 14),
+        children: [
+          const TextSpan(
+              text:
+                  'Al tocar Acepto, creas tu cuenta y aceptas las '),
+          link('Condiciones', 'https://plansocial.app/legal/condiciones'),
+          const TextSpan(
+              text:
+                  ' de la app. Obtén información sobre cómo recogemos, utilizamos y compartimos tus datos en nuestra '),
+          link('Política de privacidad',
+              'https://plansocial.app/legal/privacidad'),
+          const TextSpan(
+              text: ' y cómo usamos las cookies en nuestra '),
+          link('Política de cookies', 'https://plansocial.app/legal/cookies'),
+          const TextSpan(text: '.'),
+        ],
+      ),
+    );
+  }
+}
+

--- a/app_src/lib/start/registration/user_registration_screen.dart
+++ b/app_src/lib/start/registration/user_registration_screen.dart
@@ -20,6 +20,7 @@ import 'package:dating_app/explore_screen/main_screen/explore_screen.dart';
 
 // Enum de proveedor (google/password)
 import 'verification_provider.dart';
+import 'terms_modal.dart';
 
 class UserRegistrationScreen extends StatefulWidget {
   const UserRegistrationScreen({
@@ -167,6 +168,13 @@ class _UserRegistrationScreenState extends State<UserRegistrationScreen> {
   }
 
   /// Botón "Completar registro"
+  Future<void> _onAcceptTermsAndRegister() async {
+    final accepted = await showTermsModal(context);
+    if (accepted == true) {
+      await _onCompleteRegistration();
+    }
+  }
+
   Future<void> _onCompleteRegistration() async {
     setState(() => _isSaving = true);
 
@@ -834,7 +842,7 @@ class _UserRegistrationScreenState extends State<UserRegistrationScreen> {
                   SizedBox(
                     width: double.infinity,
                     child: ElevatedButton(
-                      onPressed: _isSaving ? null : _onCompleteRegistration,
+                      onPressed: _isSaving ? null : _onAcceptTermsAndRegister,
                       style: ElevatedButton.styleFrom(
                         backgroundColor: MyColors.AppColors.blue,
                         padding: const EdgeInsets.symmetric(vertical: 14),

--- a/public/cookies.html
+++ b/public/cookies.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset='utf-8'>
+    <meta name='viewport' content='width=device-width'>
+    <title>Política de cookies</title>
+    <style>
+        body {
+            font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+            padding: 1em;
+        }
+        .site-footer{background:#000;color:#fff;padding:2rem 1rem;text-align:center;margin-left:-1em;margin-right:-1em;}
+        .footer-container{max-width:1200px;margin:auto;display:flex;flex-direction:column;align-items:center;gap:1rem;}
+        .footer-links{display:flex;gap:1rem;flex-wrap:wrap;align-items:center;}
+        .footer-links a{color:#fff;font-size:.875rem;}
+        .footer-logo{height:40px;}
+        .lang-select{background:#000;color:#fff;border:1px solid #fff;padding:.3rem;}
+        .footer-social{display:flex;flex-direction:column;gap:.5rem;align-items:center;font-size:.875rem;}
+        .social-icon{height:20px;}
+    </style>
+</head>
+<body>
+<div data-lang='es'>
+    <h1>Política de cookies</h1>
+    <p>Contenido provisional. Próximamente añadiremos la información completa.</p>
+    <img src='plan-sin-fondo.png' alt='Plan Social' style='max-width:200px;'>
+    <hr>
+    <footer class='site-footer'>
+        <div class='footer-container'>
+            <img class='footer-logo' src='plan-sin-fondo.png' alt='Plan Social'>
+            <div class='footer-links'>
+                <a href='help.html'>Ayuda</a>
+                <a href='privacy_policy.html'>Privacidad</a>
+                <a href='terms_and_conditions.html'>Condiciones</a>
+                <select class='lang-select'>
+                    <option value='es'>Español</option>
+                    <option value='en'>English</option>
+                </select>
+                <div class='footer-social'>
+                    <div>Síguenos en <button onclick="window.open('https://www.instagram.com/plan0525/', '_blank')" style='background:none;border:none;padding:0'><img src='instagram.png' alt='Instagram' class='social-icon'></button></div>
+                </div>
+            </div>
+            <p>© 2025 Plan</p>
+        </div>
+    </footer>
+</div>
+<script>
+(function(){
+  const selects=document.querySelectorAll('.lang-select');
+  function setLang(l){
+    document.documentElement.lang=l;
+    document.querySelectorAll('[data-lang]').forEach(el=>{
+      el.style.display=el.getAttribute('data-lang')===l?'':'none';
+    });
+    selects.forEach(s=>s.value=l);
+  }
+  const initial=((navigator.language||navigator.userLanguage)||'en').startsWith('es')?'es':'en';
+  setLang(initial);
+  selects.forEach(sel=>sel.addEventListener('change',e=>setLang(e.target.value)));
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create terms acceptance modal in registration flow
- prompt modal before completing registration and show on startup if not accepted
- store acceptance in SharedPreferences
- add basic cookies.html page

## Testing
- `npm test` *(fails: Could not read package.json)*