### PR TITLE
Fix dummy user creation

### DIFF
--- a/app_src/lib/services/notification_service.dart
+++ b/app_src/lib/services/notification_service.dart
@@ -93,6 +93,11 @@ class NotificationService {
     final user = FirebaseAuth.instance.currentUser;
     if (user == null || token == null) return;
 
+    final profileDoc = await _firestore.doc('users/${user.uid}').get();
+    final hasProfile = profileDoc.exists &&
+        (profileDoc.data()?['name'] ?? '').toString().isNotEmpty;
+    if (!hasProfile) return;
+
     final batch = _firestore.batch();
 
     // 1 ▸ Elimina el token de cualquier otro usuario


### PR DESCRIPTION
## Summary
- avoid creating users that only have a `tokens` field

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683df31290048332b6884634e3519897