### PR TITLE
Add quick start guide

### DIFF
--- a/app_src/lib/explore_screen/main_screen/explore_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/explore_screen.dart
@@ -17,6 +17,7 @@ import '../profile/profile_screen.dart';
 import 'notification_screen.dart';
 import 'package:dating_app/plan_creation/new_plan_creation_screen.dart';
 import 'searcher.dart';
+import '../../tutorial/quick_start_guide.dart';
 
 class ExploreScreen extends StatefulWidget {
   final bool initiallyOpenSidebar;
@@ -34,6 +35,7 @@ class ExploreScreenState extends State<ExploreScreen> {
   final User? currentUser = FirebaseAuth.instance.currentUser;
   final GlobalKey<MainSideBarScreenState> _menuKey =
       GlobalKey<MainSideBarScreenState>();
+  final GlobalKey _addButtonKey = GlobalKey();
 
   late bool isMenuOpen;
   RangeValues selectedAgeRange = const RangeValues(18, 40);
@@ -61,6 +63,9 @@ class ExploreScreenState extends State<ExploreScreen> {
     ];
     _currentIndex = 0;
     _selectedIconIndex = 0;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      QuickStartGuide(context: context, addButtonKey: _addButtonKey).show();
+    });
   }
 
   @override
@@ -484,6 +489,7 @@ class ExploreScreenState extends State<ExploreScreen> {
                     currentIndex: _currentIndex,
                     selectedIconIndex: _selectedIconIndex,
                     onTapIcon: _onDockIconTap,
+                    addButtonKey: _addButtonKey,
                     notificationCountStream: null,
                     unreadMessagesCountStream: _unreadMessagesCountStream(),
                     badgeSize: 10,
@@ -510,6 +516,7 @@ class DockSection extends StatelessWidget {
   final int currentIndex;
   final int selectedIconIndex;
   final Function(int) onTapIcon;
+  final GlobalKey addButtonKey;
   final double iconSize;
   final double selectedBackgroundSize;
   final double iconSpacing;
@@ -530,6 +537,7 @@ class DockSection extends StatelessWidget {
     required this.currentIndex,
     required this.selectedIconIndex,
     required this.onTapIcon,
+    required this.addButtonKey,
     this.iconSize = 23.0,
     this.selectedBackgroundSize = 60.0,
     // Ajustamos iconSpacing para acercar los iconos.
@@ -581,6 +589,7 @@ class DockSection extends StatelessWidget {
                 asset: 'assets/anadir.svg',
                 notificationCountStream: notificationCountStream,
                 overrideIconSize: 70.0,
+                targetKey: addButtonKey,
               ),
               SizedBox(width: iconSpacing),
               _buildIconButton(
@@ -605,6 +614,7 @@ class DockSection extends StatelessWidget {
     Stream<int>? notificationCountStream,
     Stream<int>? unreadMessagesCountStream,
     double? overrideIconSize,
+    Key? targetKey,
   }) {
     final double effectiveIconSize = overrideIconSize ?? iconSize;
     final bool isSelected = selectedIconIndex == index;
@@ -616,6 +626,7 @@ class DockSection extends StatelessWidget {
           onTap: () => onTapIcon(index),
           borderRadius: BorderRadius.circular(selectedBackgroundSize / 2),
           child: Container(
+            key: targetKey,
             width: selectedBackgroundSize,
             height: selectedBackgroundSize,
             alignment: Alignment.center,

--- a/app_src/lib/tutorial/quick_start_guide.dart
+++ b/app_src/lib/tutorial/quick_start_guide.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tutorial_coach_mark/tutorial_coach_mark.dart';
+
+class QuickStartGuide {
+  QuickStartGuide({required this.context, required this.addButtonKey});
+
+  final BuildContext context;
+  final GlobalKey addButtonKey;
+  TutorialCoachMark? _tutorial;
+
+  Future<void> show() async {
+    final prefs = await SharedPreferences.getInstance();
+    final alreadyShown = prefs.getBool('quickStartShown') ?? false;
+
+    // Siempre mostramos la guía para pruebas. Para la versión final
+    // se debería comprobar `alreadyShown` antes de mostrarla.
+    if (alreadyShown && false) return;
+
+    _tutorial = TutorialCoachMark(
+      targets: _createTargets(),
+      colorShadow: Colors.black,
+      textSkip: 'Omitir',
+      alignSkip: Alignment.topLeft,
+      opacityShadow: 0.8,
+      onFinish: () async {
+        await prefs.setBool('quickStartShown', true);
+      },
+      onSkip: () async {
+        await prefs.setBool('quickStartShown', true);
+      },
+    );
+
+    _tutorial!.show(context: context);
+  }
+
+  List<TargetFocus> _createTargets() {
+    return [
+      TargetFocus(
+        identify: 'add_button',
+        keyTarget: addButtonKey,
+        shape: ShapeLightFocus.circle,
+        contents: [
+          TargetContent(
+            align: ContentAlign.top,
+            builder: (context, controller) => _buildContent(controller),
+          ),
+        ],
+      ),
+    ];
+  }
+
+  Widget _buildContent(TargetContentController controller) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Pinchando en el icono de + podrás crear un plan o evento.',
+            style: TextStyle(color: Colors.white, fontSize: 18),
+          ),
+          const SizedBox(height: 10),
+          Align(
+            alignment: Alignment.topRight,
+            child: TextButton(
+              onPressed: controller.next,
+              child: const Text(
+                'Siguiente',
+                style: TextStyle(color: Colors.white),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app_src/pubspec.yaml
+++ b/app_src/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
     git:
       url: https://github.com/KasemJaffer/receive_sharing_intent
       ref: 2cea396843cd3ab1b5ec4334be4233864637874e   # fix JVM-target
+  tutorial_coach_mark: ^1.2.5
 
 
 


### PR DESCRIPTION
## Summary
- add `tutorial_coach_mark` dependency
- create `QuickStartGuide` helper
- show tutorial over + button in `ExploreScreen`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68455fa475b08332b960fab7709f1762