### PR TITLE
Fix registration navigation logic

### DIFF
--- a/app_src/lib/main.dart
+++ b/app_src/lib/main.dart
@@ -282,15 +282,9 @@ class _MyAppState extends State<MyApp> {
                 return const ExploreScreen();
               }
 
-              final providerId =
-                  user.providerData.isNotEmpty ? user.providerData.first.providerId : '';
-              final provider = providerId == 'google.com'
-                  ? VerificationProvider.google
-                  : VerificationProvider.password;
-              return UserRegistrationScreen(
-                provider: provider,
-                firebaseUser: user,
-              );
+              // Si no hay perfil completo, cerramos sesión y mostramos bienvenida
+              signOutAndRemoveToken();
+              return const WelcomeScreen();
             },
           );
         },

--- a/app_src/lib/start/login/login_screen.dart
+++ b/app_src/lib/start/login/login_screen.dart
@@ -15,7 +15,8 @@ import '../../main/colors.dart';
 import '../../explore_screen/users_managing/presence_service.dart';
 import 'recover_password.dart';
 import '../registration/register_screen.dart';
-import '../registration/register_with_google.dart';
+import '../registration/user_registration_screen.dart';
+import '../registration/verification_provider.dart';
 
 const Color backgroundColor = AppColors.background;
 
@@ -64,8 +65,17 @@ class _LoginScreenState extends State<LoginScreen> {
       if (user == null) throw FirebaseAuthException(code: 'USER_NULL');
 
       if (!await _userDocExists(user.uid)) {
-        await _auth.signOut();
-        if (mounted) _showNoProfileDialog();
+        if (!mounted) return;
+        Navigator.pushAndRemoveUntil(
+          context,
+          MaterialPageRoute(
+            builder: (_) => UserRegistrationScreen(
+              provider: VerificationProvider.password,
+              firebaseUser: user,
+            ),
+          ),
+          (_) => false,
+        );
         return;
       }
 
@@ -107,15 +117,17 @@ class _LoginScreenState extends State<LoginScreen> {
       if (user == null) throw FirebaseAuthException(code: 'USER_NULL');
 
       if (!await _userDocExists(user.uid)) {
-        await _auth.signOut();
         if (!mounted) return;
-        final create = await _showGoogleNoProfileDialog();
-        if (create == true && mounted) {
-          Navigator.push(
-            context,
-            MaterialPageRoute(builder: (_) => const RegisterWithGoogle()),
-          );
-        }
+        Navigator.pushAndRemoveUntil(
+          context,
+          MaterialPageRoute(
+            builder: (_) => UserRegistrationScreen(
+              provider: VerificationProvider.google,
+              firebaseUser: user,
+            ),
+          ),
+          (_) => false,
+        );
         return;
       }
 
@@ -142,43 +154,6 @@ class _LoginScreenState extends State<LoginScreen> {
   /* ───────────────────────────────────────────────────────────
    *  Diálogos de error
    * ───────────────────────────────────────────────────────── */
-  void _showNoProfileDialog() {
-    showDialog(
-      context: context,
-      builder: (_) => AlertDialog(
-        title: const Text('No estás registrado'),
-        content: const Text(
-          'No hay ningún perfil en la base de datos para este usuario. '
-          'Debes registrarte primero.',
-        ),
-        actions: [
-          TextButton(onPressed: () => Navigator.pop(context), child: const Text('Aceptar')),
-        ],
-      ),
-    );
-  }
-
-  Future<bool?> _showGoogleNoProfileDialog() {
-    return showDialog<bool>(
-      context: context,
-      builder: (_) => AlertDialog(
-        title: const Text('No hay perfil'),
-        content: const Text(
-          'No hay un perfil asociado a tu cuenta de Google. ¿Crear una nueva cuenta?'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: const Text('Cancelar'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(context, true),
-            child: const Text('Aceptar'),
-          ),
-        ],
-      ),
-    );
-  }
-
   void _showErrorDialog(String msg) {
     showDialog(
       context: context,

--- a/app_src/lib/start/registration/user_registration_screen.dart
+++ b/app_src/lib/start/registration/user_registration_screen.dart
@@ -14,7 +14,7 @@ import 'package:geocoding/geocoding.dart' show placemarkFromCoordinates, Placema
 
 // Importa tus colores desde tu archivo principal (ajusta el import si lo requieres)
 import 'package:dating_app/main/colors.dart' as MyColors;
-import 'register_screen.dart';
+import '../welcome_screen.dart';
 
 // Pantalla final (la que verás tras completar registro):
 import 'package:dating_app/explore_screen/main_screen/explore_screen.dart';
@@ -647,10 +647,22 @@ class _UserRegistrationScreenState extends State<UserRegistrationScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Material(
-      color: Colors.white,
-      child: SafeArea(
-        child: Stack(
+    return WillPopScope(
+      onWillPop: () async {
+        await FirebaseAuth.instance.signOut();
+        if (mounted) {
+          Navigator.pushAndRemoveUntil(
+            context,
+            MaterialPageRoute(builder: (_) => const WelcomeScreen()),
+            (_) => false,
+          );
+        }
+        return false;
+      },
+      child: Material(
+        color: Colors.white,
+        child: SafeArea(
+          child: Stack(
           children: [
             SingleChildScrollView(
               padding: EdgeInsets.only(
@@ -872,13 +884,15 @@ class _UserRegistrationScreenState extends State<UserRegistrationScreen> {
               child: IconButton(
                 icon: const Icon(Icons.arrow_back),
                 color: MyColors.AppColors.blue,
-                onPressed: () {
-                  Navigator.pushReplacement(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => const RegisterScreen(),
-                    ),
-                  );
+                onPressed: () async {
+                  await FirebaseAuth.instance.signOut();
+                  if (mounted) {
+                    Navigator.pushAndRemoveUntil(
+                      context,
+                      MaterialPageRoute(builder: (_) => const WelcomeScreen()),
+                      (_) => false,
+                    );
+                  }
                 },
               ),
             ),

--- a/app_src/lib/start/welcome_screen.dart
+++ b/app_src/lib/start/welcome_screen.dart
@@ -105,7 +105,7 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
         if (!hasInfo) {
           // No hay doc completo → vamos a UserRegistrationScreen
           if (mounted) {
-            Navigator.pushReplacement(
+            Navigator.push(
               context,
               MaterialPageRoute(
                 builder: (_) => const UserRegistrationScreen(


### PR DESCRIPTION
## Summary
- sign out when profile is incomplete so app opens on welcome screen
- adjust welcome screen to push registration screen instead of replacing
- redirect to registration screen after login if profile missing
- sign out when leaving registration screen

## Testing
- `dart format` *(fails: command not found)*
- `flutter format` *(fails: command not found)*