### PR TITLE
Añade pasos de guía rápida para navegación

### DIFF
--- a/app_src/lib/explore_screen/main_screen/explore_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/explore_screen.dart
@@ -36,6 +36,10 @@ class ExploreScreenState extends State<ExploreScreen> {
   final GlobalKey<MainSideBarScreenState> _menuKey =
       GlobalKey<MainSideBarScreenState>();
   final GlobalKey _addButtonKey = GlobalKey();
+  final GlobalKey _homeButtonKey = GlobalKey();
+  final GlobalKey _mapButtonKey = GlobalKey();
+  final GlobalKey _chatButtonKey = GlobalKey();
+  final GlobalKey _profileButtonKey = GlobalKey();
 
   late bool isMenuOpen;
   RangeValues selectedAgeRange = const RangeValues(18, 40);
@@ -64,7 +68,14 @@ class ExploreScreenState extends State<ExploreScreen> {
     _currentIndex = 0;
     _selectedIconIndex = 0;
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      QuickStartGuide(context: context, addButtonKey: _addButtonKey).show();
+      QuickStartGuide(
+        context: context,
+        addButtonKey: _addButtonKey,
+        homeButtonKey: _homeButtonKey,
+        mapButtonKey: _mapButtonKey,
+        chatButtonKey: _chatButtonKey,
+        profileButtonKey: _profileButtonKey,
+      ).show();
     });
   }
 
