### PR TITLE
Add confirmation and specialPlan support for invitations

### DIFF
--- a/app_src/lib/explore_screen/main_screen/notification_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/notification_screen.dart
@@ -632,11 +632,13 @@ class _NotificationScreenState extends State<NotificationScreen> {
                                 ),
                               );
                             case 'invitation':
+                              final int specialPlan = data['specialPlan'] ?? 0;
+                              final String message = specialPlan == 1
+                                  ? "$senderName te ha invitado a un plan especial de $planType"
+                                  : "¡$senderName te está invitando a un plan! ¿Aceptas?";
                               return ListTile(
                                 leading: leadingAvatar,
-                                title: Text(
-                                  "$senderName te ha invitado a un plan especial de $planType",
-                                ),
+                                title: Text(message),
                                 subtitle: buildSubtitle("Plan: $planType"),
                                 onTap: () => _showPlanDetails(context, planId),
                                 isThreeLine: true,

--- a/app_src/lib/explore_screen/special_plans/invite_existing_plan_screen.dart
+++ b/app_src/lib/explore_screen/special_plans/invite_existing_plan_screen.dart
@@ -100,12 +100,32 @@ class _InviteExistingPlanScreenState extends State<InviteExistingPlanScreen> {
                         activeColor: Colors.white,
                         inactiveTrackColor: Colors.grey,
                         inactiveThumbColor: Colors.white,
-                        onChanged: (value) {
-                          setState(() {
-                            _selectedId = value ? plan.id : null;
-                          });
+                        onChanged: (value) async {
                           if (value) {
-                            widget.onPlanSelected(plan);
+                            final confirm = await showDialog<bool>(
+                                  context: context,
+                                  builder: (_) => AlertDialog(
+                                        title: const Text('Invitar a un plan'),
+                                        content: const Text('¿Estás seguro de que quieres invitarle a un plan?'),
+                                        actions: [
+                                          TextButton(
+                                            onPressed: () => Navigator.pop(context, false),
+                                            child: const Text('Cancelar'),
+                                          ),
+                                          ElevatedButton(
+                                            onPressed: () => Navigator.pop(context, true),
+                                            child: const Text('Aceptar'),
+                                          ),
+                                        ],
+                                      ));
+                            if (confirm == true) {
+                              setState(() => _selectedId = plan.id);
+                              widget.onPlanSelected(plan);
+                            } else {
+                              setState(() => _selectedId = null);
+                            }
+                          } else {
+                            setState(() => _selectedId = null);
                           }
                         },
                       ),

--- a/app_src/lib/explore_screen/special_plans/invite_users_to_plan_screen.dart
+++ b/app_src/lib/explore_screen/special_plans/invite_users_to_plan_screen.dart
@@ -349,6 +349,7 @@ class _InvitePlanPopupState extends State<_InvitePlanPopup> {
       receiverUid: invitedUid,
       planId: plan.id,
       planType: plan.type,
+      specialPlan: plan.special_plan,
     );
 
     Navigator.pop(context);
@@ -1262,6 +1263,7 @@ class _NewPlanInviteContentState extends State<_NewPlanInviteContent> {
         receiverUid: widget.invitedUserId,
         planId: planId,
         planType: (dataToSave["type"] ?? "Plan").toString(),
+        specialPlan: 1,
       );
 
       Navigator.pop(context);
@@ -1309,6 +1311,7 @@ Future<void> _sendInvitationNotification({
   required String receiverUid,
   required String planId,
   required String planType,
+  required int specialPlan,
 }) async {
   final notiDoc = FirebaseFirestore.instance.collection('notifications').doc();
   await notiDoc.set({
@@ -1318,6 +1321,7 @@ Future<void> _sendInvitationNotification({
     "receiverId": receiverUid,
     "planId": planId,
     "planName": planType,
+    "specialPlan": specialPlan,
     "timestamp": FieldValue.serverTimestamp(),
     "read": false,
   });


### PR DESCRIPTION
## Summary
- ask for confirmation before inviting to an existing plan
- pass specialPlan info in invitation notifications
- show different invitation text based on special plan state

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c55c734dc833282360685f314f6e5