### PR TITLE
Add firestore index and rule files

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,13 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "participants", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "timestamp", "order": "ASCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,55 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /users/{uid} {
+      allow read: if request.auth != null;
+      allow create, update, delete: if request.auth.uid == uid;
+      match /{sub=**} {
+        allow read: if request.auth != null;
+        allow write: if request.auth.uid == uid;
+      }
+    }
+    match /plans/{planId} {
+      allow read, create: if request.auth != null;
+      allow update, delete: if request.auth.uid == resource.data.createdBy;
+    }
+    match /notifications/{id} {
+      allow create: if request.auth.uid == request.resource.data.senderId;
+      allow read, delete: if request.auth.uid == resource.data.receiverId || request.auth.uid == resource.data.senderId;
+    }
+    match /messages/{msgId} {
+      allow read, write: if request.auth != null && (
+        (resource.data.participants is list && request.auth.uid in resource.data.participants) ||
+        (request.resource.data.participants is list && request.auth.uid in request.resource.data.participants)
+      );
+    }
+    match /plan_chat/{chatId} {
+      allow create, read: if request.auth != null;
+      allow delete: if request.auth.uid == resource.data.senderId;
+    }
+    match /followers/{docId} {
+      allow read, write: if request.auth != null;
+    }
+    match /followed/{docId} {
+      allow read, write: if request.auth != null;
+    }
+    match /follow_requests/{id} {
+      allow read, write: if request.auth != null && (request.auth.uid == resource.data.fromId || request.auth.uid == resource.data.toId);
+    }
+    match /blocked_users/{blockId} {
+      allow read: if request.auth != null;
+      allow create: if request.auth != null && request.auth.uid == request.resource.data.blockerId;
+      allow delete: if request.auth != null && request.auth.uid == resource.data.blockerId;
+    }
+    match /subscriptions/{docId} {
+      allow read, write: if request.auth != null && (request.auth.uid == request.resource.data.userId || request.auth.uid == request.resource.data.createdBy);
+    }
+    match /reports/{docId} {
+      allow create: if request.auth.uid == request.resource.data.reporterUserId;
+      allow read: if request.auth.token.admin == true;
+    }
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Firestore security rules used in the project
- add firestore indexes including one for messages collection

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683df8da8fc083328cd6522beb77311f