### PR TITLE
Implementar registro local antes de crear usuario

### DIFF
--- a/app_src/lib/start/registration/local_registration_service.dart
+++ b/app_src/lib/start/registration/local_registration_service.dart
@@ -1,0 +1,42 @@
+import 'package:shared_preferences/shared_preferences.dart';
+import 'verification_provider.dart';
+
+class LocalRegistrationService {
+  static const _providerKey = 'pending_reg_provider';
+  static const _emailKey = 'pending_reg_email';
+  static const _passwordKey = 'pending_reg_password';
+
+  static Future<void> saveEmailPassword({
+    required String email,
+    required String password,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_providerKey, VerificationProvider.password.name);
+    await prefs.setString(_emailKey, email);
+    await prefs.setString(_passwordKey, password);
+  }
+
+  static Future<void> saveGoogle({String? email}) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_providerKey, VerificationProvider.google.name);
+    if (email != null) await prefs.setString(_emailKey, email);
+  }
+
+  static Future<(VerificationProvider?, String?, String?)> getPending() async {
+    final prefs = await SharedPreferences.getInstance();
+    final providerName = prefs.getString(_providerKey);
+    if (providerName == null) return (null, null, null);
+    final provider = VerificationProvider.values
+        .firstWhere((e) => e.name == providerName);
+    final email = prefs.getString(_emailKey);
+    final password = prefs.getString(_passwordKey);
+    return (provider, email, password);
+  }
+
+  static Future<void> clear() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_providerKey);
+    await prefs.remove(_emailKey);
+    await prefs.remove(_passwordKey);
+  }
+}

--- a/app_src/lib/start/registration/register_screen.dart
+++ b/app_src/lib/start/registration/register_screen.dart
@@ -2,10 +2,10 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:dating_app/main/colors.dart';
-import 'email_verification_screen.dart';
 import 'register_with_google.dart';
 import 'verification_provider.dart';
-import 'auth_service.dart';
+import 'user_registration_screen.dart';
+import 'local_registration_service.dart';
 
 class RegisterScreen extends StatefulWidget {
   const RegisterScreen({Key? key}) : super(key: key);
@@ -23,44 +23,25 @@ class _RegisterScreenState extends State<RegisterScreen> {
     setState(() => isLoading = true);
 
     try {
-      final cred = await AuthService.createUserWithEmail(
-        email: emailController.text,
-        password: passwordController.text,
+      await LocalRegistrationService.saveEmailPassword(
+        email: emailController.text.trim(),
+        password: passwordController.text.trim(),
       );
 
-      final user = cred.user;
-      if (user != null && !user.emailVerified) {
-        await showDialog(
-          context: context,
-          builder: (_) => AlertDialog(
-            title: const Text('Verifica tu correo'),
-            content: Text(
-              'Se ha enviado un correo de verificación a ${emailController.text.trim()}. '
-              'Sigue el enlace recibido para continuar.',
-            ),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.pop(context),
-                child: const Text('Aceptar'),
-              ),
-            ],
+      if (!mounted) return;
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(
+          builder: (_) => UserRegistrationScreen(
+            provider: VerificationProvider.password,
+            email: emailController.text.trim(),
+            password: passwordController.text.trim(),
           ),
-        );
-
-        Navigator.pushReplacement(
-          context,
-          MaterialPageRoute(
-            builder: (_) => EmailVerificationScreen(
-              email: emailController.text.trim(),
-              password: passwordController.text.trim(),
-              provider: VerificationProvider.password,
-            ),
-          ),
-        );
-      }
+        ),
+      );
     } catch (e) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Error al registrarte: $e')),
+        SnackBar(content: Text('Error al iniciar registro: $e')),
       );
     } finally {
       setState(() => isLoading = false);


### PR DESCRIPTION
## Summary
- registrar datos en local antes de crear el usuario
- mover la creación de usuario a `Completar registro`
- simplificar el flujo con Google

## Testing
- `flutter test` *(falla: comando no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_683a27b6d2b483328f25136ab9675ef6