### PR TITLE
Fix notifications badge update

### DIFF
--- a/app_src/lib/explore_screen/main_screen/explore_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/explore_screen.dart
@@ -84,6 +84,8 @@ class ExploreScreenState extends State<ExploreScreen> {
       }
       if (_currentUser == null) return;
 
+      setState(() {});
+
       final prefs = await SharedPreferences.getInstance();
       final userId = _currentUser!.uid;
       final key = 'quickStartShown_$userId';


### PR DESCRIPTION
## Summary
- rebuild ExploreScreen after setting current user so the notifications badge updates correctly

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a953592c8332a33e69aa09c3bc95