### PR TITLE
Add welcome notification doc on user creation

### DIFF
--- a/app_src/functions/src/index.ts
+++ b/app_src/functions/src/index.ts
@@ -194,3 +194,25 @@ export const sendPushOnPlanChat = onDocumentCreated(
     }
   }
 );
+
+export const createWelcomeNotification = onDocumentCreated(
+  {region: "europe-west1", document: "/users/{userId}"},
+  async (event) => {
+    const userId = event.params.userId;
+    const data = event.data?.data();
+    if (!data) return;
+
+    const db = getFirestore();
+    await db.collection("notifications").add({
+      type: "welcome",
+      receiverId: userId,
+      senderId: "system",
+      senderName: "Plan",
+      senderProfilePic: "",
+      message:
+        "El equipo de Plan te da la bienvenida a la app que te conecta con nuevas experiencias y personas. ¡Comienza a explorar y a crear momentos inolvidables!",
+      timestamp: FieldValue.serverTimestamp(),
+      read: false,
+    });
+  }
+);


### PR DESCRIPTION
## Summary
- trigger a new cloud function on user document creation
- store a 'welcome' notification for the new user in Firestore

## Testing
- `npm run lint -- --fix` *(fails: ESLint couldn't find an eslint.config.js)*
- `npm run build` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_6845a24e1d088332ad6023341b2be4f4