### PR TITLE
Implement back button behavior

### DIFF
--- a/app_src/lib/explore_screen/main_screen/explore_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/explore_screen.dart
@@ -503,6 +503,27 @@ class ExploreScreenState extends State<ExploreScreen> {
     }
   }
 
+  Future<bool> _handleBackPress() async {
+    if (Navigator.of(context).canPop()) {
+      return true;
+    }
+
+    if (isMenuOpen) {
+      _menuKey.currentState?.toggleMenu();
+      return false;
+    }
+
+    if (_currentIndex != 0) {
+      setState(() {
+        _currentIndex = 0;
+        _selectedIconIndex = 0;
+      });
+      return false;
+    }
+
+    return true;
+  }
+
   @override
   Widget build(BuildContext context) {
     return AnnotatedRegion<SystemUiOverlayStyle>(
@@ -510,12 +531,14 @@ class ExploreScreenState extends State<ExploreScreen> {
         statusBarColor: Colors.transparent,
         statusBarIconBrightness: Brightness.dark,
       ),
-      child: Scaffold(
-        resizeToAvoidBottomInset: false,
-        body: Container(
-          decoration: const BoxDecoration(
-            gradient: LinearGradient(
-              colors: [
+      child: WillPopScope(
+        onWillPop: _handleBackPress,
+        child: Scaffold(
+          resizeToAvoidBottomInset: false,
+          body: Container(
+            decoration: const BoxDecoration(
+              gradient: LinearGradient(
+                colors: [
                 Color.fromARGB(255, 245, 239, 240),
                 Color.fromARGB(255, 250, 249, 251),
               ],


### PR DESCRIPTION
## Summary
- intercept hardware back button on ExploreScreen
- close the sidebar or return to home when back is pressed

## Testing
- `dart format lib/explore_screen/main_screen/explore_screen.dart` *(fails: `dart: command not found`)*
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684d6d26b6e48332943e5501f3569d31