### PR TITLE
Show cover photo for users without plans

### DIFF
--- a/app_src/lib/explore_screen/users_grid/users_grid.dart
+++ b/app_src/lib/explore_screen/users_grid/users_grid.dart
@@ -233,6 +233,7 @@ class _UsersGridState extends State<UsersGrid> {
     final String name = userData['name']?.toString().trim() ?? 'Usuario';
     final String? uid = userData['uid']?.toString();
     final String? fallbackPhotoUrl = userData['photoUrl']?.toString();
+    final String? coverPhotoUrl = userData['coverPhotoUrl']?.toString();
     final bool showActivity = userData['activityStatusPublic'] != false;
 
     return Center(
@@ -245,15 +246,23 @@ class _UsersGridState extends State<UsersGrid> {
             // Imagen de fondo
             ClipRRect(
               borderRadius: BorderRadius.circular(30),
-              child: (fallbackPhotoUrl != null && fallbackPhotoUrl.isNotEmpty)
+              child: (coverPhotoUrl != null && coverPhotoUrl.isNotEmpty)
                   ? Image.network(
-                      fallbackPhotoUrl,
+                      coverPhotoUrl,
                       fit: BoxFit.cover,
                       width: double.infinity,
                       height: double.infinity,
                       errorBuilder: (_, __, ___) => buildPlaceholder(),
                     )
-                  : buildPlaceholder(),
+                  : (fallbackPhotoUrl != null && fallbackPhotoUrl.isNotEmpty)
+                      ? Image.network(
+                          fallbackPhotoUrl,
+                          fit: BoxFit.cover,
+                          width: double.infinity,
+                          height: double.infinity,
+                          errorBuilder: (_, __, ___) => buildPlaceholder(),
+                        )
+                      : buildPlaceholder(),
             ),
 
             // Bloque superior con avatar + nombre + estado de actividad


### PR DESCRIPTION
## Summary
- for users without plans, display their `coverPhotoUrl` in `UsersGrid`
- fall back to the profile photo if there's no cover image

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841bd5a93fc8332a257365e8256abfc