### PR TITLE
Revisar sesión persistente al iniciar la app

### DIFF
--- a/app_src/lib/main.dart
+++ b/app_src/lib/main.dart
@@ -66,7 +66,17 @@ Future<void> main() async {
   FirebaseMessaging.onMessage.listen(NotificationService.instance.show);
 
   // 5 ▸ Presencia + token si hay sesión persistente
-  final user = FirebaseAuth.instance.currentUser;
+  final auth = FirebaseAuth.instance;
+  User? user = auth.currentUser;
+  if (user != null) {
+    try {
+      await user.reload();
+      user = auth.currentUser;
+    } on FirebaseAuthException {
+      await auth.signOut();
+      user = null;
+    }
+  }
   if (user != null) {
     PresenceService.dispose();
     await PresenceService.init(user);


### PR DESCRIPTION
## Summary
- verificar si el usuario de Firebase sigue existiendo
- cerrar sesión automáticamente si fue eliminado

## Testing
- `flutter test` *(falló: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c14c480608332a559db83fd978b63