@@ -490,6 +501,10 @@ class ExploreScreenState extends State<ExploreScreen> {
                     selectedIconIndex: _selectedIconIndex,
                     onTapIcon: _onDockIconTap,
                     addButtonKey: _addButtonKey,
+                    homeButtonKey: _homeButtonKey,
+                    mapButtonKey: _mapButtonKey,
+                    chatButtonKey: _chatButtonKey,
+                    profileButtonKey: _profileButtonKey,
                     notificationCountStream: null,
                     unreadMessagesCountStream: _unreadMessagesCountStream(),
                     badgeSize: 10,
@@ -517,6 +532,10 @@ class DockSection extends StatelessWidget {
   final int selectedIconIndex;
   final Function(int) onTapIcon;
   final GlobalKey addButtonKey;
+  final GlobalKey homeButtonKey;
+  final GlobalKey mapButtonKey;
+  final GlobalKey chatButtonKey;
+  final GlobalKey profileButtonKey;
   final double iconSize;
   final double selectedBackgroundSize;
   final double iconSpacing;
@@ -538,6 +557,10 @@ class DockSection extends StatelessWidget {
     required this.selectedIconIndex,
     required this.onTapIcon,
     required this.addButtonKey,
+    required this.homeButtonKey,
+    required this.mapButtonKey,
+    required this.chatButtonKey,
+    required this.profileButtonKey,
     this.iconSize = 23.0,
     this.selectedBackgroundSize = 60.0,
     // Ajustamos iconSpacing para acercar los iconos.
@@ -579,10 +602,18 @@ class DockSection extends StatelessWidget {
               // margen interior izquierdo
               Padding(
                 padding: const EdgeInsets.only(left: 6.0),
-                child: _buildIconButton(index: 0, asset: 'assets/casa.svg'),
+                child: _buildIconButton(
+                  index: 0,
+                  asset: 'assets/casa.svg',
+                  targetKey: homeButtonKey,
+                ),
               ),
               SizedBox(width: iconSpacing),
-              _buildIconButton(index: 1, asset: 'assets/icono-mapa.svg'),
+              _buildIconButton(
+                index: 1,
+                asset: 'assets/icono-mapa.svg',
+                targetKey: mapButtonKey,
+              ),
               SizedBox(width: iconSpacing),
               _buildIconButton(
                 index: 2,
@@ -596,9 +627,14 @@ class DockSection extends StatelessWidget {
                 index: 3,
                 asset: 'assets/mensaje.svg',
                 unreadMessagesCountStream: unreadMessagesCountStream,
+                targetKey: chatButtonKey,
               ),
               SizedBox(width: iconSpacing),
-              _buildIconButton(index: 4, asset: 'assets/usuario.svg'),
+              _buildIconButton(
+                index: 4,
+                asset: 'assets/usuario.svg',
+                targetKey: profileButtonKey,
+              ),
               // margen interior derecho NUEVO
               const SizedBox(width: 6),
             ],

--- a/app_src/lib/tutorial/quick_start_guide.dart
+++ b/app_src/lib/tutorial/quick_start_guide.dart
@@ -3,10 +3,21 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tutorial_coach_mark/tutorial_coach_mark.dart';
 
 class QuickStartGuide {
-  QuickStartGuide({required this.context, required this.addButtonKey});
+  QuickStartGuide({
+    required this.context,
+    required this.addButtonKey,
+    required this.homeButtonKey,
+    required this.mapButtonKey,
+    required this.chatButtonKey,
+    required this.profileButtonKey,
+  });
 
   final BuildContext context;
   final GlobalKey addButtonKey;
+  final GlobalKey homeButtonKey;
+  final GlobalKey mapButtonKey;
+  final GlobalKey chatButtonKey;
+  final GlobalKey profileButtonKey;
   TutorialCoachMark? _tutorial;
 
   Future<void> show() async {
@@ -44,31 +55,81 @@ class QuickStartGuide {
         contents: [
           TargetContent(
             align: ContentAlign.top,
-            builder: (context, controller) => _buildContent(controller),
+            builder: (context, controller) =>
+                _buildContent('Pinchando en el icono de + podrás crear un plan o evento.', controller),
+          ),
+        ],
+      ),
+      TargetFocus(
+        identify: 'home_button',
+        keyTarget: homeButtonKey,
+        shape: ShapeLightFocus.Circle,
+        contents: [
+          TargetContent(
+            align: ContentAlign.top,
+            builder: (context, controller) =>
+                _buildContent('En el icono de inicio verás los planes cercanos.', controller),
+          ),
+        ],
+      ),
+      TargetFocus(
+        identify: 'map_button',
+        keyTarget: mapButtonKey,
+        shape: ShapeLightFocus.Circle,
+        contents: [
+          TargetContent(
+            align: ContentAlign.top,
+            builder: (context, controller) =>
+                _buildContent('Con el mapa podrás localizar planes visualmente.', controller),
+          ),
+        ],
+      ),
+      TargetFocus(
+        identify: 'chat_button',
+        keyTarget: chatButtonKey,
+        shape: ShapeLightFocus.Circle,
+        contents: [
+          TargetContent(
+            align: ContentAlign.top,
+            builder: (context, controller) =>
+                _buildContent('Desde aquí accedes a tus conversaciones.', controller),
+          ),
+        ],
+      ),
+      TargetFocus(
+        identify: 'profile_button',
+        keyTarget: profileButtonKey,
+        shape: ShapeLightFocus.Circle,
+        contents: [
+          TargetContent(
+            align: ContentAlign.top,
+            builder: (context, controller) => _buildContent(
+                'En el perfil puedes ver y editar tu información.', controller,
+                isLast: true),
           ),
         ],
       ),
     ];
   }
 
-  Widget _buildContent(dynamic controller) {
+  Widget _buildContent(String text, dynamic controller, {bool isLast = false}) {
     return Padding(
       padding: const EdgeInsets.all(16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text(
-            'Pinchando en el icono de + podrás crear un plan o evento.',
-            style: TextStyle(color: Colors.white, fontSize: 18),
+          Text(
+            text,
+            style: const TextStyle(color: Colors.white, fontSize: 18),
           ),
           const SizedBox(height: 10),
           Align(
             alignment: Alignment.topRight,
             child: TextButton(
-              onPressed: controller.next,
-              child: const Text(
-                'Siguiente',
-                style: TextStyle(color: Colors.white),
+              onPressed: isLast ? controller.finish : controller.next,
+              child: Text(
+                isLast ? 'Entendido' : 'Siguiente',
+                style: const TextStyle(color: Colors.white),
               ),
             ),
           ),


### PR DESCRIPTION
## Summary
- amplía `QuickStartGuide` con nuevas ayudas sobre la barra de navegación
- integra las nuevas claves en `ExploreScreen`
- pasa las referencias de los iconos a `DockSection`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68456473e2088332b1d9fe8e73a68738