### PR TITLE
Fix leaving plan and stale subscriptions

### DIFF
--- a/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
@@ -79,8 +79,20 @@ class SubscribedPlansScreen extends StatelessWidget {
           .get();
       if (planDoc.exists) {
         final planData = planDoc.data() as Map<String, dynamic>;
-        planData['id'] = planDoc.id;
-        plans.add(PlanModel.fromMap(planData));
+        final List<dynamic> participants = planData['participants'] ?? [];
+        if (participants.contains(userId)) {
+          planData['id'] = planDoc.id;
+          plans.add(PlanModel.fromMap(planData));
+        } else {
+          final subs = await FirebaseFirestore.instance
+              .collection('subscriptions')
+              .where('userId', isEqualTo: userId)
+              .where('id', isEqualTo: planId)
+              .get();
+          for (var doc in subs.docs) {
+            await doc.reference.delete();
+          }
+        }
       }
     }
     return plans;


### PR DESCRIPTION
## Summary
- prune subscriptions in subscribed plans screen if user was removed from a plan
- remove stale subscriptions when selecting a plan for chat

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c905a8a048332a3721a47dbda2a70