### PR TITLE
Add filter toggle for exploring plans

### DIFF
--- a/app_src/lib/explore_screen/main_screen/explore_screen_filter.dart
+++ b/app_src/lib/explore_screen/main_screen/explore_screen_filter.dart
@@ -33,6 +33,7 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
   String? _customPlan;
 
   bool _onlyFollowed = false;
+  bool _onlyPlans = false;
 
   String regionBusqueda = '';
   final TextEditingController _regionController = TextEditingController();
@@ -62,6 +63,7 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
         _selectedPlans = List<String>.from(init['selectedPlans']);
       }
       _onlyFollowed = init['onlyFollowed'] ?? false;
+      _onlyPlans = init['onlyPlans'] ?? false;
       regionBusqueda = init['regionBusqueda'] ?? '';
       edadRange = RangeValues(
         (init['edadMin'] ?? 18).toDouble(),
@@ -252,6 +254,7 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
       'edadMax': edadRange.end,
       'genero': generoSeleccionado,
       'onlyFollowed': _onlyFollowed,
+      'onlyPlans': _onlyPlans,
       'userCoordinates': _userPosition != null
           ? {
               'lat': _userPosition!.latitude,
@@ -272,6 +275,7 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
       edadRange = const RangeValues(18, 60);
       _selectedDate = null;
       _onlyFollowed = false;
+      _onlyPlans = false;
     });
   }
 
@@ -327,6 +331,36 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
                       thickness: 0.2,
                       height: 20,
                     ),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        const Text(
+                          '¿Qué deseas ver?',
+                          style: TextStyle(fontSize: 16, color: Colors.black),
+                        ),
+                        Row(
+                          children: [
+                            Switch(
+                              value: !_onlyPlans,
+                              activeColor: AppColors.planColor,
+                              inactiveThumbColor: Colors.grey,
+                              onChanged: (v) {
+                                setState(() {
+                                  _onlyPlans = !v;
+                                });
+                              },
+                            ),
+                            const SizedBox(width: 8),
+                            Text(
+                              _onlyPlans ? 'Solo planes' : 'Todo',
+                              style:
+                                  const TextStyle(fontSize: 14, color: Colors.black),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 10),
                     Wrap(
                       spacing: 6,
                       runSpacing: 6,

--- a/app_src/lib/explore_screen/map/map_screen.dart
+++ b/app_src/lib/explore_screen/map/map_screen.dart
@@ -95,9 +95,14 @@ class MapScreenState extends State<MapScreen> {
     final plansLoader = PlansInMapScreen();
     final planMarkers =
         await plansLoader.loadPlansMarkers(context, filters: filters);
-    // Only display markers for users that have upcoming plans. Users without
-    // future plans should not appear on the map.
-    _allMarkers = [...planMarkers];
+    Set<Marker> markers = {...planMarkers};
+    final bool onlyPlans = filters?['onlyPlans'] == true;
+    if (!onlyPlans) {
+      final userMarkers =
+          await plansLoader.loadUsersWithoutPlansMarkers(context, filters: filters);
+      markers.addAll(userMarkers);
+    }
+    _allMarkers = markers.toList();
     _updateVisibleMarkers(_currentZoom);
   }
 


### PR DESCRIPTION
## Summary
- add `onlyPlans` option in explore filter dialog
- show new toggle labeled "¿Qué deseas ver?" above plan types
- use `onlyPlans` in map screen to load extra user markers if disabled
- support followed filter when loading user markers

## Testing
- `dart format` *(fails: command not found)*
- `flutter format` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_684c1d4648ac83329e056004056e2095