### PR TITLE
Add cookies menu and persistent header

### DIFF
--- a/public/ayuda.html
+++ b/public/ayuda.html
@@ -6,18 +6,57 @@
   <title>Ayuda - Plan</title>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700&display=swap" rel="stylesheet">
   <style>
-    body{font-family:'Poppins',sans-serif;margin:0;padding:2rem;background:#fff;color:#444;}
-    header{display:flex;align-items:center;gap:1rem;}
-    header img{height:40px;}
+    body{font-family:'Poppins',sans-serif;margin:0;padding-top:72px;background:#fff;color:#444;}
+    header{position:fixed;top:0;width:100%;height:72px;background:#fff;border-bottom:1px solid #eee;z-index:100;}
+    .nav-container{max-width:1200px;margin:auto;height:100%;display:grid;grid-template-columns:1fr auto 1fr;align-items:center;padding:0 1rem;position:relative;}
+    .nav-logo{margin:0;position:static;justify-self:center;}
+    header .nav-logo img{height:64px;margin-top:4px;}
+    .btn-download{background:#5D17EB;color:#fff;padding:.6rem 1.2rem;border-radius:24px;font-weight:600;transition:background .2s,transform .2s,box-shadow .2s;justify-self:end;box-shadow:0 8px 16px rgba(0,0,0,.15);}
+    .btn-download:hover{background:#4D07DB;transform:translateY(-2px);box-shadow:0 12px 20px rgba(0,0,0,.2);}
+    nav ul{display:flex;gap:1.5rem;list-style:none;}
+    nav ul li a{font-weight:500;color:#fff;transition:color .2s;}
+    nav ul li a:hover,nav ul li a:active,nav ul li a:focus{color:#5D17EB;}
+    .nav-toggle{display:none;background:none;border:none;font-size:1.5rem;cursor:pointer;justify-self:start;}
+    @media(max-width:768px){
+      .nav-toggle{display:block;order:1;}
+      nav ul .nav-close{display:block;position:absolute;top:.5rem;right:.5rem;background:none;border:none;color:#fff;font-size:1.5rem;z-index:101;}
+      .nav-logo{order:2;margin:0;position:static;justify-self:center;}
+      .btn-download{order:3;margin:0;justify-self:end;}
+      nav{order:4;}
+      nav ul{position:fixed;top:72px;left:-100%;width:200px;height:calc(100% - 72px);background:#000;flex-direction:column;align-items:flex-start;padding:3rem 1rem 1rem;gap:1rem;transition:left .3s ease;box-shadow:4px 0 8px rgba(0,0,0,.1);}
+      nav ul.open{left:0;}
+    }
   </style>
 </head>
 <body>
   <header>
-    <img src="plan-sin-fondo.png" alt="Plan Social">
-    <h1>Ayuda</h1>
+    <div class="nav-container">
+      <button class="nav-toggle" aria-label="Abrir menú">☰</button>
+      <div class="nav-logo"><img src="plan-sin-fondo.png" alt="Plan Social"></div>
+      <nav>
+        <ul>
+          <li><button class="nav-close" aria-label="Cerrar menú">×</button></li>
+          <li><a href="index.html#hero">Inicio</a></li>
+          <li><a href="index.html#downloadSection">Descargar</a></li>
+          <li><a href="help.html">Ayuda</a></li>
+          <li><a href="privacy_policy.html">Privacidad</a></li>
+          <li><a href="terms_and_conditions.html">Condiciones</a></li>
+          <li><a href="cookies.html">Cookies</a></li>
+        </ul>
+      </nav>
+      <a href="index.html#downloadSection" class="btn-download">Descargar</a>
+    </div>
   </header>
-  <main>
+  <main style="padding:2rem;">
+    <h1>Ayuda</h1>
     <p>Contenido de ejemplo para la página de ayuda.</p>
   </main>
+  <script>
+    const navToggle=document.querySelector('.nav-toggle');
+    const navClose=document.querySelector('nav ul .nav-close');
+    const navList=document.querySelector('nav ul');
+    navToggle.addEventListener('click',()=>{navList.classList.toggle('open');});
+    navClose.addEventListener('click',()=>{navList.classList.remove('open');});
+  </script>
 </body>
 </html>

--- a/public/condiciones.html
+++ b/public/condiciones.html
@@ -6,18 +6,57 @@
   <title>Condiciones - Plan</title>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700&display=swap" rel="stylesheet">
   <style>
-    body{font-family:'Poppins',sans-serif;margin:0;padding:2rem;background:#fff;color:#444;}
-    header{display:flex;align-items:center;gap:1rem;}
-    header img{height:40px;}
+    body{font-family:'Poppins',sans-serif;margin:0;padding-top:72px;background:#fff;color:#444;}
+    header{position:fixed;top:0;width:100%;height:72px;background:#fff;border-bottom:1px solid #eee;z-index:100;}
+    .nav-container{max-width:1200px;margin:auto;height:100%;display:grid;grid-template-columns:1fr auto 1fr;align-items:center;padding:0 1rem;position:relative;}
+    .nav-logo{margin:0;position:static;justify-self:center;}
+    header .nav-logo img{height:64px;margin-top:4px;}
+    .btn-download{background:#5D17EB;color:#fff;padding:.6rem 1.2rem;border-radius:24px;font-weight:600;transition:background .2s,transform .2s,box-shadow .2s;justify-self:end;box-shadow:0 8px 16px rgba(0,0,0,.15);}
+    .btn-download:hover{background:#4D07DB;transform:translateY(-2px);box-shadow:0 12px 20px rgba(0,0,0,.2);}
+    nav ul{display:flex;gap:1.5rem;list-style:none;}
+    nav ul li a{font-weight:500;color:#fff;transition:color .2s;}
+    nav ul li a:hover,nav ul li a:active,nav ul li a:focus{color:#5D17EB;}
+    .nav-toggle{display:none;background:none;border:none;font-size:1.5rem;cursor:pointer;justify-self:start;}
+    @media(max-width:768px){
+      .nav-toggle{display:block;order:1;}
+      nav ul .nav-close{display:block;position:absolute;top:.5rem;right:.5rem;background:none;border:none;color:#fff;font-size:1.5rem;z-index:101;}
+      .nav-logo{order:2;margin:0;position:static;justify-self:center;}
+      .btn-download{order:3;margin:0;justify-self:end;}
+      nav{order:4;}
+      nav ul{position:fixed;top:72px;left:-100%;width:200px;height:calc(100% - 72px);background:#000;flex-direction:column;align-items:flex-start;padding:3rem 1rem 1rem;gap:1rem;transition:left .3s ease;box-shadow:4px 0 8px rgba(0,0,0,.1);}
+      nav ul.open{left:0;}
+    }
   </style>
 </head>
 <body>
   <header>
-    <img src="plan-sin-fondo.png" alt="Plan Social">
-    <h1>Condiciones</h1>
+    <div class="nav-container">
+      <button class="nav-toggle" aria-label="Abrir menú">☰</button>
+      <div class="nav-logo"><img src="plan-sin-fondo.png" alt="Plan Social"></div>
+      <nav>
+        <ul>
+          <li><button class="nav-close" aria-label="Cerrar menú">×</button></li>
+          <li><a href="index.html#hero">Inicio</a></li>
+          <li><a href="index.html#downloadSection">Descargar</a></li>
+          <li><a href="help.html">Ayuda</a></li>
+          <li><a href="privacy_policy.html">Privacidad</a></li>
+          <li><a href="terms_and_conditions.html">Condiciones</a></li>
+          <li><a href="cookies.html">Cookies</a></li>
+        </ul>
+      </nav>
+      <a href="index.html#downloadSection" class="btn-download">Descargar</a>
+    </div>
   </header>
-  <main>
+  <main style="padding:2rem;">
+    <h1>Condiciones</h1>
     <p>Información de ejemplo sobre las condiciones de uso.</p>
   </main>
+  <script>
+    const navToggle=document.querySelector('.nav-toggle');
+    const navClose=document.querySelector('nav ul .nav-close');
+    const navList=document.querySelector('nav ul');
+    navToggle.addEventListener('click',()=>{navList.classList.toggle('open');});
+    navClose.addEventListener('click',()=>{navList.classList.remove('open');});
+  </script>
 </body>
 </html>

--- a/public/cookies.html
+++ b/public/cookies.html
@@ -5,9 +5,25 @@
     <meta name='viewport' content='width=device-width'>
     <title>Política de cookies</title>
     <style>
-        body {
-            font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-            padding: 1em;
+        body {font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;margin:0;padding-top:72px;}
+        header{position:fixed;top:0;width:100%;height:72px;background:#fff;border-bottom:1px solid #eee;z-index:100;}
+        .nav-container{max-width:1200px;margin:auto;height:100%;display:grid;grid-template-columns:1fr auto 1fr;align-items:center;padding:0 1rem;position:relative;}
+        .nav-logo{margin:0;position:static;justify-self:center;}
+        header .nav-logo img{height:64px;margin-top:4px;}
+        .btn-download{background:#5D17EB;color:#fff;padding:.6rem 1.2rem;border-radius:24px;font-weight:600;transition:background .2s,transform .2s,box-shadow .2s;justify-self:end;box-shadow:0 8px 16px rgba(0,0,0,.15);}
+        .btn-download:hover{background:#4D07DB;transform:translateY(-2px);box-shadow:0 12px 20px rgba(0,0,0,.2);}
+        nav ul{display:flex;gap:1.5rem;list-style:none;}
+        nav ul li a{font-weight:500;color:#fff;transition:color .2s;}
+        nav ul li a:hover,nav ul li a:active,nav ul li a:focus{color:#5D17EB;}
+        .nav-toggle{display:none;background:none;border:none;font-size:1.5rem;cursor:pointer;justify-self:start;}
+        @media(max-width:768px){
+            .nav-toggle{display:block;order:1;}
+            nav ul .nav-close{display:block;position:absolute;top:.5rem;right:.5rem;background:none;border:none;color:#fff;font-size:1.5rem;z-index:101;}
+            .nav-logo{order:2;margin:0;position:static;justify-self:center;}
+            .btn-download{order:3;margin:0;justify-self:end;}
+            nav{order:4;}
+            nav ul{position:fixed;top:72px;left:-100%;width:200px;height:calc(100% - 72px);background:#000;flex-direction:column;align-items:flex-start;padding:3rem 1rem 1rem;gap:1rem;transition:left .3s ease;box-shadow:4px 0 8px rgba(0,0,0,.1);}
+            nav ul.open{left:0;}
         }
         .site-footer{background:#000;color:#fff;padding:2rem 1rem;text-align:center;margin-left:-1em;margin-right:-1em;}
         .footer-container{max-width:1200px;margin:auto;display:flex;flex-direction:column;align-items:center;gap:1rem;}
@@ -22,9 +38,24 @@
 <body>
   <div data-lang="en">
     <header>
-      <img src="plan-sin-fondo.png" alt="Plan Social" style="height:40px;">
-      <h1>Cookies Policy</h1>
+      <div class="nav-container">
+        <button class="nav-toggle" aria-label="Open menu">☰</button>
+        <div class="nav-logo"><img src="plan-sin-fondo.png" alt="Plan Social"></div>
+        <nav>
+          <ul>
+            <li><button class="nav-close" aria-label="Close menu">×</button></li>
+            <li><a href="index.html#hero">Home</a></li>
+            <li><a href="index.html#downloadSection">Download</a></li>
+            <li><a href="help.html">Help</a></li>
+            <li><a href="privacy_policy.html">Privacy</a></li>
+            <li><a href="terms_and_conditions.html">Terms</a></li>
+            <li><a href="cookies.html">Cookies</a></li>
+          </ul>
+        </nav>
+        <a href="index.html#downloadSection" class="btn-download">Download</a>
+      </div>
     </header>
+    <h1 style="padding:1em;">Cookies Policy</h1>
     <p>As described in our Privacy Policy, both our service providers and we use cookies and similar technologies to provide the Plan Platform and enhance your experience. This Cookies Policy explains how and why we use these technologies on our websites, apps and other services (the “Platform”). The terms “Plan,” “we,” “us,” or “our” refer to Inan Ilik Ilik and affiliates. By using the Platform, you agree to our storing and accessing cookies and related technologies on your device as set forth in this Policy.</p>
     <h2>What are cookies?</h2>
     <p>Cookies are small data files downloaded to your device when you visit a website. On subsequent visits they are sent back to the site that created them or another site that recognizes them. Cookies allow us to identify your device.</p>
@@ -83,9 +114,24 @@
 
   <div data-lang='es'>
     <header>
-      <img src='plan-sin-fondo.png' alt='Plan Social' style='height:40px;'>
-      <h1>Política de cookies</h1>
+      <div class='nav-container'>
+        <button class='nav-toggle' aria-label='Abrir menú'>☰</button>
+        <div class='nav-logo'><img src='plan-sin-fondo.png' alt='Plan Social'></div>
+        <nav>
+          <ul>
+            <li><button class='nav-close' aria-label='Cerrar menú'>×</button></li>
+            <li><a href='index.html#hero'>Inicio</a></li>
+            <li><a href='index.html#downloadSection'>Descargar</a></li>
+            <li><a href='help.html'>Ayuda</a></li>
+            <li><a href='privacy_policy.html'>Privacidad</a></li>
+            <li><a href='terms_and_conditions.html'>Condiciones</a></li>
+            <li><a href='cookies.html'>Cookies</a></li>
+          </ul>
+        </nav>
+        <a href='index.html#downloadSection' class='btn-download'>Descargar</a>
+      </div>
     </header>
+    <h1 style='padding:1em;'>Política de cookies</h1>
     <p>Conforme se describe en nuestra Política de Privacidad, tanto nuestros proveedores de servicios como nosotros utilizamos cookies y tecnologías similares para ofrecer la Plataforma de Plan y mejorar tu experiencia. Esta Política de cookies detalla cómo y por qué empleamos dichas tecnologías en nuestros sitios web, aplicaciones y otros servicios (en conjunto, la “Plataforma”). Los términos “Plan”, “nosotros”, “nos” o “nuestro” se refieren a Inan Ilik Ilik y sus filiales. Al usar la Plataforma, aceptas que almacenemos cookies y tecnologías afines en tu dispositivo y que tengamos acceso a ellas, según lo establece esta Política.</p>
     <h2>¿Qué son las cookies?</h2>
     <p>Las cookies son pequeños archivos de datos que se descargan a tu dispositivo cuando visitas un sitio web. En cada visita posterior se envían de vuelta al sitio que las creó o a otro que las reconozca. Las cookies nos permiten identificar tu dispositivo.</p>
@@ -155,6 +201,13 @@
     setLang(initial);
     selects.forEach(sel=>sel.addEventListener('change',e=>setLang(e.target.value)));
   })();
+  </script>
+  <script>
+    const navToggle=document.querySelector('.nav-toggle');
+    const navClose=document.querySelector('nav ul .nav-close');
+    const navList=document.querySelector('nav ul');
+    navToggle.addEventListener('click',()=>{navList.classList.toggle('open');});
+    navClose.addEventListener('click',()=>{navList.classList.remove('open');});
   </script>
 </body>
 </html>

--- a/public/help.html
+++ b/public/help.html
@@ -6,9 +6,28 @@
   <title>Plan Social</title>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700&display=swap" rel="stylesheet">
   <style>
-    body{font-family:'Poppins',sans-serif;padding:1em;line-height:1.5;color:#444;}
+    body{font-family:'Poppins',sans-serif;margin:0;padding-top:72px;line-height:1.5;color:#444;}
     h1{font-size:1.5rem;}
     h2{margin-top:1.5rem;}
+    header{position:fixed;top:0;width:100%;height:72px;background:#fff;border-bottom:1px solid #eee;z-index:100;}
+    .nav-container{max-width:1200px;margin:auto;height:100%;display:grid;grid-template-columns:1fr auto 1fr;align-items:center;padding:0 1rem;position:relative;}
+    .nav-logo{margin:0;position:static;justify-self:center;}
+    header .nav-logo img{height:64px;margin-top:4px;}
+    .btn-download{background:#5D17EB;color:#fff;padding:.6rem 1.2rem;border-radius:24px;font-weight:600;transition:background .2s,transform .2s,box-shadow .2s;justify-self:end;box-shadow:0 8px 16px rgba(0,0,0,.15);}
+    .btn-download:hover{background:#4D07DB;transform:translateY(-2px);box-shadow:0 12px 20px rgba(0,0,0,.2);}
+    nav ul{display:flex;gap:1.5rem;list-style:none;}
+    nav ul li a{font-weight:500;color:#fff;transition:color .2s;}
+    nav ul li a:hover,nav ul li a:active,nav ul li a:focus{color:#5D17EB;}
+    .nav-toggle{display:none;background:none;border:none;font-size:1.5rem;cursor:pointer;justify-self:start;}
+    @media(max-width:768px){
+      .nav-toggle{display:block;order:1;}
+      nav ul .nav-close{display:block;position:absolute;top:.5rem;right:.5rem;background:none;border:none;color:#fff;font-size:1.5rem;z-index:101;}
+      .nav-logo{order:2;margin:0;position:static;justify-self:center;}
+      .btn-download{order:3;margin:0;justify-self:end;}
+      nav{order:4;}
+      nav ul{position:fixed;top:72px;left:-100%;width:200px;height:calc(100% - 72px);background:#000;flex-direction:column;align-items:flex-start;padding:3rem 1rem 1rem;gap:1rem;transition:left .3s ease;box-shadow:4px 0 8px rgba(0,0,0,.1);}
+      nav ul.open{left:0;}
+    }
     .site-footer{background:#000;color:#fff;padding:2rem 1rem;text-align:center;margin-left:-1em;margin-right:-1em;}
     .footer-container{max-width:1200px;margin:auto;display:flex;flex-direction:column;align-items:center;gap:1rem;}
     .footer-links{display:flex;gap:1rem;flex-wrap:wrap;align-items:center;}
@@ -22,10 +41,25 @@
 <body>
   <div data-lang="es">
     <header>
-      <img src="plan-sin-fondo.png" alt="Plan Social" style="height:40px;">
-      <h1>Ayuda</h1>
+      <div class="nav-container">
+        <button class="nav-toggle" aria-label="Abrir menú">☰</button>
+        <div class="nav-logo"><img src="plan-sin-fondo.png" alt="Plan Social"></div>
+        <nav>
+          <ul>
+            <li><button class="nav-close" aria-label="Cerrar menú">×</button></li>
+            <li><a href="index.html#hero">Inicio</a></li>
+            <li><a href="index.html#downloadSection">Descargar</a></li>
+            <li><a href="help.html">Ayuda</a></li>
+            <li><a href="privacy_policy.html">Privacidad</a></li>
+            <li><a href="terms_and_conditions.html">Condiciones</a></li>
+            <li><a href="cookies.html">Cookies</a></li>
+          </ul>
+        </nav>
+        <a href="index.html#downloadSection" class="btn-download">Descargar</a>
+      </div>
     </header>
-    <main>
+    <main style="padding:1em;">
+      <h1>Ayuda</h1>
       <h2>Preguntas frecuentes</h2>
       <div>
       <h3>¿Cómo creo un nuevo plan?</h3>
@@ -117,10 +151,25 @@
   </div>
   <div data-lang="en">
     <header>
-      <img src="plan-sin-fondo.png" alt="Plan Social" style="height:40px;">
-      <h1>Help</h1>
+      <div class="nav-container">
+        <button class="nav-toggle" aria-label="Open menu">☰</button>
+        <div class="nav-logo"><img src="plan-sin-fondo.png" alt="Plan Social"></div>
+        <nav>
+          <ul>
+            <li><button class="nav-close" aria-label="Close menu">×</button></li>
+            <li><a href="index.html#hero">Home</a></li>
+            <li><a href="index.html#downloadSection">Download</a></li>
+            <li><a href="help.html">Help</a></li>
+            <li><a href="privacy_policy.html">Privacy</a></li>
+            <li><a href="terms_and_conditions.html">Terms</a></li>
+            <li><a href="cookies.html">Cookies</a></li>
+          </ul>
+        </nav>
+        <a href="index.html#downloadSection" class="btn-download">Download</a>
+      </div>
     </header>
-    <main>
+    <main style="padding:1em;">
+      <h1>Help</h1>
       <h2>Frequently Asked Questions</h2>
       <div>
         <h3>How do I create a new plan?</h3>
@@ -224,6 +273,13 @@
       setLang(initial);
       selects.forEach(sel=>sel.addEventListener('change',e=>setLang(e.target.value)));
     })();
+  </script>
+  <script>
+    const navToggle=document.querySelector('.nav-toggle');
+    const navClose=document.querySelector('nav ul .nav-close');
+    const navList=document.querySelector('nav ul');
+    navToggle.addEventListener('click',()=>{navList.classList.toggle('open');});
+    navClose.addEventListener('click',()=>{navList.classList.remove('open');});
   </script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -528,14 +528,15 @@
           <li>
             <button class="nav-close" aria-label="Cerrar menú">×</button>
           </li>
-          <li><a href="#hero">Inicio</a></li>
-          <li><a href="#downloadSection">Descargar</a></li>
+          <li><a href="index.html#hero">Inicio</a></li>
+          <li><a href="index.html#downloadSection">Descargar</a></li>
           <li><a href="help.html">Ayuda</a></li>
           <li><a href="privacy_policy.html">Privacidad</a></li>
           <li><a href="terms_and_conditions.html">Condiciones</a></li>
+          <li><a href="cookies.html">Cookies</a></li>
         </ul>
       </nav>
-      <a href="#downloadSection" class="btn-download">Descargar</a>
+      <a href="index.html#downloadSection" class="btn-download">Descargar</a>
     </div>
   </header>
   <main>

--- a/public/privacy_policy.html
+++ b/public/privacy_policy.html
@@ -6,9 +6,25 @@
     <meta name='viewport' content='width=device-width'>
     <title>Privacy Policy</title>
     <style>
-        body {
-            font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-            padding: 1em;
+        body {font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;margin:0;padding-top:72px;}
+        header{position:fixed;top:0;width:100%;height:72px;background:#fff;border-bottom:1px solid #eee;z-index:100;}
+        .nav-container{max-width:1200px;margin:auto;height:100%;display:grid;grid-template-columns:1fr auto 1fr;align-items:center;padding:0 1rem;position:relative;}
+        .nav-logo{margin:0;position:static;justify-self:center;}
+        header .nav-logo img{height:64px;margin-top:4px;}
+        .btn-download{background:#5D17EB;color:#fff;padding:.6rem 1.2rem;border-radius:24px;font-weight:600;transition:background .2s,transform .2s,box-shadow .2s;justify-self:end;box-shadow:0 8px 16px rgba(0,0,0,.15);}
+        .btn-download:hover{background:#4D07DB;transform:translateY(-2px);box-shadow:0 12px 20px rgba(0,0,0,.2);}
+        nav ul{display:flex;gap:1.5rem;list-style:none;}
+        nav ul li a{font-weight:500;color:#fff;transition:color .2s;}
+        nav ul li a:hover,nav ul li a:active,nav ul li a:focus{color:#5D17EB;}
+        .nav-toggle{display:none;background:none;border:none;font-size:1.5rem;cursor:pointer;justify-self:start;}
+        @media(max-width:768px){
+            .nav-toggle{display:block;order:1;}
+            nav ul .nav-close{display:block;position:absolute;top:.5rem;right:.5rem;background:none;border:none;color:#fff;font-size:1.5rem;z-index:101;}
+            .nav-logo{order:2;margin:0;position:static;justify-self:center;}
+            .btn-download{order:3;margin:0;justify-self:end;}
+            nav{order:4;}
+            nav ul{position:fixed;top:72px;left:-100%;width:200px;height:calc(100% - 72px);background:#000;flex-direction:column;align-items:flex-start;padding:3rem 1rem 1rem;gap:1rem;transition:left .3s ease;box-shadow:4px 0 8px rgba(0,0,0,.1);}
+            nav ul.open{left:0;}
         }
         .site-footer{background:#000;color:#fff;padding:2rem 1rem;text-align:center;margin-left:-1em;margin-right:-1em;}
         .footer-container{max-width:1200px;margin:auto;display:flex;flex-direction:column;align-items:center;gap:1rem;}
@@ -24,9 +40,24 @@
 <body>
   <div data-lang="en">
     <header>
-      <img src="plan-sin-fondo.png" alt="Plan Social" style="height:40px;">
-      <h1>Privacy Policy</h1>
+      <div class="nav-container">
+        <button class="nav-toggle" aria-label="Open menu">☰</button>
+        <div class="nav-logo"><img src="plan-sin-fondo.png" alt="Plan Social"></div>
+        <nav>
+          <ul>
+            <li><button class="nav-close" aria-label="Close menu">×</button></li>
+            <li><a href="index.html#hero">Home</a></li>
+            <li><a href="index.html#downloadSection">Download</a></li>
+            <li><a href="help.html">Help</a></li>
+            <li><a href="privacy_policy.html">Privacy</a></li>
+            <li><a href="terms_and_conditions.html">Terms</a></li>
+            <li><a href="cookies.html">Cookies</a></li>
+          </ul>
+        </nav>
+        <a href="index.html#downloadSection" class="btn-download">Download</a>
+      </div>
     </header>
+    <h1 style="padding:1em;">Privacy Policy</h1>
     <p>This privacy policy applies to the Plan app (hereby referred to as "Application") for mobile devices that was
         created by Inan Ilik Ilik (hereby referred to as "Service Provider") as a Freemium service. This service is
         intended for use "AS IS".</p><br><strong>Information Collection and Use</strong>
@@ -146,9 +177,24 @@
   </div>
   <div data-lang="es">
     <header>
-      <img src="plan-sin-fondo.png" alt="Plan Social" style="height:40px;">
-      <h1>Política de Privacidad</h1>
+      <div class="nav-container">
+        <button class="nav-toggle" aria-label="Abrir menú">☰</button>
+        <div class="nav-logo"><img src="plan-sin-fondo.png" alt="Plan Social"></div>
+        <nav>
+          <ul>
+            <li><button class="nav-close" aria-label="Cerrar menú">×</button></li>
+            <li><a href="index.html#hero">Inicio</a></li>
+            <li><a href="index.html#downloadSection">Descargar</a></li>
+            <li><a href="help.html">Ayuda</a></li>
+            <li><a href="privacy_policy.html">Privacidad</a></li>
+            <li><a href="terms_and_conditions.html">Condiciones</a></li>
+            <li><a href="cookies.html">Cookies</a></li>
+          </ul>
+        </nav>
+        <a href="index.html#downloadSection" class="btn-download">Descargar</a>
+      </div>
     </header>
+    <h1 style="padding:1em;">Política de Privacidad</h1>
     <p>Esta política de privacidad se aplica a la app Plan (en adelante, "Aplicación") para dispositivos móviles creada por Inan Ilik Ilik (en adelante, "Proveedor del Servicio") como servicio Freemium. Este servicio se ofrece "TAL CUAL".</p><br><strong>Recopilación y Uso de Información</strong>
     <p>La Aplicación recopila información cuando la descargas y la utilizas. Esta información puede incluir datos como </p>
     <ul>
@@ -224,8 +270,8 @@
     </footer>
   </div>
   <script>
-    (function(){
-      const selects=document.querySelectorAll('.lang-select');
+  (function(){
+    const selects=document.querySelectorAll('.lang-select');
       function setLang(l){
         document.documentElement.lang=l;
         document.querySelectorAll('[data-lang]').forEach(el=>{
@@ -235,8 +281,15 @@
       }
       const initial=((navigator.language||navigator.userLanguage)||'en').startsWith('es')?'es':'en';
       setLang(initial);
-      selects.forEach(sel=>sel.addEventListener('change',e=>setLang(e.target.value)));
-    })();
+    selects.forEach(sel=>sel.addEventListener('change',e=>setLang(e.target.value)));
+  })();
+  </script>
+  <script>
+    const navToggle=document.querySelector('.nav-toggle');
+    const navClose=document.querySelector('nav ul .nav-close');
+    const navList=document.querySelector('nav ul');
+    navToggle.addEventListener('click',()=>{navList.classList.toggle('open');});
+    navClose.addEventListener('click',()=>{navList.classList.remove('open');});
   </script>
 </body>
 

--- a/public/terms_and_conditions.html
+++ b/public/terms_and_conditions.html
@@ -6,9 +6,25 @@
     <meta name='viewport' content='width=device-width'>
     <title>Terms &amp; Conditions</title>
     <style>
-        body {
-            font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-            padding: 1em;
+        body {font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;margin:0;padding-top:72px;}
+        header{position:fixed;top:0;width:100%;height:72px;background:#fff;border-bottom:1px solid #eee;z-index:100;}
+        .nav-container{max-width:1200px;margin:auto;height:100%;display:grid;grid-template-columns:1fr auto 1fr;align-items:center;padding:0 1rem;position:relative;}
+        .nav-logo{margin:0;position:static;justify-self:center;}
+        header .nav-logo img{height:64px;margin-top:4px;}
+        .btn-download{background:#5D17EB;color:#fff;padding:.6rem 1.2rem;border-radius:24px;font-weight:600;transition:background .2s,transform .2s,box-shadow .2s;justify-self:end;box-shadow:0 8px 16px rgba(0,0,0,.15);}
+        .btn-download:hover{background:#4D07DB;transform:translateY(-2px);box-shadow:0 12px 20px rgba(0,0,0,.2);}
+        nav ul{display:flex;gap:1.5rem;list-style:none;}
+        nav ul li a{font-weight:500;color:#fff;transition:color .2s;}
+        nav ul li a:hover,nav ul li a:active,nav ul li a:focus{color:#5D17EB;}
+        .nav-toggle{display:none;background:none;border:none;font-size:1.5rem;cursor:pointer;justify-self:start;}
+        @media(max-width:768px){
+            .nav-toggle{display:block;order:1;}
+            nav ul .nav-close{display:block;position:absolute;top:.5rem;right:.5rem;background:none;border:none;color:#fff;font-size:1.5rem;z-index:101;}
+            .nav-logo{order:2;margin:0;position:static;justify-self:center;}
+            .btn-download{order:3;margin:0;justify-self:end;}
+            nav{order:4;}
+            nav ul{position:fixed;top:72px;left:-100%;width:200px;height:calc(100% - 72px);background:#000;flex-direction:column;align-items:flex-start;padding:3rem 1rem 1rem;gap:1rem;transition:left .3s ease;box-shadow:4px 0 8px rgba(0,0,0,.1);}
+            nav ul.open{left:0;}
         }
         .site-footer{background:#000;color:#fff;padding:2rem 1rem;text-align:center;margin-left:-1em;margin-right:-1em;}
         .footer-container{max-width:1200px;margin:auto;display:flex;flex-direction:column;align-items:center;gap:1rem;}
@@ -24,9 +40,24 @@
 <body>
   <div data-lang="en">
     <header>
-      <img src="plan-sin-fondo.png" alt="Plan Social" style="height:40px;">
-      <h1>Terms &amp; Conditions</h1>
+      <div class="nav-container">
+        <button class="nav-toggle" aria-label="Open menu">☰</button>
+        <div class="nav-logo"><img src="plan-sin-fondo.png" alt="Plan Social"></div>
+        <nav>
+          <ul>
+            <li><button class="nav-close" aria-label="Close menu">×</button></li>
+            <li><a href="index.html#hero">Home</a></li>
+            <li><a href="index.html#downloadSection">Download</a></li>
+            <li><a href="help.html">Help</a></li>
+            <li><a href="privacy_policy.html">Privacy</a></li>
+            <li><a href="terms_and_conditions.html">Terms</a></li>
+            <li><a href="cookies.html">Cookies</a></li>
+          </ul>
+        </nav>
+        <a href="index.html#downloadSection" class="btn-download">Download</a>
+      </div>
     </header>
+    <h1 style="padding:1em;">Terms &amp; Conditions</h1>
     <p>These terms and conditions apply to the Plan app (hereby referred to as "Application") for mobile devices that
         was created by Inan Ilik Ilik (hereby referred to as "Service Provider") as a Freemium service.</p><br>
     <p>Upon downloading or utilizing the Application, you are automatically agreeing to the following terms. It is
@@ -120,9 +151,24 @@
   </div>
   <div data-lang="es">
     <header>
-      <img src="plan-sin-fondo.png" alt="Plan Social" style="height:40px;">
-      <h1>Términos y Condiciones</h1>
+      <div class="nav-container">
+        <button class="nav-toggle" aria-label="Abrir menú">☰</button>
+        <div class="nav-logo"><img src="plan-sin-fondo.png" alt="Plan Social"></div>
+        <nav>
+          <ul>
+            <li><button class="nav-close" aria-label="Cerrar menú">×</button></li>
+            <li><a href="index.html#hero">Inicio</a></li>
+            <li><a href="index.html#downloadSection">Descargar</a></li>
+            <li><a href="help.html">Ayuda</a></li>
+            <li><a href="privacy_policy.html">Privacidad</a></li>
+            <li><a href="terms_and_conditions.html">Condiciones</a></li>
+            <li><a href="cookies.html">Cookies</a></li>
+          </ul>
+        </nav>
+        <a href="index.html#downloadSection" class="btn-download">Descargar</a>
+      </div>
     </header>
+    <h1 style="padding:1em;">Términos y Condiciones</h1>
     <p>Estos términos y condiciones se aplican a la app Plan (en adelante, "Aplicación") para dispositivos móviles creada por Inan Ilik Ilik (en adelante, "Proveedor del Servicio") como servicio Freemium.</p><br>
     <p>Al descargar o utilizar la Aplicación aceptas automáticamente los siguientes términos. Se recomienda leerlos detenidamente antes de usar la Aplicación. Queda estrictamente prohibido copiar o modificar la Aplicación, cualquier parte de ella o nuestras marcas. Tampoco está permitido extraer el código fuente de la Aplicación, traducirla a otros idiomas ni crear versiones derivadas. Todas las marcas, derechos de autor, derechos sobre bases de datos y demás derechos de propiedad intelectual relacionados con la Aplicación siguen siendo propiedad del Proveedor del Servicio.</p><br>
     <p>El Proveedor del Servicio se esfuerza por que la Aplicación sea lo más útil y eficiente posible, por lo que se reserva el derecho de modificarla o cobrar por sus servicios en cualquier momento y por cualquier motivo. Cualquier cargo por la Aplicación o sus servicios será claramente comunicado.</p><br>
@@ -170,8 +216,8 @@
     </footer>
   </div>
   <script>
-    (function(){
-      const selects=document.querySelectorAll('.lang-select');
+  (function(){
+    const selects=document.querySelectorAll('.lang-select');
       function setLang(l){
         document.documentElement.lang=l;
         document.querySelectorAll('[data-lang]').forEach(el=>{
@@ -181,8 +227,15 @@
       }
       const initial=((navigator.language||navigator.userLanguage)||'en').startsWith('es')?'es':'en';
       setLang(initial);
-      selects.forEach(sel=>sel.addEventListener('change',e=>setLang(e.target.value)));
-    })();
+    selects.forEach(sel=>sel.addEventListener('change',e=>setLang(e.target.value)));
+  })();
+  </script>
+  <script>
+    const navToggle=document.querySelector('.nav-toggle');
+    const navClose=document.querySelector('nav ul .nav-close');
+    const navList=document.querySelector('nav ul');
+    navToggle.addEventListener('click',()=>{navList.classList.toggle('open');});
+    navClose.addEventListener('click',()=>{navList.classList.remove('open');});
   </script>
 </body>
 


### PR DESCRIPTION
## Summary
- add link to Cookies in hamburger menu
- make header sticky across all info pages
- include mobile menu script on all pages

## Testing
- `flutter test` *(fails: command not found)*
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6848993cfa308332b302157ca046acc2