### PR TITLE
Handle registration edge cases

### DIFF
--- a/app_src/lib/main.dart
+++ b/app_src/lib/main.dart
@@ -67,9 +67,14 @@ Future<void> main() async {
   // 5 ▸ Presencia + token si hay sesión persistente
   final user = FirebaseAuth.instance.currentUser;
   if (user != null) {
-    PresenceService.dispose();
-    await PresenceService.init(user);
-    await _registerFcmToken(user);
+    final hasProfile = await _hasCompleteProfile(user.uid);
+    if (hasProfile) {
+      PresenceService.dispose();
+      await PresenceService.init(user);
+      await _registerFcmToken(user);
+    } else {
+      await signOutAndRemoveToken();
+    }
   }
 
   runApp(const MyApp());
@@ -138,11 +143,19 @@ Future<void> signOutAndRemoveToken() async {
   final fcm = FirebaseMessaging.instance;
   final token = await fcm.getToken();
   if (token != null) {
-    await FirebaseFirestore.instance.doc('users/${user.uid}').update({
-      'tokens': FieldValue.arrayRemove([token])
-    });
+    try {
+      await FirebaseFirestore.instance.doc('users/${user.uid}').update({
+        'tokens': FieldValue.arrayRemove([token])
+      });
+    } catch (_) {
+      // ignorar fallos al eliminar el token
+    }
   }
-  await FirebaseAuth.instance.signOut();
+  try {
+    await FirebaseAuth.instance.signOut();
+  } catch (_) {
+    // ignorar fallos al cerrar sesión
+  }
 }
 
 Future<bool> _hasCompleteProfile(String uid) async {
@@ -257,8 +270,6 @@ class _MyAppState extends State<MyApp> {
               final enabled = prefs.getBool('notificationsEnabled') ?? true;
               NotificationService.instance.init(enabled: enabled);
             });
-
-            _registerFcmToken(user);
           }
 
           if (_sharedText != null) {
@@ -279,18 +290,13 @@ class _MyAppState extends State<MyApp> {
 
               final hasProfile = profileSnap.data == true;
               if (hasProfile) {
+                _registerFcmToken(user);
                 return const ExploreScreen();
               }
 
-              final providerId =
-                  user.providerData.isNotEmpty ? user.providerData.first.providerId : '';
-              final provider = providerId == 'google.com'
-                  ? VerificationProvider.google
-                  : VerificationProvider.password;
-              return UserRegistrationScreen(
-                provider: provider,
-                firebaseUser: user,
-              );
+              // Si no hay perfil completo, cerramos sesión y mostramos bienvenida
+              signOutAndRemoveToken();
+              return const WelcomeScreen();
             },
           );
         },

--- a/app_src/lib/start/login/login_screen.dart
+++ b/app_src/lib/start/login/login_screen.dart
@@ -15,7 +15,8 @@ import '../../main/colors.dart';
 import '../../explore_screen/users_managing/presence_service.dart';
 import 'recover_password.dart';
 import '../registration/register_screen.dart';
-import '../registration/register_with_google.dart';
+import '../registration/user_registration_screen.dart';
+import '../registration/verification_provider.dart';
 
 const Color backgroundColor = AppColors.background;
 
