### PR TITLE
Add leave-plan notification

### DIFF
--- a/app_src/functions/src/index.ts
+++ b/app_src/functions/src/index.ts
@@ -17,6 +17,7 @@ const titles: Record<string, string> = {
   new_plan_published: "Nuevo plan publicado",
   plan_chat_message: "Nuevo comentario",
   welcome: "Bienvenido a Plan",
+  plan_left: "Participante ha abandonado",
 };
 
 export const sendPushOnNotification = onDocumentCreated(

--- a/app_src/lib/explore_screen/main_screen/notification_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/notification_screen.dart
@@ -42,6 +42,7 @@ class _NotificationScreenState extends State<NotificationScreen> {
       'new_plan_published', // <--- Agregamos este nuevo tipo
       'plan_chat_message',
       'welcome',
+      'plan_left',
     ]).snapshots();
   }
 
@@ -771,6 +772,22 @@ class _NotificationScreenState extends State<NotificationScreen> {
                                 ),
                                 onTap: () => _openPlanChatFromNotification(
                                     context, planId),
+                                trailing: IconButton(
+                                  icon: const Icon(Icons.delete,
+                                      color: Colors.red),
+                                  onPressed: () =>
+                                      _handleDeleteNotification(doc),
+                                ),
+                              );
+                            case 'plan_left':
+                              return ListTile(
+                                leading: leadingAvatar,
+                                title: Text(
+                                  "$senderName ha decidido abandonar tu plan.",
+                                ),
+                                subtitle: buildSubtitle("Plan: $planType"),
+                                isThreeLine: true,
+                                onTap: () => _showPlanDetails(context, planId),
                                 trailing: IconButton(
                                   icon: const Icon(Icons.delete,
                                       color: Colors.red),

--- a/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
@@ -131,6 +131,31 @@ class SubscribedPlansScreen extends StatelessWidget {
                     'invitedUsers': FieldValue.arrayRemove([userId])
                   });
 
+                  try {
+                    final userDoc = await FirebaseFirestore.instance
+                        .collection('users')
+                        .doc(userId)
+                        .get();
+                    final String leaverName =
+                        userDoc.data()?['name'] ?? 'Usuario';
+                    final String leaverPhoto =
+                        userDoc.data()?['photoUrl'] ?? '';
+
+                    await FirebaseFirestore.instance
+                        .collection('notifications')
+                        .add({
+                      'type': 'plan_left',
+                      'receiverId': plan.createdBy,
+                      'senderId': userId,
+                      'senderName': leaverName,
+                      'senderProfilePic': leaverPhoto,
+                      'planId': plan.id,
+                      'planType': plan.type,
+                      'timestamp': FieldValue.serverTimestamp(),
+                      'read': false,
+                    });
+                  } catch (_) {}
+
                   ScaffoldMessenger.of(context).showSnackBar(
                     SnackBar(
                       content: Text('Has abandonado el plan ${plan.type}.'),


### PR DESCRIPTION
## Summary
- notify plan creator when a participant leaves
- handle new `plan_left` notification type in the app
- support new push notification title

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run build` *(fails: missing module type declarations)*


------
https://chatgpt.com/codex/tasks/task_e_684d573df12c8332b4b1399c82891549