### PR TITLE
Fix back button overlay

### DIFF
--- a/app_src/lib/start/registration/user_registration_screen.dart
+++ b/app_src/lib/start/registration/user_registration_screen.dart
@@ -703,20 +703,6 @@ class _UserRegistrationScreenState extends State<UserRegistrationScreen> {
       child: SafeArea(
         child: Stack(
           children: [
-            Positioned(
-              top: 40,
-              left: 10,
-              child: IconButton(
-                icon: const Icon(Icons.arrow_back),
-                color: MyColors.AppColors.planColor,
-                onPressed: () {
-                  Navigator.pushReplacement(
-                    context,
-                    MaterialPageRoute(builder: (_) => const RegisterScreen()),
-                  );
-                },
-              ),
-            ),
             SingleChildScrollView(
               padding: EdgeInsets.only(
                 bottom: MediaQuery.of(context).viewInsets.bottom + 20,
@@ -965,6 +951,21 @@ class _UserRegistrationScreenState extends State<UserRegistrationScreen> {
                   ),
                   const SizedBox(height: 40),
                 ],
+              ),
+            ),
+
+            Positioned(
+              top: 40,
+              left: 10,
+              child: IconButton(
+                icon: const Icon(Icons.arrow_back),
+                color: MyColors.AppColors.planColor,
+                onPressed: () {
+                  Navigator.pushReplacement(
+                    context,
+                    MaterialPageRoute(builder: (_) => const RegisterScreen()),
+                  );
+                },
               ),
             ),
 


### PR DESCRIPTION
## Summary
- reordenar los widgets en `user_registration_screen.dart` para que el botón de volver quede sobre el contenido

## Testing
- `dart analyze` *(falla: comando no encontrado)*
- `flutter test` *(falla: comando no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_68430a6f02e08332a5ca6d5a10009c03