### PR TITLE
Fix login path for incomplete registration

### DIFF
--- a/app_src/lib/start/login/login_screen.dart
+++ b/app_src/lib/start/login/login_screen.dart
@@ -35,8 +35,11 @@ class _LoginScreenState extends State<LoginScreen> {
   bool isLoading = false;
 
   Future<bool> _userDocExists(String uid) async {
-    final doc = await FirebaseFirestore.instance.collection('users').doc(uid).get();
-    return doc.exists;
+    final doc =
+        await FirebaseFirestore.instance.collection('users').doc(uid).get();
+    if (!doc.exists) return false;
+    final name = (doc.data()?['name'] ?? '').toString();
+    return name.isNotEmpty;
   }
 
   Future<void> _goToExplore() async {


### PR DESCRIPTION
## Summary
- fix LoginScreen doc check to require `name` field

## Testing
- `dart format lib/start/login/login_screen.dart` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683c36db72388332ac81ff4ec1e96979