### PR TITLE
Actualiza diálogo de código SMS

### DIFF
--- a/app_src/lib/start/login/recover_password.dart
+++ b/app_src/lib/start/login/recover_password.dart
@@ -80,13 +80,23 @@ class _RecoverPasswordScreenState extends State<RecoverPasswordScreen> {
     showDialog(
       context: context,
       builder: (_) => AlertDialog(
-        title: const Text('Código + nueva contraseña'),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+        title: const Text(
+          'Introduce el código recibido por SMS',
+          textAlign: TextAlign.center,
+        ),
         content: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
             TextField(
               controller: _codeController,
-              decoration: const InputDecoration(labelText: 'Código SMS'),
+              keyboardType: TextInputType.number,
+              decoration: const InputDecoration(
+                labelText: 'Código SMS',
+                border: OutlineInputBorder(),
+              ),
             ),
             TextField(
               controller: _pwdController,

--- a/app_src/lib/start/registration/register_screen.dart
+++ b/app_src/lib/start/registration/register_screen.dart
@@ -235,10 +235,20 @@ class _RegisterScreenState extends State<RegisterScreen> {
     showDialog(
       context: context,
       builder: (_) => AlertDialog(
-        title: const Text('C\u00f3digo SMS'),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+        title: const Text(
+          'Introduce el código recibido por SMS',
+          textAlign: TextAlign.center,
+        ),
         content: TextField(
           controller: controller,
-          decoration: const InputDecoration(labelText: 'C\u00f3digo'),
+          keyboardType: TextInputType.number,
+          decoration: const InputDecoration(
+            labelText: 'Código',
+            border: OutlineInputBorder(),
+          ),
         ),
         actions: [
           TextButton(


### PR DESCRIPTION
## Summary
- mejora el cuadro de diálogo para ingresar el código SMS en registro
- estiliza y actualiza el cuadro de diálogo de recuperación de contraseña

## Testing
- `flutter test` *(falla: comando no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_684af06201bc8332975555d8439841d6