### PR TITLE
Fix quick start guide after registration

### DIFF
--- a/app_src/lib/explore_screen/main_screen/explore_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/explore_screen.dart
@@ -22,8 +22,13 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class ExploreScreen extends StatefulWidget {
   final bool initiallyOpenSidebar;
+  final bool showQuickStart;
 
-  const ExploreScreen({Key? key, this.initiallyOpenSidebar = false}) : super(key: key);
+  const ExploreScreen({
+    Key? key,
+    this.initiallyOpenSidebar = false,
+    this.showQuickStart = false,
+  }) : super(key: key);
 
   @override
   ExploreScreenState createState() => ExploreScreenState();
@@ -83,7 +88,7 @@ class ExploreScreenState extends State<ExploreScreen> {
       final userId = _currentUser!.uid;
       final key = 'quickStartShown_\$userId';
       final alreadyShown = prefs.getBool(key) ?? false;
-      if (!alreadyShown) {
+      if (widget.showQuickStart || !alreadyShown) {
         Future.delayed(const Duration(milliseconds: 500), () {
           QuickStartGuide(
             context: context,

--- a/app_src/lib/start/registration/user_registration_screen.dart
+++ b/app_src/lib/start/registration/user_registration_screen.dart
@@ -309,7 +309,9 @@ class _UserRegistrationScreenState extends State<UserRegistrationScreen> {
       if (!mounted) return;
       Navigator.pushAndRemoveUntil(
         context,
-        MaterialPageRoute(builder: (_) => const ExploreScreen()),
+        MaterialPageRoute(
+          builder: (_) => const ExploreScreen(showQuickStart: true),
+        ),
         (_) => false,
       );
     } catch (e) {


### PR DESCRIPTION
## Summary
- show quick start when ExploreScreen is opened after completing registration
- add `showQuickStart` parameter to ExploreScreen

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684590728cd88332a4dd16e3373396b7