### PR TITLE
Fix back navigation to open sidebar from ExploreScreen

### DIFF
--- a/app_src/lib/explore_screen/main_screen/explore_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/explore_screen.dart
@@ -19,7 +19,9 @@ import 'package:dating_app/plan_creation/new_plan_creation_screen.dart';
 import 'searcher.dart';
 
 class ExploreScreen extends StatefulWidget {
-  const ExploreScreen({Key? key}) : super(key: key);
+  final bool initiallyOpenSidebar;
+
+  const ExploreScreen({Key? key, this.initiallyOpenSidebar = false}) : super(key: key);
 
   @override
   ExploreScreenState createState() => ExploreScreenState();
@@ -33,7 +35,7 @@ class ExploreScreenState extends State<ExploreScreen> {
   final GlobalKey<MainSideBarScreenState> _menuKey =
       GlobalKey<MainSideBarScreenState>();
 
-  bool isMenuOpen = false;
+  late bool isMenuOpen;
   RangeValues selectedAgeRange = const RangeValues(18, 40);
   double selectedDistance = 50;
 
@@ -50,6 +52,7 @@ class ExploreScreenState extends State<ExploreScreen> {
   @override
   void initState() {
     super.initState();
+    isMenuOpen = widget.initiallyOpenSidebar;
     _setStatusBarDark();
     _otherPages = [
       const MapScreen(),
@@ -493,6 +496,7 @@ class ExploreScreenState extends State<ExploreScreen> {
                 key: _menuKey,
                 onMenuToggled: (bool open) => setState(() => isMenuOpen = open),
                 onPageChange: changePage,
+                initiallyOpenSidebar: widget.initiallyOpenSidebar,
               ),
             ],
           ),

--- a/app_src/lib/explore_screen/menu_side_bar/favourites_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/favourites_screen.dart
@@ -7,6 +7,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import '../plans_managing/plan_card.dart';
 import '../../models/plan_model.dart';
 import '../../main/colors.dart';
+import '../main_screen/explore_screen.dart';
 
 class FavouritesScreen extends StatelessWidget {
   const FavouritesScreen({Key? key}) : super(key: key);
@@ -190,7 +191,14 @@ class FavouritesScreen extends StatelessWidget {
                   ),
                   IconButton(
                     icon: const Icon(Icons.arrow_back_ios, color: Colors.black),
-                    onPressed: () => Navigator.pop(context),
+                    onPressed: () {
+                      Navigator.pushReplacement(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => const ExploreScreen(initiallyOpenSidebar: true),
+                        ),
+                      );
+                    },
                   ),
                 ],
               ),

--- a/app_src/lib/explore_screen/menu_side_bar/menu_side_bar_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/menu_side_bar_screen.dart
@@ -17,10 +17,14 @@ class MainSideBarScreen extends StatefulWidget {
   final ValueChanged<bool>? onMenuToggled;
   final Function(int)? onPageChange;
 
+  /// Determina si el menú debe mostrarse abierto al iniciar.
+  final bool initiallyOpenSidebar;
+
   const MainSideBarScreen({
     super.key,
     this.onMenuToggled,
     this.onPageChange,
+    this.initiallyOpenSidebar = false,
   });
 
   @override
@@ -28,9 +32,15 @@ class MainSideBarScreen extends StatefulWidget {
 }
 
 class MainSideBarScreenState extends State<MainSideBarScreen> {
-  bool isOpen = false;
+  late bool isOpen;
   final String? currentUserId = FirebaseAuth.instance.currentUser?.uid;
   int _pressedIndex = -1;
+
+  @override
+  void initState() {
+    super.initState();
+    isOpen = widget.initiallyOpenSidebar;
+  }
 
   void toggleMenu() {
     setState(() {

--- a/app_src/lib/explore_screen/menu_side_bar/my_plans_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/my_plans_screen.dart
@@ -12,6 +12,7 @@ import '../../utils/plans_list.dart' as plansData;
 import '../../plan_creation/new_plan_creation_screen.dart';
 import '../plans_managing/plan_card.dart';
 import '../plans_managing/frosted_plan_dialog_state.dart' as new_frosted;
+import '../main_screen/explore_screen.dart';
 
 class MyPlansScreen extends StatelessWidget {
   const MyPlansScreen({Key? key}) : super(key: key);
@@ -115,7 +116,14 @@ class MyPlansScreen extends StatelessWidget {
                   ),
                   IconButton(
                     icon: const Icon(Icons.arrow_back_ios, color: Colors.black),
-                    onPressed: () => Navigator.pop(context),
+                    onPressed: () {
+                      Navigator.pushReplacement(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => const ExploreScreen(initiallyOpenSidebar: true),
+                        ),
+                      );
+                    },
                   ),
                 ],
               ),

--- a/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
@@ -11,6 +11,7 @@ import '../../main/colors.dart';
 import '../../utils/plans_list.dart' as plansData;
 import '../plans_managing/frosted_plan_dialog_state.dart' as new_frosted;
 import '../plans_managing/plan_card.dart';
+import '../main_screen/explore_screen.dart';
 
 class SubscribedPlansScreen extends StatelessWidget {
   final String userId;
@@ -372,7 +373,14 @@ class SubscribedPlansScreen extends StatelessWidget {
                   ),
                   IconButton(
                     icon: const Icon(Icons.arrow_back_ios, color: Colors.black),
-                    onPressed: () => Navigator.pop(context),
+                    onPressed: () {
+                      Navigator.pushReplacement(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => const ExploreScreen(initiallyOpenSidebar: true),
+                        ),
+                      );
+                    },
                   ),
                 ],
               ),


### PR DESCRIPTION
## Summary
- rename `initiallyOpenMenu` param to `initiallyOpenSidebar`
- wire sidebar initialization parameter consistently
- open ExploreScreen with sidebar when returning from plan lists

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684443e58cf8833295f180fcb1eec0ae