### PR TITLE
feat: toggle plan selection

### DIFF
--- a/app_src/lib/explore_screen/special_plans/invite_existing_plan_screen.dart
+++ b/app_src/lib/explore_screen/special_plans/invite_existing_plan_screen.dart
@@ -92,25 +92,22 @@ class _InviteExistingPlanScreenState extends State<InviteExistingPlanScreen> {
                       hideJoinButton: true,
                     ),
                     Positioned(
-                      top: 8,
+                      top: 22,
                       right: 8,
-                      child: GestureDetector(
-                        onTap: () {
-                          setState(() => _selectedId = plan.id);
-                          widget.onPlanSelected(plan);
+                      child: Switch(
+                        value: isSelected,
+                        activeTrackColor: AppColors.planColor,
+                        activeColor: Colors.white,
+                        inactiveTrackColor: Colors.grey,
+                        inactiveThumbColor: Colors.white,
+                        onChanged: (value) {
+                          setState(() {
+                            _selectedId = value ? plan.id : null;
+                          });
+                          if (value) {
+                            widget.onPlanSelected(plan);
+                          }
                         },
-                        child: Container(
-                          width: 28,
-                          height: 28,
-                          decoration: BoxDecoration(
-                            shape: BoxShape.circle,
-                            color: isSelected ? AppColors.planColor : Colors.grey[300],
-                            border: Border.all(
-                              color: isSelected ? AppColors.planColor : Colors.grey,
-                              width: 2,
-                            ),
-                          ),
-                        ),
                       ),
                     ),
                   ],


### PR DESCRIPTION
## Summary
- replace circle selection with a toggle switch in InviteExistingPlanScreen
- align switch with creator avatar and allow deselection

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c50fae9148332bcd7364068076f82