### PR TITLE
Fix overflow in notification tile

### DIFF
--- a/app_src/lib/explore_screen/main_screen/notification_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/notification_screen.dart
@@ -608,6 +608,7 @@ class _NotificationScreenState extends State<NotificationScreen> {
                                 ),
                                 subtitle: buildSubtitle("Plan: $planType"),
                                 onTap: () => _showPlanDetails(context, planId),
+                                isThreeLine: true,
                                 trailing: acceptRejectButtons(
                                   onAccept: () =>
                                       _handleAcceptJoinRequest(doc),
@@ -653,6 +654,7 @@ class _NotificationScreenState extends State<NotificationScreen> {
                                 ),
                                 subtitle: buildSubtitle("Plan: $planType"),
                                 onTap: () => _showPlanDetails(context, planId),
+                                isThreeLine: true,
                                 trailing: acceptRejectButtons(
                                   onAccept: () =>
                                       _handleAcceptInvitation(doc),
@@ -677,6 +679,7 @@ class _NotificationScreenState extends State<NotificationScreen> {
                                     ),
                                   );
                                 },
+                                isThreeLine: true,
                                 trailing: acceptRejectButtons(
                                   onAccept: () =>
                                       _handleAcceptFollowRequest(doc),


### PR DESCRIPTION
## Summary
- update ListTile items using `acceptRejectButtons` to use `isThreeLine` for more vertical space

## Testing
- `dart format app_src/lib/explore_screen/main_screen/notification_screen.dart` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68441822c90c83329f99bac5e9f584f9