### PR TITLE
Implementación de guía rápida solo al primer acceso

### DIFF
--- a/app_src/lib/explore_screen/main_screen/explore_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/explore_screen.dart
@@ -18,6 +18,7 @@ import 'notification_screen.dart';
 import 'package:dating_app/plan_creation/new_plan_creation_screen.dart';
 import 'searcher.dart';
 import '../../tutorial/quick_start_guide.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class ExploreScreen extends StatefulWidget {
   final bool initiallyOpenSidebar;
@@ -70,18 +71,22 @@ class ExploreScreenState extends State<ExploreScreen> {
     ];
     _currentIndex = 0;
     _selectedIconIndex = 0;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      QuickStartGuide(
-        context: context,
-        addButtonKey: _addButtonKey,
-        homeButtonKey: _homeButtonKey,
-        mapButtonKey: _mapButtonKey,
-        chatButtonKey: _chatButtonKey,
-        profileButtonKey: _profileButtonKey,
-        menuButtonKey: _menuIconKey,
-        notificationButtonKey: _notificationIconKey,
-        searchBarKey: _searchBarKey,
-      ).show();
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      final prefs = await SharedPreferences.getInstance();
+      final alreadyShown = prefs.getBool('quickStartShown') ?? false;
+      if (!alreadyShown) {
+        QuickStartGuide(
+          context: context,
+          addButtonKey: _addButtonKey,
+          homeButtonKey: _homeButtonKey,
+          mapButtonKey: _mapButtonKey,
+          chatButtonKey: _chatButtonKey,
+          profileButtonKey: _profileButtonKey,
+          menuButtonKey: _menuIconKey,
+          notificationButtonKey: _notificationIconKey,
+          searchBarKey: _searchBarKey,
+        ).show();
+      }
     });
   }
 

--- a/app_src/lib/tutorial/quick_start_guide.dart
+++ b/app_src/lib/tutorial/quick_start_guide.dart
@@ -30,9 +30,8 @@ class QuickStartGuide {
     final prefs = await SharedPreferences.getInstance();
     final alreadyShown = prefs.getBool('quickStartShown') ?? false;
 
-    // Siempre mostramos la guía para pruebas. Para la versión final
-    // se debería comprobar `alreadyShown` antes de mostrarla.
-    if (alreadyShown && false) return;
+    // Solo mostramos la guía si aún no se ha visto
+    if (alreadyShown) return;
 
     _tutorial = TutorialCoachMark(
       targets: _createTargets(),


### PR DESCRIPTION
## Summary
- mostrar `QuickStartGuide` solo si el usuario no la ha visto
- comprobar en `ExploreScreen` si la guía ya se mostró antes de lanzarla

## Testing
- `flutter test` *(falló: comando no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_6845826d4838833285564982633a493e