### PR TITLE
Implement email verification flow

### DIFF
--- a/app_src/lib/start/registration/register_screen.dart
+++ b/app_src/lib/start/registration/register_screen.dart
@@ -4,7 +4,8 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:dating_app/main/colors.dart';
 import 'register_with_google.dart';
 import 'verification_provider.dart';
-import 'user_registration_screen.dart';
+import 'email_verification_screen.dart';
+import 'auth_service.dart';
 import 'local_registration_service.dart';
 
 class RegisterScreen extends StatefulWidget {
@@ -23,6 +24,13 @@ class _RegisterScreenState extends State<RegisterScreen> {
     setState(() => isLoading = true);
 
     try {
+      // Crea el usuario y envía el correo de verificación
+      await AuthService.createUserWithEmail(
+        email: emailController.text.trim(),
+        password: passwordController.text.trim(),
+      );
+
+      // Guardamos que hay un registro pendiente
       await LocalRegistrationService.saveEmailPassword(
         email: emailController.text.trim(),
         password: passwordController.text.trim(),
@@ -32,10 +40,10 @@ class _RegisterScreenState extends State<RegisterScreen> {
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(
-          builder: (_) => UserRegistrationScreen(
-            provider: VerificationProvider.password,
+          builder: (_) => EmailVerificationScreen(
             email: emailController.text.trim(),
             password: passwordController.text.trim(),
+            provider: VerificationProvider.password,
           ),
         ),
       );

--- a/app_src/lib/start/registration/user_registration_screen.dart
+++ b/app_src/lib/start/registration/user_registration_screen.dart
@@ -180,26 +180,23 @@ class _UserRegistrationScreenState extends State<UserRegistrationScreen> {
 
     User? user;
     try {
-        if (widget.provider == VerificationProvider.password &&
-            widget.email != null &&
-            widget.password != null) {
-          final cred = await AuthService.createUserWithEmail(
-            email: widget.email!.trim(),
-            password: widget.password!.trim(),
-          );
-          user = cred.user;
-          if (user != null) {
-            await user.sendEmailVerification();
-          }
-        } else if (widget.provider == VerificationProvider.google) {
-          if (widget.firebaseUser != null) {
-            user = widget.firebaseUser;
-          } else {
-            final cred = await AuthService.signInWithGoogle();
-            user = cred.user;
-          }
-        }
-        if (user == null) throw Exception('No user');
+      if (widget.firebaseUser != null) {
+        // Usuario ya creado (por ejemplo tras verificar correo)
+        user = widget.firebaseUser;
+      } else if (widget.provider == VerificationProvider.password &&
+          widget.email != null &&
+          widget.password != null) {
+        final cred = await AuthService.createUserWithEmail(
+          email: widget.email!.trim(),
+          password: widget.password!.trim(),
+        );
+        user = cred.user;
+      } else if (widget.provider == VerificationProvider.google) {
+        final cred = await AuthService.signInWithGoogle();
+        user = cred.user;
+      }
+
+      if (user == null) throw Exception('No user');
     } catch (e) {
       setState(() => _isSaving = false);
       _showErrorPopup('Error al crear usuario: $e');


### PR DESCRIPTION
## Summary
- send email verification after registering with email/password
- redirect to a verification screen instead of profile
- accept pre-created users when completing registration

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c4faa79c483329183163b26f52557