### PR TITLE
Mantener sesión tras verificación

### DIFF
--- a/app_src/lib/main.dart
+++ b/app_src/lib/main.dart
@@ -58,11 +58,10 @@ Future<void> main() async {
   await NotificationService.instance.init(enabled: enabled);
   await LanguageService.loadLocale();
 
-  // 4 ▸ Cancelar registro pendiente y cerrar sesión
+  // 4 ▸ Limpiar registro pendiente (sin cerrar sesión)
   final (provider, _, __) = await LocalRegistrationService.getPending();
   if (provider != null) {
     await LocalRegistrationService.clear();
-    await signOutAndRemoveToken();
   }
 
   // 5 ▸ Mostrar notificaciones en foreground


### PR DESCRIPTION
## Resumen
- no cerrar sesión al detectar un registro pendiente

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684304ffa4bc8332a7c91d9612af8a12