### PR TITLE
Fix dejar plan

### DIFF
--- a/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
@@ -114,27 +114,35 @@ class SubscribedPlansScreen extends StatelessWidget {
             ElevatedButton(
               style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
               onPressed: () async {
-                final subs = await FirebaseFirestore.instance
-                    .collection('subscriptions')
-                    .where('userId', isEqualTo: userId)
-                    .where('id', isEqualTo: plan.id)
-                    .get();
-                for (var doc in subs.docs) {
-                  await doc.reference.delete();
-                }
-                await FirebaseFirestore.instance
-                    .collection('plans')
-                    .doc(plan.id)
-                    .update({
-                  'participants': FieldValue.arrayRemove([userId])
-                });
+                try {
+                  final subs = await FirebaseFirestore.instance
+                      .collection('subscriptions')
+                      .where('userId', isEqualTo: userId)
+                      .where('id', isEqualTo: plan.id)
+                      .get();
+                  for (var doc in subs.docs) {
+                    await doc.reference.delete();
+                  }
+                  await FirebaseFirestore.instance
+                      .collection('plans')
+                      .doc(plan.id)
+                      .update({
+                    'participants': FieldValue.arrayRemove([userId]),
+                    'invitedUsers': FieldValue.arrayRemove([userId])
+                  });
 
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    content: Text('Has abandonado el plan ${plan.type}.'),
-                  ),
-                );
-                Navigator.pop(context);
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text('Has abandonado el plan ${plan.type}.'),
+                    ),
+                  );
+                } catch (e) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Error al abandonar el plan.')),
+                  );
+                } finally {
+                  Navigator.pop(context);
+                }
               },
               child: const Text("Sí"),
             ),

--- a/firestore.rules
+++ b/firestore.rules
@@ -14,7 +14,8 @@ service cloud.firestore {
     match /plans/{planId} {
       allow read, create: if request.auth != null;
       allow update, delete: if request.auth.uid == resource.data.createdBy
-        || (request.auth.uid in resource.data.invitedUsers
+        || ((request.auth.uid in resource.data.invitedUsers
+            || request.auth.uid in resource.data.participants)
             && request.resource.data.diff(resource.data).changedKeys().hasOnly(['participants', 'invitedUsers']));
     }
 


### PR DESCRIPTION
## Summary
- allow plan participants to remove themselves via Firestore rules
- handle errors when leaving a plan so the dialog closes

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684d53f1b4748332814b470d229528a3