### PR TITLE
Add birthdate in registration and skip Google verification

### DIFF
--- a/app_src/lib/main.dart
+++ b/app_src/lib/main.dart
@@ -29,6 +29,7 @@ import 'start/welcome_screen.dart';
 import 'start/registration/terms_modal.dart';
 import 'start/registration/user_registration_screen.dart';
 import 'start/registration/verification_provider.dart';
+import 'start/registration/local_registration_service.dart';
 
 /* ─────────────────────────────────────────────────────────
  *  Handler FCM en background
@@ -129,6 +130,7 @@ class _MyAppState extends State<MyApp> {
     }
 
     _checkTerms();
+    _checkPendingRegistration();
   }
 
   void _onMedia(List<SharedMediaFile> files) {
@@ -153,6 +155,14 @@ class _MyAppState extends State<MyApp> {
           showTermsModal(ctx);
         }
       });
+    }
+  }
+
+  void _checkPendingRegistration() async {
+    final (provider, _, __) = await LocalRegistrationService.getPending();
+    if (provider != null) {
+      await LocalRegistrationService.clear();
+      await signOutAndRemoveToken();
     }
   }
 

--- a/app_src/lib/start/registration/register_with_google.dart
+++ b/app_src/lib/start/registration/register_with_google.dart
@@ -1,7 +1,7 @@
 // lib/start/registration/register_with_google.dart
 import 'package:flutter/material.dart';
 import 'package:dating_app/main/colors.dart';
-import 'package:dating_app/start/registration/email_verification_screen.dart';
+import 'user_registration_screen.dart';
 import 'verification_provider.dart';
 import 'local_registration_service.dart';
 import 'auth_service.dart';
@@ -32,16 +32,13 @@ class _RegisterWithGoogleState extends State<RegisterWithGoogle> {
 
       await LocalRegistrationService.saveGoogle(email: user.email);
 
-      // Enviamos correo de verificación siempre
-      await user.sendEmailVerification();
-
       if (!mounted) return;
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(
-          builder: (_) => EmailVerificationScreen(
-            email: user.email ?? '',
+          builder: (_) => UserRegistrationScreen(
             provider: VerificationProvider.google,
+            firebaseUser: user,
           ),
         ),
       );


### PR DESCRIPTION
## Summary
- sign out on app start if a registration was left unfinished
- skip email verification when registering with Google and go straight to the registration form
- replace age slider with a birthdate picker and show the computed age
- require name and birthdate to enable registration and indicate with asterisks

## Testing
- `dart format` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683c330a6ac88332a108da8a4f72cd0b