### PR TITLE
Amplia guia rápida en Explore

### DIFF
--- a/app_src/lib/explore_screen/main_screen/explore_app_bar.dart
+++ b/app_src/lib/explore_screen/main_screen/explore_app_bar.dart
@@ -6,6 +6,8 @@ import 'notification_screen.dart';
 class ExploreAppBar extends StatelessWidget {
   final VoidCallback onMenuPressed;
   final VoidCallback onNotificationPressed;
+  final GlobalKey menuButtonKey;
+  final GlobalKey notificationButtonKey;
   final ValueChanged<String> onSearchChanged;
   final Stream<int>? notificationCountStream;
 
@@ -13,6 +15,8 @@ class ExploreAppBar extends StatelessWidget {
     super.key,
     required this.onMenuPressed,
     required this.onNotificationPressed,
+    required this.menuButtonKey,
+    required this.notificationButtonKey,
     required this.onSearchChanged,
     this.notificationCountStream,
   });
@@ -48,6 +52,7 @@ class ExploreAppBar extends StatelessWidget {
                     border: Border.all(color: Colors.white.withOpacity(0.3)),
                   ),
                   child: IconButton(
+                    key: menuButtonKey,
                     padding: EdgeInsets.zero,
                     constraints: const BoxConstraints(),
                     icon: ShaderMask(
@@ -114,6 +119,7 @@ class ExploreAppBar extends StatelessWidget {
                         clipBehavior: Clip.none,
                         children: [
                           IconButton(
+                            key: notificationButtonKey,
                             padding: EdgeInsets.zero,
                             constraints: const BoxConstraints(),
                             icon: ShaderMask(

--- a/app_src/lib/explore_screen/main_screen/explore_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/explore_screen.dart
@@ -40,6 +40,9 @@ class ExploreScreenState extends State<ExploreScreen> {
   final GlobalKey _mapButtonKey = GlobalKey();
   final GlobalKey _chatButtonKey = GlobalKey();
   final GlobalKey _profileButtonKey = GlobalKey();
+  final GlobalKey _menuIconKey = GlobalKey();
+  final GlobalKey _notificationIconKey = GlobalKey();
+  final GlobalKey _searchBarKey = GlobalKey();
 
   late bool isMenuOpen;
   RangeValues selectedAgeRange = const RangeValues(18, 40);
@@ -75,6 +78,9 @@ class ExploreScreenState extends State<ExploreScreen> {
         mapButtonKey: _mapButtonKey,
         chatButtonKey: _chatButtonKey,
         profileButtonKey: _profileButtonKey,
+        menuButtonKey: _menuIconKey,
+        notificationButtonKey: _notificationIconKey,
+        searchBarKey: _searchBarKey,
       ).show();
     });
   }
@@ -137,6 +143,7 @@ class ExploreScreenState extends State<ExploreScreen> {
         children: [
           ExploreAppBar(
             onMenuPressed: () => _menuKey.currentState?.toggleMenu(),
+            menuButtonKey: _menuIconKey,
             onNotificationPressed: () {
               Navigator.push(
                 context,
@@ -147,6 +154,7 @@ class ExploreScreenState extends State<ExploreScreen> {
                 ),
               );
             },
+            notificationButtonKey: _notificationIconKey,
             onSearchChanged: _onSearchChanged,
             notificationCountStream: _notificationCountStream(),
           ),
@@ -169,6 +177,7 @@ class ExploreScreenState extends State<ExploreScreen> {
     return Padding(
       padding: const EdgeInsets.only(left: 15, right: 15, top: 0, bottom: 10),
       child: Container(
+        key: _searchBarKey,
         decoration: BoxDecoration(
           color: const Color.fromARGB(255, 213, 212, 212),
           borderRadius: BorderRadius.circular(30),

--- a/app_src/lib/tutorial/quick_start_guide.dart
+++ b/app_src/lib/tutorial/quick_start_guide.dart
@@ -10,6 +10,9 @@ class QuickStartGuide {
     required this.mapButtonKey,
     required this.chatButtonKey,
     required this.profileButtonKey,
+    required this.menuButtonKey,
+    required this.notificationButtonKey,
+    required this.searchBarKey,
   });
 
   final BuildContext context;
@@ -18,6 +21,9 @@ class QuickStartGuide {
   final GlobalKey mapButtonKey;
   final GlobalKey chatButtonKey;
   final GlobalKey profileButtonKey;
+  final GlobalKey menuButtonKey;
+  final GlobalKey notificationButtonKey;
+  final GlobalKey searchBarKey;
   TutorialCoachMark? _tutorial;
 
   Future<void> show() async {
@@ -104,8 +110,52 @@ class QuickStartGuide {
           TargetContent(
             align: ContentAlign.top,
             builder: (context, controller) => _buildContent(
-                'En el perfil puedes ver y editar tu información.', controller,
-                isLast: true),
+              'En el perfil puedes ver y editar tu información.',
+              controller,
+            ),
+          ),
+        ],
+      ),
+      TargetFocus(
+        identify: 'menu_button',
+        keyTarget: menuButtonKey,
+        shape: ShapeLightFocus.Circle,
+        contents: [
+          TargetContent(
+            align: ContentAlign.top,
+            builder: (context, controller) => _buildContent(
+              'En este men\u00FA encontrar\u00E1s planes que has creado o a los que te has suscrito, adem\u00E1s del control sobre tu perfil',
+              controller,
+            ),
+          ),
+        ],
+      ),
+      TargetFocus(
+        identify: 'notification_button',
+        keyTarget: notificationButtonKey,
+        shape: ShapeLightFocus.Circle,
+        contents: [
+          TargetContent(
+            align: ContentAlign.top,
+            builder: (context, controller) => _buildContent(
+              'Aqu\u00ED recibir\u00E1s todas tus notificaciones.',
+              controller,
+            ),
+          ),
+        ],
+      ),
+      TargetFocus(
+        identify: 'search_bar',
+        keyTarget: searchBarKey,
+        shape: ShapeLightFocus.RRect,
+        contents: [
+          TargetContent(
+            align: ContentAlign.bottom,
+            builder: (context, controller) => _buildContent(
+              'Aqu\u00ED podr\u00E1s buscar o filtrar planes y usuarios',
+              controller,
+              isLast: true,
+            ),
           ),
         ],
       ),
@@ -128,7 +178,7 @@ class QuickStartGuide {
             child: TextButton(
               onPressed: isLast ? controller.finish : controller.next,
               child: Text(
-                isLast ? 'Entendido' : 'Siguiente',
+                isLast ? 'Finalizar' : 'Siguiente',
                 style: const TextStyle(color: Colors.white),
               ),
             ),


### PR DESCRIPTION
## Summary
- añade nuevos pasos a la guía rápida
- agrega claves a la barra de navegación
- integra las nuevas claves en `ExploreScreen`

## Testing
- `npm test` *(falla: package.json no encontrado)*
- `flutter test` *(falla: comando no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_684571522f8083329a5446f9806dfd67