### PR TITLE
Fix overflow in notification buttons

### DIFF
--- a/app_src/lib/explore_screen/main_screen/notification_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/notification_screen.dart
@@ -536,25 +536,39 @@ class _NotificationScreenState extends State<NotificationScreen> {
                               mainAxisSize: MainAxisSize.min,
                               children: [
                                 Container(
+                                  width: 24,
+                                  height: 24,
                                   decoration: BoxDecoration(
                                     color: bgColor,
                                     borderRadius: BorderRadius.circular(8),
                                   ),
                                   child: IconButton(
-                                    icon: const Icon(Icons.check,
-                                        color: Colors.green),
+                                    padding: EdgeInsets.zero,
+                                    constraints: const BoxConstraints(),
+                                    iconSize: 16,
+                                    icon: const Icon(
+                                      Icons.check,
+                                      color: Colors.green,
+                                    ),
                                     onPressed: onAccept,
                                   ),
                                 ),
                                 const SizedBox(height: 4),
                                 Container(
+                                  width: 24,
+                                  height: 24,
                                   decoration: BoxDecoration(
                                     color: bgColor,
                                     borderRadius: BorderRadius.circular(8),
                                   ),
                                   child: IconButton(
-                                    icon: const Icon(Icons.close,
-                                        color: Colors.red),
+                                    padding: EdgeInsets.zero,
+                                    constraints: const BoxConstraints(),
+                                    iconSize: 16,
+                                    icon: const Icon(
+                                      Icons.close,
+                                      color: Colors.red,
+                                    ),
                                     onPressed: onReject,
                                   ),
                                 ),


### PR DESCRIPTION
## Summary
- reduce size of accept/reject buttons in notification screen

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844159451e083328ea6ec00f85b3e1e