### PR TITLE
Direct Google login to register screen when no profile exists

### DIFF
--- a/app_src/lib/start/login/login_screen.dart
+++ b/app_src/lib/start/login/login_screen.dart
@@ -15,7 +15,6 @@ import '../../main/colors.dart';
 import '../../explore_screen/users_managing/presence_service.dart';
 import 'recover_password.dart';
 import '../registration/register_screen.dart';
-import '../registration/register_with_google.dart';
 
 const Color backgroundColor = AppColors.background;
 
@@ -116,7 +115,7 @@ class _LoginScreenState extends State<LoginScreen> {
         if (create == true && mounted) {
           Navigator.push(
             context,
-            MaterialPageRoute(builder: (_) => const RegisterWithGoogle()),
+            MaterialPageRoute(builder: (_) => const RegisterScreen()),
           );
         }
         return;


### PR DESCRIPTION
## Summary
- update Google login flow
  - remove `RegisterWithGoogle` import
  - when no profile is found, push `RegisterScreen` directly

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683c3fa28f348332a95f715eda0f9247