### PR TITLE
Fix welcome screen navigation

### DIFF
--- a/app_src/lib/start/welcome_screen.dart
+++ b/app_src/lib/start/welcome_screen.dart
@@ -101,17 +101,9 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
             doc != null && doc.exists && (doc.data()?['name'] ?? '').toString().isNotEmpty;
 
         if (!hasProfile) {
-          // Perfil incompleto → vamos a UserRegistrationScreen
-          if (mounted) {
-            Navigator.pushReplacement(
-              context,
-              MaterialPageRoute(
-                builder: (_) => const UserRegistrationScreen(
-                  provider: VerificationProvider.password,
-                ),
-              ),
-            );
-          }
+          // Si no hay perfil, cerramos la sesión para volver a la bienvenida
+          await FirebaseAuth.instance.signOut();
+          if (mounted) setState(() => _isLoading = false);
           return;
         }
 


### PR DESCRIPTION
## Summary
- avoid forcing the registration screen when there is an account without profile
- sign out and show WelcomeScreen instead

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_683c1c4d45388332b5ee25541c03de33