@@ -65,7 +66,19 @@ class _LoginScreenState extends State<LoginScreen> {
 
       if (!await _userDocExists(user.uid)) {
         await _auth.signOut();
-        if (mounted) _showNoProfileDialog();
+        if (!mounted) return;
+        final create = await _showCreateProfileDialog();
+        if (create == true && mounted) {
+          Navigator.pushReplacement(
+            context,
+            MaterialPageRoute(
+              builder: (_) => UserRegistrationScreen(
+                provider: VerificationProvider.password,
+                firebaseUser: user,
+              ),
+            ),
+          );
+        }
         return;
       }
 
@@ -109,11 +122,16 @@ class _LoginScreenState extends State<LoginScreen> {
       if (!await _userDocExists(user.uid)) {
         await _auth.signOut();
         if (!mounted) return;
-        final create = await _showGoogleNoProfileDialog();
+        final create = await _showCreateProfileDialog();
         if (create == true && mounted) {
-          Navigator.push(
+          Navigator.pushReplacement(
             context,
-            MaterialPageRoute(builder: (_) => const RegisterWithGoogle()),
+            MaterialPageRoute(
+              builder: (_) => UserRegistrationScreen(
+                provider: VerificationProvider.google,
+                firebaseUser: user,
+              ),
+            ),
           );
         }
         return;
@@ -142,29 +160,13 @@ class _LoginScreenState extends State<LoginScreen> {
   /* ───────────────────────────────────────────────────────────
    *  Diálogos de error
    * ───────────────────────────────────────────────────────── */
-  void _showNoProfileDialog() {
-    showDialog(
-      context: context,
-      builder: (_) => AlertDialog(
-        title: const Text('No estás registrado'),
-        content: const Text(
-          'No hay ningún perfil en la base de datos para este usuario. '
-          'Debes registrarte primero.',
-        ),
-        actions: [
-          TextButton(onPressed: () => Navigator.pop(context), child: const Text('Aceptar')),
-        ],
-      ),
-    );
-  }
-
-  Future<bool?> _showGoogleNoProfileDialog() {
+  Future<bool?> _showCreateProfileDialog() {
     return showDialog<bool>(
       context: context,
       builder: (_) => AlertDialog(
         title: const Text('No hay perfil'),
         content: const Text(
-          'No hay un perfil asociado a tu cuenta de Google. ¿Crear una nueva cuenta?'),
+          'No existe un perfil asociado a esta cuenta. ¿Crear uno nuevo?'),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),

--- a/app_src/lib/start/registration/user_registration_screen.dart
+++ b/app_src/lib/start/registration/user_registration_screen.dart
@@ -14,7 +14,7 @@ import 'package:geocoding/geocoding.dart' show placemarkFromCoordinates, Placema
 
 // Importa tus colores desde tu archivo principal (ajusta el import si lo requieres)
 import 'package:dating_app/main/colors.dart' as MyColors;
-import 'register_screen.dart';
+import '../welcome_screen.dart';
 
 // Pantalla final (la que verás tras completar registro):
 import 'package:dating_app/explore_screen/main_screen/explore_screen.dart';
@@ -647,10 +647,22 @@ class _UserRegistrationScreenState extends State<UserRegistrationScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Material(
-      color: Colors.white,
-      child: SafeArea(
-        child: Stack(
+    return WillPopScope(
+      onWillPop: () async {
+        await FirebaseAuth.instance.signOut();
+        if (mounted) {
+          Navigator.pushAndRemoveUntil(
+            context,
+            MaterialPageRoute(builder: (_) => const WelcomeScreen()),
+            (_) => false,
+          );
+        }
+        return false;
+      },
+      child: Material(
+        color: Colors.white,
+        child: SafeArea(
+          child: Stack(
           children: [
             SingleChildScrollView(
               padding: EdgeInsets.only(
@@ -872,13 +884,15 @@ class _UserRegistrationScreenState extends State<UserRegistrationScreen> {
               child: IconButton(
                 icon: const Icon(Icons.arrow_back),
                 color: MyColors.AppColors.blue,
-                onPressed: () {
-                  Navigator.pushReplacement(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => const RegisterScreen(),
-                    ),
-                  );
+                onPressed: () async {
+                  await FirebaseAuth.instance.signOut();
+                  if (mounted) {
+                    Navigator.pushAndRemoveUntil(
+                      context,
+                      MaterialPageRoute(builder: (_) => const WelcomeScreen()),
+                      (_) => false,
+                    );
+                  }
                 },
               ),
             ),

--- a/app_src/lib/start/welcome_screen.dart
+++ b/app_src/lib/start/welcome_screen.dart
@@ -105,7 +105,7 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
         if (!hasInfo) {
           // No hay doc completo → vamos a UserRegistrationScreen
           if (mounted) {
-            Navigator.pushReplacement(
+            Navigator.push(
               context,
               MaterialPageRoute(
                 builder: (_) => const UserRegistrationScreen(


### PR DESCRIPTION
## Summary
- check profile before registering FCM token on startup
- ignore Firestore errors when removing tokens on sign out
- only register FCM token after confirming profile exists
- show dialog when account has no profile before opening registration

## Testing
- `dart format app_src/lib/main.dart app_src/lib/start/login/login_screen.dart` *(fails: command not found)*
- `flutter format app_src/lib/main.dart app_src/lib/start/login/login_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6839f054fab083329cbfa3bcb6522d94