### PR TITLE
Fix text according to block state

### DIFF
--- a/app_src/lib/explore_screen/chats/chat_screen.dart
+++ b/app_src/lib/explore_screen/chats/chat_screen.dart
@@ -512,6 +512,7 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
                                         context,
                                         me.uid,
                                         widget.chatPartnerId,
+                                        oldValue,
                                       );
                                     } catch (e) {
                                       // Si hay error, revertimos

--- a/app_src/lib/explore_screen/users_managing/report_and_block_user.dart
+++ b/app_src/lib/explore_screen/users_managing/report_and_block_user.dart
@@ -240,10 +240,12 @@ class ReportAndBlockUser {
                                 InkWell(
                                   onTap: () async {
                                     Navigator.pop(ctx);
+                                    final previousBlocked = isBlocked;
                                     await toggleBlockUser(
                                       context,
                                       currentUserId,
                                       chatPartnerId,
+                                      previousBlocked,
                                     );
                                   },
                                   child: Row(
@@ -305,8 +307,9 @@ class ReportAndBlockUser {
     BuildContext context,
     String currentUserId,
     String chatPartnerId,
+    bool isCurrentlyBlocked,
   ) async {
-    if (isBlocked) {
+    if (isCurrentlyBlocked) {
       // => Desbloquear
       await _unblockUser(currentUserId, chatPartnerId);
     } else {
@@ -315,7 +318,7 @@ class ReportAndBlockUser {
     }
 
     // Actualizamos el estado local
-    isBlocked = !isBlocked;
+    isBlocked = !isCurrentlyBlocked;
 
     // Mostramos popup confirmando acción
     showDialog(

--- a/app_src/lib/explore_screen/users_managing/user_info_check.dart
+++ b/app_src/lib/explore_screen/users_managing/user_info_check.dart
@@ -552,6 +552,7 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
                                         context,
                                         me.uid,
                                         widget.userId,
+                                        oldValue,
                                       );
                                     } catch (e) {
                                       setState(() {


### PR DESCRIPTION
## Summary
- pass blocked state to `toggleBlockUser`
- ensure block/unblock option text matches the real status

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432b72675c8332902b7ba8631d0fd0