### PR TITLE
Fix social links fallback

### DIFF
--- a/app_src/lib/explore_screen/menu_side_bar/menu_side_bar_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/menu_side_bar_screen.dart
@@ -464,8 +464,11 @@ class MainSideBarScreenState extends State<MainSideBarScreen> {
       tooltip: tooltip,
       onPressed: () async {
         final uri = Uri.parse(url);
-        if (await canLaunchUrl(uri)) {
-          await launchUrl(uri, mode: LaunchMode.externalApplication);
+        // Intenta abrir primero con una aplicación externa (por ejemplo,
+        // la app oficial de la red social). Si no hay ninguna instalada,
+        // se abre en un navegador dentro de la app.
+        if (!await launchUrl(uri, mode: LaunchMode.externalApplication)) {
+          await launchUrl(uri, mode: LaunchMode.inAppBrowser);
         }
       },
     );


### PR DESCRIPTION
## Summary
- handle missing external applications for social network links

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b2eeaf724833299bacd46a657ec52