### PR TITLE
Asegurar guía rápida por usuario

### DIFF
--- a/app_src/lib/explore_screen/main_screen/explore_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/explore_screen.dart
@@ -73,7 +73,9 @@ class ExploreScreenState extends State<ExploreScreen> {
     _selectedIconIndex = 0;
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       final prefs = await SharedPreferences.getInstance();
-      final alreadyShown = prefs.getBool('quickStartShown') ?? false;
+      final userId = currentUser?.uid ?? '';
+      final key = 'quickStartShown_\$userId';
+      final alreadyShown = prefs.getBool(key) ?? false;
       if (!alreadyShown) {
         QuickStartGuide(
           context: context,
@@ -85,6 +87,7 @@ class ExploreScreenState extends State<ExploreScreen> {
           menuButtonKey: _menuIconKey,
           notificationButtonKey: _notificationIconKey,
           searchBarKey: _searchBarKey,
+          userId: userId,
         ).show();
       }
     });

--- a/app_src/lib/tutorial/quick_start_guide.dart
+++ b/app_src/lib/tutorial/quick_start_guide.dart
@@ -13,6 +13,7 @@ class QuickStartGuide {
     required this.menuButtonKey,
     required this.notificationButtonKey,
     required this.searchBarKey,
+    required this.userId,
   });
 
   final BuildContext context;
@@ -24,11 +25,13 @@ class QuickStartGuide {
   final GlobalKey menuButtonKey;
   final GlobalKey notificationButtonKey;
   final GlobalKey searchBarKey;
+  final String userId;
   TutorialCoachMark? _tutorial;
 
   Future<void> show() async {
     final prefs = await SharedPreferences.getInstance();
-    final alreadyShown = prefs.getBool('quickStartShown') ?? false;
+    final key = 'quickStartShown_\$userId';
+    final alreadyShown = prefs.getBool(key) ?? false;
 
     // Solo mostramos la guía si aún no se ha visto
     if (alreadyShown) return;
@@ -40,10 +43,10 @@ class QuickStartGuide {
       alignSkip: Alignment.topRight,
       opacityShadow: 0.8,
       onFinish: () async {
-        await prefs.setBool('quickStartShown', true);
+        await prefs.setBool(key, true);
       },
       onSkip: () {
-        prefs.setBool('quickStartShown', true);
+        prefs.setBool(key, true);
         return true;
       },
     );


### PR DESCRIPTION
## Resumen
- guarda en preferencias la guía rápida por cada usuario
- revisa en `ExploreScreen` la preferencia específica del usuario antes de mostrarla

## Testing
- `flutter analyze` *(falla: comando no encontrado)*
- `dart analyze` *(falla: comando no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_684584f863e08332abfe3190342368fb