### PR TITLE
Add bilingual cookies policy

### DIFF
--- a/public/cookies.html
+++ b/public/cookies.html
@@ -20,10 +20,105 @@
     </style>
 </head>
 <body>
-<div data-lang='es'>
-    <h1>Política de cookies</h1>
-    <p>Contenido provisional. Próximamente añadiremos la información completa.</p>
-    <img src='plan-sin-fondo.png' alt='Plan Social' style='max-width:200px;'>
+  <div data-lang="en">
+    <header>
+      <img src="plan-sin-fondo.png" alt="Plan Social" style="height:40px;">
+      <h1>Cookies Policy</h1>
+    </header>
+    <p>As described in our Privacy Policy, both our service providers and we use cookies and similar technologies to provide the Plan Platform and enhance your experience. This Cookies Policy explains how and why we use these technologies on our websites, apps and other services (the “Platform”). The terms “Plan,” “we,” “us,” or “our” refer to Inan Ilik Ilik and affiliates. By using the Platform, you agree to our storing and accessing cookies and related technologies on your device as set forth in this Policy.</p>
+    <h2>What are cookies?</h2>
+    <p>Cookies are small data files downloaded to your device when you visit a website. On subsequent visits they are sent back to the site that created them or another site that recognizes them. Cookies allow us to identify your device.</p>
+    <h2>How do we use cookies?</h2>
+    <p>We use cookies for various purposes:</p>
+    <ol>
+      <li><strong>Authentication</strong><br>We recognize if you have logged in to the Platform through services such as Firebase Authentication or Google Sign‑In. This helps us offer personalized features.</li>
+      <li><strong>Security</strong><br>Cookies help us implement security features and detect malicious activity or breaches of our Terms of Use.</li>
+      <li><strong>Services, features and preferences</strong><br>Cookies remember your preferences (for example, selected language) and support functions such as uploading images or managing plans, which rely on Firebase services like Firestore, Storage and Cloud Functions.</li>
+      <li><strong>Performance, analytics and research</strong><br>We use cookies as an analytics tool to understand how the Platform is accessed and improve it. Plan integrates Firebase/Google Analytics, which collects device and browsing information to generate statistics.</li>
+      <li><strong>Advertising</strong><br>If we partner with advertising networks or third‑party providers, they may use cookies or similar technologies to show you ads based on your interests. Plan currently does not display personalized ads, but this may change in the future. Any updates will be reflected in this policy.</li>
+      <li><strong>Other third‑party services</strong><br>Some providers (Google Play Services, Google Maps Platform and Geolocator, Google Fonts, Hostinger for email delivery and Firebase Hosting) may place cookies or similar technologies on your device when you interact with their services integrated into Plan.</li>
+    </ol>
+    <h2>Cookie duration</h2>
+    <ul>
+      <li><strong>Session cookies</strong>: removed when you log out or close your browser.</li>
+      <li><strong>Persistent cookies</strong>: remain on your device for a longer period.</li>
+    </ul>
+    <h2>Other technologies</h2>
+    <p>Besides cookies, we may allow the use of:</p>
+    <ul>
+      <li><strong>Pixel tags</strong> or web beacons to understand how you interact with our emails and pages.</li>
+      <li><strong>Device identifiers</strong> to analyze the Platform’s performance on mobile devices.</li>
+      <li><strong>Local storage</strong> to save certain preferences locally on your device.</li>
+    </ul>
+    <h2>How to control cookies</h2>
+    <p>Most browsers accept cookies by default. You can delete or reject cookies by following your browser settings or visiting <a href="https://www.allaboutcookies.org/" target="_blank" rel="noopener noreferrer">allaboutcookies.org</a>. Note that disabling cookies may limit some Plan features.</p>
+    <p>If we use personalized ads in the future, we will inform you about the available opt‑out options (for example, via the Digital Advertising Alliance or the European Interactive Digital Advertising Alliance).</p>
+    <h2>International transfers</h2>
+    <p>Our service providers, such as Google and Hostinger, may host data outside the European Economic Area. By using Plan, you consent to these international data transfers under adequate safeguards.</p>
+    <h2>Changes to this Cookies Policy</h2>
+    <p>We may modify this Policy when necessary. We will post the updated version with its effective date and, if changes are significant, will provide additional notice (for example, via email or a prominent notice on the Platform).</p>
+    <h2>Contact</h2>
+    <p>If you have any questions regarding this Cookies Policy, please contact us at <strong>soporte@plansocialapp.es</strong>.</p>
+    <hr>
+    <footer class='site-footer'>
+        <div class='footer-container'>
+            <img class='footer-logo' src='plan-sin-fondo.png' alt='Plan Social'>
+            <div class='footer-links'>
+                <a href='help.html'>Help</a>
+                <a href='privacy_policy.html'>Privacy</a>
+                <a href='terms_and_conditions.html'>Terms</a>
+                <select class='lang-select'>
+                    <option value='es'>Español</option>
+                    <option value='en'>English</option>
+                </select>
+                <div class='footer-social'>
+                    <div>Follow us on <button onclick="window.open('https://www.instagram.com/plan0525/', '_blank')" style='background:none;border:none;padding:0'><img src='instagram.png' alt='Instagram' class='social-icon'></button></div>
+                </div>
+            </div>
+            <p>© 2025 Plan</p>
+        </div>
+    </footer>
+  </div>
+
+  <div data-lang='es'>
+    <header>
+      <img src='plan-sin-fondo.png' alt='Plan Social' style='height:40px;'>
+      <h1>Política de cookies</h1>
+    </header>
+    <p>Conforme se describe en nuestra Política de Privacidad, tanto nuestros proveedores de servicios como nosotros utilizamos cookies y tecnologías similares para ofrecer la Plataforma de Plan y mejorar tu experiencia. Esta Política de cookies detalla cómo y por qué empleamos dichas tecnologías en nuestros sitios web, aplicaciones y otros servicios (en conjunto, la “Plataforma”). Los términos “Plan”, “nosotros”, “nos” o “nuestro” se refieren a Inan Ilik Ilik y sus filiales. Al usar la Plataforma, aceptas que almacenemos cookies y tecnologías afines en tu dispositivo y que tengamos acceso a ellas, según lo establece esta Política.</p>
+    <h2>¿Qué son las cookies?</h2>
+    <p>Las cookies son pequeños archivos de datos que se descargan a tu dispositivo cuando visitas un sitio web. En cada visita posterior se envían de vuelta al sitio que las creó o a otro que las reconozca. Las cookies nos permiten identificar tu dispositivo.</p>
+    <h2>¿Cómo usamos las cookies?</h2>
+    <p>Utilizamos cookies con diversos fines:</p>
+    <ol>
+      <li><strong>Autenticación</strong><br>Reconocemos si has iniciado sesión en la Plataforma a través de servicios como Firebase Authentication o Google Sign‑In. Esto nos ayuda a ofrecerte funciones personalizadas.</li>
+      <li><strong>Seguridad</strong><br>Empleamos cookies para implementar funciones de seguridad y detectar actividades malintencionadas o violaciones de nuestros Términos de uso.</li>
+      <li><strong>Servicios, funciones y preferencias</strong><br>Usamos cookies para recordar tus preferencias (por ejemplo, idioma seleccionado) y ofrecer funcionalidades como la carga de imágenes o la gestión de planes, vinculadas a servicios de Firebase (Firestore, Storage, Cloud Functions, etc.).</li>
+      <li><strong>Desempeño, análisis e investigación</strong><br>Utilizamos cookies como herramienta de análisis para comprender cómo se accede a la Plataforma y mejorarla. En particular, Plan incorpora Firebase/Google Analytics, que recopila información de tu dispositivo y de navegación para generar estadísticas.</li>
+      <li><strong>Publicidad</strong><br>En caso de asociarnos con redes publicitarias o proveedores externos, estos podrían usar cookies u otras tecnologías para mostrarte anuncios basados en tus intereses. Actualmente Plan no despliega anuncios personalizados, pero esta situación podría cambiar en el futuro. Cualquier actualización será reflejada en esta política.</li>
+      <li><strong>Otros servicios de terceros</strong><br>Algunos proveedores (Google Play Services, Google Maps Platform y Geolocator, Google Fonts, Hostinger para envíos de correo, y Firebase Hosting) pueden colocar cookies o tecnologías similares en tu dispositivo cuando interactúas con sus servicios integrados en Plan.</li>
+    </ol>
+    <h2>Duración de las cookies</h2>
+    <ul>
+      <li><strong>Cookies de sesión</strong>: se eliminan al cerrar la sesión o el navegador.</li>
+      <li><strong>Cookies persistentes</strong>: permanecen en tu dispositivo por un periodo mayor.</li>
+    </ul>
+    <h2>Otras tecnologías</h2>
+    <p>Además de cookies, podemos autorizar el uso de:</p>
+    <ul>
+      <li><strong>Etiquetas de píxeles</strong> o balizas web para entender cómo interactúas con nuestros correos y páginas.</li>
+      <li><strong>Identificadores de dispositivos</strong> para analizar el rendimiento de la Plataforma en móviles.</li>
+      <li><strong>Almacenamiento local</strong> para guardar ciertas preferencias de forma local en tu dispositivo.</li>
+    </ul>
+    <h2>Cómo controlar las cookies</h2>
+    <p>La mayoría de los navegadores aceptan cookies de manera predeterminada. Puedes eliminarlas o rechazarlas siguiendo las instrucciones de tu navegador o visitando <a href="https://www.allaboutcookies.org/" target="_blank" rel="noopener noreferrer">allaboutcookies.org</a>. Ten en cuenta que, al desactivar cookies, algunas funciones de Plan podrían verse limitadas.</p>
+    <p>Si en el futuro empleamos anuncios personalizados, te informaremos sobre las opciones disponibles para desactivarlos (por ejemplo, mediante la Digital Advertising Alliance o la European Interactive Digital Advertising Alliance).</p>
+    <h2>Transferencias internacionales</h2>
+    <p>Nuestros proveedores de servicios, como Google y Hostinger, pueden alojar datos fuera del Espacio Económico Europeo. Al utilizar Plan consientes estas transferencias internacionales de datos, siempre bajo las garantías adecuadas.</p>
+    <h2>Cambios en esta Política de cookies</h2>
+    <p>Podemos modificar esta Política cuando sea necesario. Publicaremos la versión actualizada indicando la fecha de entrada en vigor y, si los cambios son significativos, realizaremos una notificación adicional (por ejemplo, por correo electrónico o aviso destacado en la Plataforma).</p>
+    <h2>Contacto</h2>
+    <p>Para cualquier consulta relacionada con esta Política de cookies, puedes escribirnos a <strong>soporte@plansocialapp.es</strong>.</p>
     <hr>
     <footer class='site-footer'>
         <div class='footer-container'>
