### PR TITLE
Fix screen pop after inviting plan

### DIFF
--- a/app_src/lib/explore_screen/special_plans/invite_users_to_plan_screen.dart
+++ b/app_src/lib/explore_screen/special_plans/invite_users_to_plan_screen.dart
@@ -366,7 +366,6 @@ class _InvitePlanPopupState extends State<_InvitePlanPopup> {
       specialPlan: plan.special_plan,
     );
 
-    Navigator.pop(ctx);
     ScaffoldMessenger.of(ctx).showSnackBar(
       SnackBar(content: Text("Has invitado a tu plan: ${plan.type}")),
     );


### PR DESCRIPTION
## Summary
- stop popping the parent screen when inviting to an existing plan

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c9d12a3cc83329e3caf0e660cc9b4