### PR TITLE
fix: permit system welcome notifications

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -17,7 +17,9 @@ service cloud.firestore {
     }
 
     match /notifications/{id} {
-      allow create: if request.auth.uid == request.resource.data.senderId;
+      allow create: if request.auth.uid == request.resource.data.senderId
+        || (request.resource.data.senderId == 'system'
+            && request.auth.uid == request.resource.data.receiverId);
       allow read, delete: if request.auth.uid == resource.data.receiverId
         || request.auth.uid == resource.data.senderId;
     }


### PR DESCRIPTION
## Summary
- allow app to create welcome notifications from system by checking the receiver ID in Firestore rules

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68459a33cd3c83328b83618c09180618