### PR TITLE
Fix subscription doc missing ID

### DIFF
--- a/app_src/lib/explore_screen/main_screen/notification_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/notification_screen.dart
@@ -73,9 +73,10 @@ class _NotificationScreenState extends State<NotificationScreen> {
         'participants': FieldValue.arrayUnion([senderId]),
       });
 
-      // Crea la suscripción
+      // Crea la suscripción (guardamos también el id del plan)
       await _firestore.collection('subscriptions').add({
         ...planDoc.data()!,
+        'id': planId,
         'userId': senderId,
         'subscriptionDate': FieldValue.serverTimestamp(),
       });
@@ -170,9 +171,10 @@ class _NotificationScreenState extends State<NotificationScreen> {
         'participants': FieldValue.arrayUnion([currentUserId]),
       });
 
-      // Crea suscripción
+      // Crea la suscripción (guardamos también el id del plan)
       await _firestore.collection('subscriptions').add({
         ...planDoc.data()!,
+        'id': planId,
         'userId': currentUserId,
         'subscriptionDate': FieldValue.serverTimestamp(),
       });


### PR DESCRIPTION
## Summary
- add plan ID when creating subscription documents for accepted invites

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d3f9d88b0833289d2e040fbee1082