### PR TITLE
Fix messages read rule

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -24,14 +24,10 @@ service cloud.firestore {
         && request.resource.data.participants.size() == 2
         && request.auth.uid in request.resource.data.participants;
 
-      // Leer un mensaje individual
-      allow get: if request.auth != null
+      // Leer mensajes (tanto individuales como consultas)
+      allow read: if request.auth != null
         && resource.data.participants is list
         && request.auth.uid in resource.data.participants;
-
-      // Listar mensajes: la consulta debe filtrar por array-contains con el uid
-      allow list: if request.auth != null
-        && request.query.where('participants', 'array-contains', request.auth.uid);
 
       // Actualizar o borrar mensajes sólo si el usuario participa en el chat
       allow update, delete: if request.auth != null


### PR DESCRIPTION
## Summary
- fix Firestore rules so chat messages can be read correctly

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e0689909c833299b2a75cf0edf65c