### PR TITLE
Fix invitation notification and selection flow

### DIFF
--- a/app_src/lib/explore_screen/main_screen/notification_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/notification_screen.dart
@@ -635,7 +635,7 @@ class _NotificationScreenState extends State<NotificationScreen> {
                               final int specialPlan = data['specialPlan'] ?? 0;
                               final String message = specialPlan == 1
                                   ? "$senderName te ha invitado a un plan especial de $planType"
-                                  : "¡$senderName te está invitando a un plan! ¿Aceptas?";
+                                  : "¡$senderName te ha invitado a unirte a este plan!";
                               return ListTile(
                                 leading: leadingAvatar,
                                 title: Text(message),

--- a/app_src/lib/explore_screen/special_plans/invite_existing_plan_screen.dart
+++ b/app_src/lib/explore_screen/special_plans/invite_existing_plan_screen.dart
@@ -92,7 +92,7 @@ class _InviteExistingPlanScreenState extends State<InviteExistingPlanScreen> {
                       hideJoinButton: true,
                     ),
                     Positioned(
-                      top: 22,
+                      top: 8,
                       right: 8,
                       child: Switch(
                         value: isSelected,
@@ -102,24 +102,26 @@ class _InviteExistingPlanScreenState extends State<InviteExistingPlanScreen> {
                         inactiveThumbColor: Colors.white,
                         onChanged: (value) async {
                           if (value) {
+                            setState(() => _selectedId = plan.id);
+                            await Future.delayed(const Duration(milliseconds: 500));
                             final confirm = await showDialog<bool>(
-                                  context: context,
-                                  builder: (_) => AlertDialog(
-                                        title: const Text('Invitar a un plan'),
-                                        content: const Text('¿Estás seguro de que quieres invitarle a un plan?'),
-                                        actions: [
-                                          TextButton(
-                                            onPressed: () => Navigator.pop(context, false),
-                                            child: const Text('Cancelar'),
-                                          ),
-                                          ElevatedButton(
-                                            onPressed: () => Navigator.pop(context, true),
-                                            child: const Text('Aceptar'),
-                                          ),
-                                        ],
-                                      ));
+                              context: context,
+                              builder: (_) => AlertDialog(
+                                title: const Text('Invitar a un plan'),
+                                content: const Text('¿Deseas compartirle este plan?'),
+                                actions: [
+                                  TextButton(
+                                    onPressed: () => Navigator.pop(context, false),
+                                    child: const Text('Cancelar'),
+                                  ),
+                                  ElevatedButton(
+                                    onPressed: () => Navigator.pop(context, true),
+                                    child: const Text('Aceptar'),
+                                  ),
+                                ],
+                              ),
+                            );
                             if (confirm == true) {
-                              setState(() => _selectedId = plan.id);
                               widget.onPlanSelected(plan);
                             } else {
                               setState(() => _selectedId = null);

--- a/app_src/lib/explore_screen/special_plans/invite_users_to_plan_screen.dart
+++ b/app_src/lib/explore_screen/special_plans/invite_users_to_plan_screen.dart
@@ -1313,17 +1313,29 @@ Future<void> _sendInvitationNotification({
   required String planType,
   required int specialPlan,
 }) async {
+  final senderSnap =
+      await FirebaseFirestore.instance.collection('users').doc(senderUid).get();
+  String senderName = 'Usuario';
+  String senderPhoto = '';
+  if (senderSnap.exists && senderSnap.data() != null) {
+    final data = senderSnap.data()!;
+    senderName = data['name'] ?? senderName;
+    senderPhoto = data['photoUrl'] ?? senderPhoto;
+  }
+
   final notiDoc = FirebaseFirestore.instance.collection('notifications').doc();
   await notiDoc.set({
-    "id": notiDoc.id,
-    "type": "invitation",
-    "senderId": senderUid,
-    "receiverId": receiverUid,
-    "planId": planId,
-    "planName": planType,
-    "specialPlan": specialPlan,
-    "timestamp": FieldValue.serverTimestamp(),
-    "read": false,
+    'id': notiDoc.id,
+    'type': 'invitation',
+    'senderId': senderUid,
+    'senderName': senderName,
+    'senderProfilePic': senderPhoto,
+    'receiverId': receiverUid,
+    'planId': planId,
+    'planType': planType,
+    'specialPlan': specialPlan,
+    'timestamp': FieldValue.serverTimestamp(),
+    'read': false,
   });
 }
 


### PR DESCRIPTION
## Summary
- update invitation flow for existing plans with a delayed confirmation popup
- include sender info in invitation notifications
- adjust notification message text

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c86aa83488332a824e50fb99aeb74