### PR TITLE
Fix Firestore rule for invited users

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -15,7 +15,7 @@ service cloud.firestore {
       allow read, create: if request.auth != null;
       allow update, delete: if request.auth.uid == resource.data.createdBy
         || (request.auth.uid in resource.data.invitedUsers
-            && request.resource.data.keys().hasOnly(['participants', 'invitedUsers']));
+            && request.resource.data.diff(resource.data).changedKeys().hasOnly(['participants', 'invitedUsers']));
     }
 
     match /notifications/{id} {


### PR DESCRIPTION
## Summary
- allow invited users to update their plan document using changed keys

## Testing
- `npm test` *(fails: package.json missing)*


------
https://chatgpt.com/codex/tasks/task_e_684d4d0cef148332b1410a5960016487