### PR TITLE
Fix navigation flow from registration screens

### DIFF
--- a/app_src/lib/start/login/login_screen.dart
+++ b/app_src/lib/start/login/login_screen.dart
@@ -15,6 +15,7 @@ import '../../main/colors.dart';
 import '../../explore_screen/users_managing/presence_service.dart';
 import 'recover_password.dart';
 import '../registration/register_screen.dart';
+import '../welcome_screen.dart';
 
 const Color backgroundColor = AppColors.background;
 
@@ -253,7 +254,18 @@ class _LoginScreenState extends State<LoginScreen> {
               child: IconButton(
                 icon: const Icon(Icons.arrow_back),
                 color: AppColors.blue,
-                onPressed: () => Navigator.pop(context),
+                onPressed: () {
+                  if (Navigator.canPop(context)) {
+                    Navigator.pop(context);
+                  } else {
+                    Navigator.pushReplacement(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => const WelcomeScreen(),
+                      ),
+                    );
+                  }
+                },
               ),
             ),
           ],

--- a/app_src/lib/start/registration/register_screen.dart
+++ b/app_src/lib/start/registration/register_screen.dart
@@ -7,6 +7,8 @@ import 'verification_provider.dart';
 import 'email_verification_screen.dart';
 import 'auth_service.dart';
 import 'local_registration_service.dart';
+import '../login/login_screen.dart';
+import '../welcome_screen.dart';
 
 class RegisterScreen extends StatefulWidget {
   const RegisterScreen({Key? key}) : super(key: key);
@@ -234,7 +236,16 @@ class _RegisterScreenState extends State<RegisterScreen> {
 
                     GestureDetector(
                       onTap: () {
-                        Navigator.pop(context);
+                        if (Navigator.canPop(context)) {
+                          Navigator.pop(context);
+                        } else {
+                          Navigator.pushReplacement(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => const LoginScreen(),
+                            ),
+                          );
+                        }
                       },
                       child: const Text(
                         '¿Ya tienes una cuenta? Inicia sesión',
@@ -257,7 +268,16 @@ class _RegisterScreenState extends State<RegisterScreen> {
                 icon: const Icon(Icons.arrow_back),
                 color: AppColors.blue,
                 onPressed: () {
-                  Navigator.pop(context);
+                  if (Navigator.canPop(context)) {
+                    Navigator.pop(context);
+                  } else {
+                    Navigator.pushReplacement(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => const WelcomeScreen(),
+                      ),
+                    );
+                  }
                 },
               ),
             ),


### PR DESCRIPTION
## Summary
- ensure register screen can navigate back even if no prior route
- ensure login screen can navigate back even if no prior route
- add fallbacks to open login or welcome when needed

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6843112478b48332a4a2729cfa46e4f3