### PR TITLE
Fix back navigation to open sidebar

### DIFF
--- a/app_src/lib/explore_screen/menu_side_bar/favourites_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/favourites_screen.dart
@@ -7,6 +7,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import '../plans_managing/plan_card.dart';
 import '../../models/plan_model.dart';
 import '../../main/colors.dart';
+import 'menu_side_bar_screen.dart';
 
 class FavouritesScreen extends StatelessWidget {
   const FavouritesScreen({Key? key}) : super(key: key);
@@ -190,7 +191,14 @@ class FavouritesScreen extends StatelessWidget {
                   ),
                   IconButton(
                     icon: const Icon(Icons.arrow_back_ios, color: Colors.black),
-                    onPressed: () => Navigator.pop(context),
+                    onPressed: () {
+                      Navigator.pushReplacement(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => MainSideBarScreen(initiallyOpen: true),
+                        ),
+                      );
+                    },
                   ),
                 ],
               ),

--- a/app_src/lib/explore_screen/menu_side_bar/menu_side_bar_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/menu_side_bar_screen.dart
@@ -17,10 +17,14 @@ class MainSideBarScreen extends StatefulWidget {
   final ValueChanged<bool>? onMenuToggled;
   final Function(int)? onPageChange;
 
+  /// Determina si el menú debe mostrarse abierto al iniciar.
+  final bool initiallyOpen;
+
   const MainSideBarScreen({
     super.key,
     this.onMenuToggled,
     this.onPageChange,
+    this.initiallyOpen = false,
   });
 
   @override
@@ -28,9 +32,15 @@ class MainSideBarScreen extends StatefulWidget {
 }
 
 class MainSideBarScreenState extends State<MainSideBarScreen> {
-  bool isOpen = false;
+  late bool isOpen;
   final String? currentUserId = FirebaseAuth.instance.currentUser?.uid;
   int _pressedIndex = -1;
+
+  @override
+  void initState() {
+    super.initState();
+    isOpen = widget.initiallyOpen;
+  }
 
   void toggleMenu() {
     setState(() {

--- a/app_src/lib/explore_screen/menu_side_bar/my_plans_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/my_plans_screen.dart
@@ -12,6 +12,7 @@ import '../../utils/plans_list.dart' as plansData;
 import '../../plan_creation/new_plan_creation_screen.dart';
 import '../plans_managing/plan_card.dart';
 import '../plans_managing/frosted_plan_dialog_state.dart' as new_frosted;
+import 'menu_side_bar_screen.dart';
 
 class MyPlansScreen extends StatelessWidget {
   const MyPlansScreen({Key? key}) : super(key: key);
@@ -115,7 +116,14 @@ class MyPlansScreen extends StatelessWidget {
                   ),
                   IconButton(
                     icon: const Icon(Icons.arrow_back_ios, color: Colors.black),
-                    onPressed: () => Navigator.pop(context),
+                    onPressed: () {
+                      Navigator.pushReplacement(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => MainSideBarScreen(initiallyOpen: true),
+                        ),
+                      );
+                    },
                   ),
                 ],
               ),

--- a/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
@@ -11,6 +11,7 @@ import '../../main/colors.dart';
 import '../../utils/plans_list.dart' as plansData;
 import '../plans_managing/frosted_plan_dialog_state.dart' as new_frosted;
 import '../plans_managing/plan_card.dart';
+import 'menu_side_bar_screen.dart';
 
 class SubscribedPlansScreen extends StatelessWidget {
   final String userId;
@@ -372,7 +373,14 @@ class SubscribedPlansScreen extends StatelessWidget {
                   ),
                   IconButton(
                     icon: const Icon(Icons.arrow_back_ios, color: Colors.black),
-                    onPressed: () => Navigator.pop(context),
+                    onPressed: () {
+                      Navigator.pushReplacement(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => MainSideBarScreen(initiallyOpen: true),
+                        ),
+                      );
+                    },
                   ),
                 ],
               ),


### PR DESCRIPTION
## Summary
- ensure `MyPlansScreen`, `SubscribedPlansScreen` and `FavouritesScreen` go back to sidebar
- allow `MainSideBarScreen` to start open via new `initiallyOpen` parameter

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684443e58cf8833295f180fcb1eec0ae