### PR TITLE
Ensure coverPhotoUrl aligns with coverPhotos count

### DIFF
--- a/app_src/lib/explore_screen/profile/user_images_managing.dart
+++ b/app_src/lib/explore_screen/profile/user_images_managing.dart
@@ -252,10 +252,14 @@ class UserImagesManaging {
       final updatedList = List<String>.from(currentCoverImages);
       updatedList.add(imageUrl);
 
+      final updateData = {'coverPhotos': updatedList};
+      if (updatedList.length == 1) {
+        updateData['coverPhotoUrl'] = updatedList.first;
+      }
       await FirebaseFirestore.instance
           .collection('users')
           .doc(user.uid)
-          .update({'coverPhotos': updatedList});
+          .update(updateData);
 
       onImagesUpdated(updatedList);
       ScaffoldMessenger.of(context).showSnackBar(
@@ -502,10 +506,15 @@ class _FullScreenImagePageState extends State<_FullScreenImagePage> {
       // Portada
       final updatedList = List<String>.from(widget.images);
       updatedList.removeAt(_currentPage);
+      final updateData = {'coverPhotos': updatedList};
+      if (updatedList.length <= 1) {
+        updateData['coverPhotoUrl'] =
+            updatedList.isNotEmpty ? updatedList.first : '';
+      }
       await FirebaseFirestore.instance
           .collection('users')
           .doc(user.uid)
-          .update({'coverPhotos': updatedList});
+          .update(updateData);
       widget.onCoverImagesUpdated?.call(updatedList);
 
       if (updatedList.isEmpty) {


### PR DESCRIPTION
## Summary
- adjust logic when adding a cover image to set `coverPhotoUrl` when only one exists
- update deletion logic to maintain `coverPhotoUrl` when the cover image list shrinks

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c33b6be88332b650550033bf6460