### PR TITLE
Add welcome notification after registration

### DIFF
--- a/app_src/lib/start/registration/user_registration_screen.dart
+++ b/app_src/lib/start/registration/user_registration_screen.dart
@@ -304,6 +304,19 @@ class _UserRegistrationScreenState extends State<UserRegistrationScreen> {
       // Guardamos token de notificaciones
       await FcmTokenService.register(user);
 
+      // Notificación de bienvenida
+      await FirebaseFirestore.instance.collection('notifications').add({
+        'type': 'welcome',
+        'receiverId': user.uid,
+        'senderId': 'system',
+        'senderName': 'Plan',
+        'senderProfilePic': '',
+        'message':
+            'El equipo de Plan te da la bienvenida a la app que te conecta con nuevas experiencias y personas. ¡Comienza a explorar y a crear momentos inolvidables!',
+        'timestamp': FieldValue.serverTimestamp(),
+        'read': false,
+      });
+
       await LocalRegistrationService.clear();
 
       if (!mounted) return;

--- a/app_src/lib/tutorial/quick_start_guide.dart
+++ b/app_src/lib/tutorial/quick_start_guide.dart
@@ -53,7 +53,7 @@ class QuickStartGuide {
           'senderName': 'Plan',
           'senderProfilePic': '',
           'message':
-              '¡Bienvenido a Plan! Esperamos que disfrutes organizando y descubriendo planes.',
+              'El equipo de Plan te da la bienvenida a la app que te conecta con nuevas experiencias y personas. ¡Comienza a explorar y a crear momentos inolvidables!',
           'timestamp': FieldValue.serverTimestamp(),
           'read': false,
         });


### PR DESCRIPTION
## Summary
- show a welcome message when completing the tutorial
- create a default welcome notification right after user registration

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845961c0a908332bd3a70cb7a5091dc