### PR TITLE
Handle profile deletion before auth removal

### DIFF
--- a/app_src/functions/src/index.ts
+++ b/app_src/functions/src/index.ts
@@ -2,6 +2,7 @@ import {initializeApp} from "firebase-admin/app";
 import {getMessaging} from "firebase-admin/messaging";
 import {getFirestore, FieldValue} from "firebase-admin/firestore";
 import {onDocumentCreated} from "firebase-functions/v2/firestore";
+import {onUserDeleted} from "firebase-functions/v2/identity";
 
 initializeApp();
 
@@ -74,6 +75,19 @@ export const sendPushOnNotification = onDocumentCreated(
       await receiverRef.update({
         tokens: FieldValue.arrayRemove(...invalid),
       });
+    }
+  }
+);
+
+export const cleanupUserData = onUserDeleted(
+  {region: "europe-west1"},
+  async (event) => {
+    const uid = event.data.uid;
+    const db = getFirestore();
+    try {
+      await db.doc(`users/${uid}`).delete();
+    } catch (e) {
+      console.error("Failed to clean user data", e);
     }
   }
 );

--- a/app_src/lib/explore_screen/menu_side_bar/settings/account.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/settings/account.dart
@@ -117,24 +117,6 @@ Future<void> _deleteAccount(BuildContext context) async {
     final doc = await docRef.get();
     final data = doc.data();
 
-    // Primero intentamos borrar al usuario para garantizar la reautenticación
-    try {
-      await user.delete();
-    } on FirebaseAuthException catch (e) {
-      Navigator.of(context).pop();
-      if (e.code == 'requires-recent-login') {
-        final success = await _showReauthDialog(context);
-        if (success) {
-          // Intentar de nuevo tras reautenticación
-          await _deleteAccount(context);
-        }
-      } else if (context.mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Error: ${e.message}')));
-      }
-      return;
-    }
-
     if (data != null) {
       final urls = <String>[];
       void addUrl(dynamic u) {
@@ -156,6 +138,24 @@ Future<void> _deleteAccount(BuildContext context) async {
     }
 
     await docRef.delete();
+
+    // Tras borrar los datos en Firestore eliminamos la cuenta de autenticación
+    try {
+      await user.delete();
+    } on FirebaseAuthException catch (e) {
+      Navigator.of(context).pop();
+      if (e.code == 'requires-recent-login') {
+        final success = await _showReauthDialog(context);
+        if (success) {
+          // Intentar de nuevo tras reautenticación
+          await _deleteAccount(context);
+        }
+      } else if (context.mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Error: ${e.message}')));
+      }
+      return;
+    }
 
     if (context.mounted) {
       Navigator.of(context).pop(); // Cerrar el indicador de carga


### PR DESCRIPTION
## Summary
- delete Firestore user document before calling `FirebaseAuth.delete`
- add `cleanupUserData` Cloud Function to remove leftover user documents

## Testing
- `npm run build` *(fails: Cannot find module)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ae9ecfb48332b6bb20c34b9474c0