### PR TITLE
Fix overflow in reauthentication dialog

### DIFF
--- a/app_src/lib/explore_screen/menu_side_bar/settings/account.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/settings/account.dart
@@ -195,23 +195,25 @@ Future<bool> _showReauthDialog(BuildContext context) async {
     builder: (ctx) {
       return AlertDialog(
         title: const Text('Reautenticación requerida'),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Text(
-                'Por cuestiones de seguridad debes introducir tus credenciales de inicio de sesión para eliminar tu cuenta definitivamente'),
-            const SizedBox(height: 16),
-            TextField(
-              controller: emailCtrl,
-              decoration: const InputDecoration(
-                  labelText: 'Correo electrónico o teléfono'),
-            ),
-            TextField(
-              controller: passCtrl,
-              obscureText: true,
-              decoration: const InputDecoration(labelText: 'Contraseña'),
-            ),
-          ],
+        content: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text(
+                  'Por cuestiones de seguridad debes introducir tus credenciales de inicio de sesión para eliminar tu cuenta definitivamente'),
+              const SizedBox(height: 16),
+              TextField(
+                controller: emailCtrl,
+                decoration: const InputDecoration(
+                    labelText: 'Correo electrónico o teléfono'),
+              ),
+              TextField(
+                controller: passCtrl,
+                obscureText: true,
+                decoration: const InputDecoration(labelText: 'Contraseña'),
+              ),
+            ],
+          ),
         ),
         actions: [
           TextButton(


### PR DESCRIPTION
## Summary
- wrap the reauthentication dialog content in `SingleChildScrollView` to avoid overflow when the keyboard shows

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683dec7366408332aafbce03df89d7ad