### PR TITLE
Add Planes section divider

### DIFF
--- a/app_src/lib/explore_screen/main_screen/explore_screen_filter.dart
+++ b/app_src/lib/explore_screen/main_screen/explore_screen_filter.dart
@@ -360,6 +360,21 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
                         ),
                       ],
                     ),
+                    const Divider(
+                      color: Colors.black,
+                      thickness: 0.2,
+                      height: 20,
+                    ),
+                    Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text(
+                        'Planes',
+                        style: TextStyle(
+                          fontSize: 16,
+                          color: Colors.black,
+                        ),
+                      ),
+                    ),
                     const SizedBox(height: 10),
                     Wrap(
                       spacing: 6,


### PR DESCRIPTION
## Summary
- add a divider and heading for the plans filter section

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c2244bd9c8332935717499b5e1020