### PR TITLE
Añade contador de compartidos

### DIFF
--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -1789,12 +1789,16 @@ class _CustomShareDialogContentState extends State<_CustomShareDialogContent> {
         'planDescription': planDesc,
         'planImage': planImage ?? '',
         'planLink': shareUrl,
-        'timestamp': FieldValue.serverTimestamp(),
-        'isRead': false,
-      });
-    }
-    Navigator.pop(context);
+      'timestamp': FieldValue.serverTimestamp(),
+      'isRead': false,
+    });
   }
+    await FirebaseFirestore.instance
+        .collection('plans')
+        .doc(widget.plan.id)
+        .update({'share_count': FieldValue.increment(1)});
+  Navigator.pop(context);
+}
 
   @override
   Widget build(BuildContext context) {

--- a/app_src/lib/explore_screen/plans_managing/plan_card.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_card.dart
@@ -1237,10 +1237,26 @@ class PlanCardState extends State<PlanCard> {
                                 },
                               ),
                               const SizedBox(width: 8),
-                              _buildFrostedAction(
-                                iconPath: 'assets/icono-compartir.svg',
-                                countText: '',
-                                onTap: _onShareButtonTap,
+                              StreamBuilder<DocumentSnapshot>(
+                                stream: FirebaseFirestore.instance
+                                    .collection('plans')
+                                    .doc(plan.id)
+                                    .snapshots(),
+                                builder: (ctx, snapShare) {
+                                  String countText = '0';
+                                  if (snapShare.hasData &&
+                                      snapShare.data!.exists) {
+                                    final d = snapShare.data!.data()
+                                        as Map<String, dynamic>;
+                                    final c = d['share_count'] ?? 0;
+                                    countText = c.toString();
+                                  }
+                                  return _buildFrostedAction(
+                                    iconPath: 'assets/icono-compartir.svg',
+                                    countText: countText,
+                                    onTap: _onShareButtonTap,
+                                  );
+                                },
                               ),
                               const SizedBox(width: 8),
                               StreamBuilder<DocumentSnapshot>(

--- a/app_src/lib/explore_screen/plans_managing/plan_share_sheet.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_share_sheet.dart
@@ -330,6 +330,11 @@ class PlanShareSheetState extends State<PlanShareSheet> {
       });
     }
 
+    await FirebaseFirestore.instance
+        .collection('plans')
+        .doc(widget.plan.id)
+        .update({'share_count': FieldValue.increment(1)});
+
     Navigator.pop(context);
   }
 }

--- a/app_src/lib/models/plan_model.dart
+++ b/app_src/lib/models/plan_model.dart
@@ -36,6 +36,7 @@ class PlanModel {
   int special_plan;
   int views;
   List<String>? viewedBy;
+  int share_count;
 
   // Varias imágenes + video
   List<String>? images;
@@ -79,6 +80,7 @@ class PlanModel {
     this.likes = 0,
     this.special_plan = 0,
     this.views = 0,
+    this.share_count = 0,
     this.viewedBy,
     this.images,
     this.originalImages,
@@ -137,6 +139,7 @@ class PlanModel {
       'likes': likes,
       'special_plan': special_plan,
       'views': views,
+      'share_count': share_count,
       'viewedBy': viewedBy ?? [],
       'images': images ?? [],
       'originalImages': originalImages ?? [],
@@ -183,6 +186,7 @@ class PlanModel {
       likes: map['likes'] ?? 0,
       special_plan: map['special_plan'] ?? 0,
       views: map['views'] ?? 0,
+      share_count: map['share_count'] ?? 0,
       viewedBy: map['viewedBy'] != null
           ? List<String>.from(map['viewedBy'] as List)
           : <String>[],
@@ -305,6 +309,7 @@ class PlanModel {
       likes: 0,
       special_plan: special_plan,
       views: 0,
+      share_count: 0,
       viewedBy: [],
       images: images ?? [],
       originalImages: originalImages ?? [],


### PR DESCRIPTION
## Summary
- increment `share_count` when sending plans
- show `share_count` on plan card next to the share icon
- track new field `share_count` in `PlanModel`

## Testing
- `flutter format app_src/lib/models/plan_model.dart app_src/lib/explore_screen/plans_managing/plan_card.dart app_src/lib/explore_screen/plans_managing/plan_share_sheet.dart app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d3a285b08332be364e6100c22af4