### PR TITLE
Fix messaging rule and queries

### DIFF
--- a/app_src/lib/explore_screen/chats/chat_screen.dart
+++ b/app_src/lib/explore_screen/chats/chat_screen.dart
@@ -184,6 +184,7 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
     try {
       QuerySnapshot unreadMessages = await FirebaseFirestore.instance
           .collection('messages')
+          .where('participants', arrayContains: currentUserId)
           .where('senderId', isEqualTo: widget.chatPartnerId)
           .where('receiverId', isEqualTo: currentUserId)
           .where('isRead', isEqualTo: false)

--- a/app_src/lib/explore_screen/chats/chats_screen.dart
+++ b/app_src/lib/explore_screen/chats/chats_screen.dart
@@ -293,6 +293,7 @@ class _ChatsScreenState extends State<ChatsScreen> {
                 return FutureBuilder<QuerySnapshot>(
                   future: FirebaseFirestore.instance
                       .collection('messages')
+                      .where('participants', arrayContains: currentUserId)
                       .where('senderId', isEqualTo: otherUserId)
                       .where('receiverId', isEqualTo: currentUserId)
                       .where('isRead', isEqualTo: false)

--- a/app_src/lib/explore_screen/main_screen/explore_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/explore_screen.dart
@@ -396,6 +396,7 @@ class ExploreScreenState extends State<ExploreScreen> {
   Stream<int> _unreadMessagesCountStream() {
     return FirebaseFirestore.instance
         .collection('messages')
+        .where('participants', arrayContains: currentUser?.uid)
         .where('receiverId', isEqualTo: currentUser?.uid)
         .where('isRead', isEqualTo: false)
         .snapshots()

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -7,6 +7,16 @@
         { "fieldPath": "participants", "arrayConfig": "CONTAINS" },
         { "fieldPath": "timestamp", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "participants", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "senderId", "order": "ASCENDING" },
+        { "fieldPath": "receiverId", "order": "ASCENDING" },
+        { "fieldPath": "isRead", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -18,10 +18,25 @@ service cloud.firestore {
       allow read, delete: if request.auth.uid == resource.data.receiverId || request.auth.uid == resource.data.senderId;
     }
     match /messages/{msgId} {
-      allow read, write: if request.auth != null && (
-        (resource.data.participants is list && request.auth.uid in resource.data.participants) ||
-        (request.resource.data.participants is list && request.auth.uid in request.resource.data.participants)
-      );
+      // Crear un nuevo mensaje: los participantes deben ser una lista con dos IDs e incluir al emisor
+      allow create: if request.auth != null
+        && request.resource.data.participants is list
+        && request.resource.data.participants.size() == 2
+        && request.auth.uid in request.resource.data.participants;
+
+      // Leer un mensaje individual
+      allow get: if request.auth != null
+        && resource.data.participants is list
+        && request.auth.uid in resource.data.participants;
+
+      // Listar mensajes: la consulta debe filtrar por array-contains con el uid
+      allow list: if request.auth != null
+        && request.query.where('participants', 'array-contains', request.auth.uid);
+
+      // Actualizar o borrar mensajes sólo si el usuario participa en el chat
+      allow update, delete: if request.auth != null
+        && resource.data.participants is list
+        && request.auth.uid in resource.data.participants;
     }
     match /plan_chat/{chatId} {
       allow create, read: if request.auth != null;


### PR DESCRIPTION
## Summary
- enforce message rules with array-contains filter
- add index for array query with sender/receiver read filter
- adapt message queries in `chat_screen.dart`, `chats_screen.dart` and `explore_screen.dart`

## Testing
- `git diff --stat`
- *No tests run due to missing flutter/dart tooling*


------
https://chatgpt.com/codex/tasks/task_e_683e01cdb5ec8332a7215f8fac21cfe8