### PR TITLE
Fix invite plan popup size

### DIFF
--- a/app_src/lib/explore_screen/special_plans/invite_users_to_plan_screen.dart
+++ b/app_src/lib/explore_screen/special_plans/invite_users_to_plan_screen.dart
@@ -18,8 +18,6 @@ import '../../../main/colors.dart';
 const double kMainPopupWidth = 500;
 const double kMainPopupPadding = 20;
 
-const double kNewPlanPopupWidth = 380;
-const double kNewPlanPopupHeight = 750;
 const double kNewPlanPadding = 20;
 
 const double kPlanTypeSectionWidth = 320;
@@ -361,9 +359,8 @@ void _showNewPlanForInvitation(BuildContext context, String invitedUserId) {
                   EdgeInsets.only(bottom: MediaQuery.of(ctx).viewInsets.bottom),
               child: SingleChildScrollView(
                 child: Container(
-                  // OJO: Quitamos el alto fijo
-                  width: kNewPlanPopupWidth,
-                  // height: kNewPlanPopupHeight, // <-- Eliminado
+                  width: MediaQuery.of(ctx).size.width * 0.9,
+                  height: MediaQuery.of(ctx).size.height * 0.9,
                   padding: const EdgeInsets.all(kNewPlanPadding),
                   decoration: BoxDecoration(
                     borderRadius: BorderRadius.circular(20),


### PR DESCRIPTION
## Summary
- ensure the popup for _Invítale a un Plan ➜ Nuevo_ uses the same size as the new plan screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c4225e45c8332b08416a9e98039e3