### PR TITLE
Añadir share count en FrostedPlanDialog

### DIFF
--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -455,10 +455,24 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
   }
 
   Widget _buildShareButton(PlanModel plan) {
-    return _buildActionButton(
-      iconPath: 'assets/icono-compartir.svg',
-      countText: "",
-      onTap: () => _openCustomShareModal(plan),
+    return StreamBuilder<DocumentSnapshot>(
+      stream: FirebaseFirestore.instance
+          .collection('plans')
+          .doc(plan.id)
+          .snapshots(),
+      builder: (context, snapshot) {
+        String countText = '0';
+        if (snapshot.hasData && snapshot.data!.exists) {
+          final data = snapshot.data!.data() as Map<String, dynamic>;
+          final count = data['share_count'] ?? 0;
+          countText = count.toString();
+        }
+        return _buildActionButton(
+          iconPath: 'assets/icono-compartir.svg',
+          countText: countText,
+          onTap: () => _openCustomShareModal(plan),
+        );
+      },
     );
   }
 


### PR DESCRIPTION
## Summary
- mostrar el conteo de compartidos en la vista de FrostedPlanDialog

## Testing
- `dart format app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart` *(falló: command not found)*
- `flutter format app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart` *(falló: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841df138618833298db91d87f612180