### PR TITLE
Fix overflow in plan card actions

### DIFF
--- a/app_src/lib/explore_screen/plans_managing/plan_card.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_card.dart
@@ -1215,7 +1215,7 @@ class PlanCardState extends State<PlanCard> {
                                 onTap: _toggleLike,
                                 iconColor: _liked ? Colors.red : Colors.white,
                               ),
-                              const SizedBox(width: 16),
+                              const SizedBox(width: 8),
                               StreamBuilder<DocumentSnapshot>(
                                 stream: FirebaseFirestore.instance
                                     .collection('plans')
@@ -1236,13 +1236,13 @@ class PlanCardState extends State<PlanCard> {
                                   );
                                 },
                               ),
-                              const SizedBox(width: 16),
+                              const SizedBox(width: 8),
                               _buildFrostedAction(
                                 iconPath: 'assets/icono-compartir.svg',
                                 countText: '',
                                 onTap: _onShareButtonTap,
                               ),
-                              const SizedBox(width: 16),
+                              const SizedBox(width: 8),
                               StreamBuilder<DocumentSnapshot>(
                                 stream: FirebaseFirestore.instance
                                     .collection('plans')


### PR DESCRIPTION
## Summary
- shrink spacing between action buttons in PlanCard to prevent horizontal overflow

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841cfc7fe348332a9887470b07dfcb8