@@ -43,21 +138,21 @@
             <p>© 2025 Plan</p>
         </div>
     </footer>
-</div>
-<script>
-(function(){
-  const selects=document.querySelectorAll('.lang-select');
-  function setLang(l){
-    document.documentElement.lang=l;
-    document.querySelectorAll('[data-lang]').forEach(el=>{
-      el.style.display=el.getAttribute('data-lang')===l?'':'none';
-    });
-    selects.forEach(s=>s.value=l);
-  }
-  const initial=((navigator.language||navigator.userLanguage)||'en').startsWith('es')?'es':'en';
-  setLang(initial);
-  selects.forEach(sel=>sel.addEventListener('change',e=>setLang(e.target.value)));
-})();
-</script>
+  </div>
+  <script>
+  (function(){
+    const selects=document.querySelectorAll('.lang-select');
+    function setLang(l){
+      document.documentElement.lang=l;
+      document.querySelectorAll('[data-lang]').forEach(el=>{
+        el.style.display=el.getAttribute('data-lang')===l?'':'none';
+      });
+      selects.forEach(s=>s.value=l);
+    }
+    const initial=((navigator.language||navigator.userLanguage)||'en').startsWith('es')?'es':'en';
+    setLang(initial);
+    selects.forEach(sel=>sel.addEventListener('change',e=>setLang(e.target.value)));
+  })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expand cookies page with a complete cookies policy
- provide English and Spanish versions selectable via the language dropdown
- keep branding with `plan-sin-fondo.png`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6848911fdac08332aeb3a7e8d9858c2a