### PR TITLE
Mostrar errores de Firebase en popups

### DIFF
--- a/app_src/lib/start/login/recover_password.dart
+++ b/app_src/lib/start/login/recover_password.dart
@@ -3,6 +3,7 @@ import 'dart:convert';                           //  ⬅️  NUEVO
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:http/http.dart' as http;
+import '../utils/auth_error_utils.dart';
 
 class RecoverPasswordScreen extends StatefulWidget {
   const RecoverPasswordScreen({Key? key}) : super(key: key);
@@ -63,7 +64,7 @@ class _RecoverPasswordScreenState extends State<RecoverPasswordScreen> {
       timeout: const Duration(seconds: 60),
       verificationCompleted: (_) {},
       verificationFailed: (e) {
-        _showSnack('Error: ${e.message}');
+        AuthErrorUtils.showError(context, e);
         setState(() => _isLoading = false);
       },
       codeSent: (verId, _) {
@@ -133,7 +134,7 @@ class _RecoverPasswordScreenState extends State<RecoverPasswordScreen> {
                 _showSnack('Contraseña actualizada');
                 Navigator.of(context).pop();
               } on FirebaseAuthException catch (e) {
-                _showSnack('Error: ${e.message}');
+                AuthErrorUtils.showError(context, e);
               }
             },
           ),

--- a/app_src/lib/start/registration/register_screen.dart
+++ b/app_src/lib/start/registration/register_screen.dart
@@ -13,6 +13,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '../login/login_screen.dart';
 import '../welcome_screen.dart';
+import '../utils/auth_error_utils.dart';
 
 class RegisterScreen extends StatefulWidget {
   const RegisterScreen({Key? key}) : super(key: key);
@@ -212,14 +213,16 @@ class _RegisterScreenState extends State<RegisterScreen> {
               await FirebaseAuth.instance.signInWithCredential(cred);
           _onPhoneUserCreated(userCred);
         } catch (e) {
-          ScaffoldMessenger.of(context)
-              .showSnackBar(SnackBar(content: Text('Error: $e')));
+          if (e is FirebaseAuthException) {
+            AuthErrorUtils.showError(context, e);
+          } else {
+            _showPopup('Error: $e');
+          }
           setState(() => isLoading = false);
         }
       },
       verificationFailed: (e) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Error: ${e.message}')));
+        AuthErrorUtils.showError(context, e);
         setState(() => isLoading = false);
       },
       codeSent: (verId, _) {
@@ -263,8 +266,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                 Navigator.of(context).pop();
                 _onPhoneUserCreated(userCred);
               } on FirebaseAuthException catch (e) {
-                ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(content: Text('Error: ${e.message}')));
+                AuthErrorUtils.showError(context, e);
               }
             },
             child: const Text('Continuar'),

--- a/app_src/lib/utils/auth_error_utils.dart
+++ b/app_src/lib/utils/auth_error_utils.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+/// Utilidades para mostrar mensajes de error de FirebaseAuth en español.
+class AuthErrorUtils {
+  AuthErrorUtils._();
+
+  /// Muestra un [AlertDialog] con un mensaje traducido según [e.code].
+  static void showError(BuildContext context, FirebaseAuthException e) {
+    final String msg = _errorMessages[e.code] ??
+        'Se produjo un error. Inténtalo de nuevo.';
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Atención'),
+        content: Text(msg),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// Mapa de códigos de error de FirebaseAuth a mensajes en español.
+  static const Map<String, String> _errorMessages = {
+    'invalid-phone-number': 'Número de teléfono no válido',
+    'missing-phone-number': 'Introduce un número de teléfono',
+    'invalid-verification-code': 'Código de verificación incorrecto',
+    'invalid-verification-id': 'Identificador de verificación inválido',
+    'missing-verification-code': 'Introduce el código de verificación',
+    'missing-verification-id': 'Falta el identificador de verificación',
+    'session-expired': 'La sesión ha expirado, solicita un nuevo código',
+    'credential-already-in-use':
+        'La credencial ya está en uso por otra cuenta',
+    'user-disabled': 'El usuario está deshabilitado',
+    'operation-not-allowed': 'Operación no permitida',
+    'too-many-requests':
+        'Hemos bloqueado las solicitudes por actividad inusual. Inténtalo más tarde',
+    'network-request-failed': 'Error de red. Revisa tu conexión',
+    'quota-exceeded': 'Cuota excedida. Inténtalo más tarde',
+  };
+}


### PR DESCRIPTION
## Summary
- centralizar mensajes de error de FirebaseAuth en español
- usar `AuthErrorUtils.showError` en registro y recuperación de contraseña

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684afb8a69ec8332ab32ffb884e17b48