### PR TITLE
Fix Material ancestor for plan selection list

### DIFF
--- a/app_src/lib/explore_screen/special_plans/invite_users_to_plan_screen.dart
+++ b/app_src/lib/explore_screen/special_plans/invite_users_to_plan_screen.dart
@@ -234,7 +234,7 @@ class _InvitePlanPopupState extends State<_InvitePlanPopup> {
                             filter: ui.ImageFilter.blur(sigmaX: 5, sigmaY: 5),
                             child: Container(
                               color: Colors.white.withOpacity(0.15),
-                              child: ListTile(
+                              child: Material(color: Colors.transparent, child: ListTile(
                                 title: Text(
                                   plan.type,
                                   style: const TextStyle(color: Colors.white),
@@ -285,7 +285,7 @@ class _InvitePlanPopupState extends State<_InvitePlanPopup> {
                                     },
                                   );
                                 },
-                              ),
+                              )),
                             ),
                           ),
                         ),


### PR DESCRIPTION
## Summary
- ensure ListTile in invite screen has a Material ancestor to prevent runtime error

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c462c45b08332abc2d76638c5a0a5