### PR TITLE
Implementar notificación de bienvenida

### DIFF
--- a/app_src/functions/src/index.ts
+++ b/app_src/functions/src/index.ts
@@ -15,6 +15,7 @@ const titles: Record<string, string> = {
   follow_rejected: "Follow rechazado",
   new_plan_published: "Nuevo plan publicado",
   plan_chat_message: "Nuevo comentario",
+  welcome: "Bienvenido a Plan",
 };
 
 export const sendPushOnNotification = onDocumentCreated(

--- a/app_src/lib/explore_screen/main_screen/notification_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/notification_screen.dart
@@ -41,6 +41,7 @@ class _NotificationScreenState extends State<NotificationScreen> {
       'follow_rejected',
       'new_plan_published', // <--- Agregamos este nuevo tipo
       'plan_chat_message',
+      'welcome',
     ]).snapshots();
   }
 
@@ -756,6 +757,28 @@ class _NotificationScreenState extends State<NotificationScreen> {
                                       color: Colors.red),
                                   onPressed: () =>
                                       _handleDeleteNotification(doc),
+                                ),
+                              );
+                            case 'welcome':
+                              final String message = data['message'] ??
+                                  '¡Bienvenido a Plan!';
+                              return ListTile(
+                                leading: const CircleAvatar(
+                                  radius: 25,
+                                  backgroundImage:
+                                      AssetImage('assets/plan-sin-fondo.png'),
+                                ),
+                                title: Text(message),
+                                subtitle: Text(
+                                  timeString,
+                                  style: const TextStyle(
+                                    color: Colors.grey,
+                                    fontSize: 12,
+                                  ),
+                                ),
+                                trailing: IconButton(
+                                  icon: const Icon(Icons.delete, color: Colors.red),
+                                  onPressed: () => _handleDeleteNotification(doc),
                                 ),
                               );
                             default:

--- a/app_src/lib/tutorial/quick_start_guide.dart
+++ b/app_src/lib/tutorial/quick_start_guide.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tutorial_coach_mark/tutorial_coach_mark.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 class QuickStartGuide {
   QuickStartGuide({
@@ -44,6 +45,17 @@ class QuickStartGuide {
       opacityShadow: 0.8,
       onFinish: () async {
         await prefs.setBool(key, true);
+        await FirebaseFirestore.instance.collection('notifications').add({
+          'type': 'welcome',
+          'receiverId': userId,
+          'senderId': 'system',
+          'senderName': 'Plan',
+          'senderProfilePic': '',
+          'message':
+              '¡Bienvenido a Plan! Esperamos que disfrutes organizando y descubriendo planes.',
+          'timestamp': FieldValue.serverTimestamp(),
+          'read': false,
+        });
       },
       onSkip: () {
         prefs.setBool(key, true);


### PR DESCRIPTION
## Summary
- enviar notificación de bienvenida al terminar QuickStartGuide
- mostrar notificación de bienvenida en NotificationScreen con avatar local
- permitir tipo `welcome` en filtros de notificaciones
- añadir título en función cloud

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6845893123ec833283ad6a2706359bad