### PR TITLE
Añade insignias de privilegio en tarjetas

### DIFF
--- a/app_src/lib/explore_screen/plans_managing/plan_card.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_card.dart
@@ -632,11 +632,12 @@ class PlanCardState extends State<PlanCard> {
                         ),
                       ),
                       const SizedBox(width: 4),
-                      SvgPicture.asset(
-                        'assets/verificado.svg',
+                      Image.asset(
+                        _getPrivilegeIcon(
+                            widget.userData['privilegeLevel']?.toString() ??
+                                'Básico'),
                         width: 14,
                         height: 14,
-                        color: Colors.blueAccent,
                       ),
                     ],
                   ),
@@ -659,6 +660,20 @@ class PlanCardState extends State<PlanCard> {
   String _truncate(String text, int maxChars) {
     if (text.length <= maxChars) return text;
     return text.substring(0, math.min(maxChars, text.length)) + '…';
+  }
+
+  String _getPrivilegeIcon(String level) {
+    final normalized = level.toLowerCase().replaceAll('á', 'a');
+    switch (normalized) {
+      case 'premium':
+        return 'assets/icono-usuario-premium.png';
+      case 'golden':
+        return 'assets/icono-usuario-golden.png';
+      case 'vip':
+        return 'assets/icono-usuario-vip.png';
+      default:
+        return 'assets/icono-usuario-basico.png';
+    }
   }
 
   // ─────────────────────────────────────────────────────────────

--- a/app_src/lib/explore_screen/users_grid/users_grid.dart
+++ b/app_src/lib/explore_screen/users_grid/users_grid.dart
@@ -351,11 +351,12 @@ class _UsersGridState extends State<UsersGrid> {
                                     ),
                                   ),
                                   const SizedBox(width: 4),
-                                  SvgPicture.asset(
-                                    'assets/verificado.svg',
+                                  Image.asset(
+                                    _getPrivilegeIcon(
+                                        userData['privilegeLevel']?.toString() ??
+                                            'Básico'),
                                     width: 14,
                                     height: 14,
-                                    color: Colors.blueAccent,
                                   ),
                                 ],
                               ),
@@ -485,5 +486,19 @@ class _UsersGridState extends State<UsersGrid> {
         ),
       ),
     );
+  }
+
+  String _getPrivilegeIcon(String level) {
+    final normalized = level.toLowerCase().replaceAll('á', 'a');
+    switch (normalized) {
+      case 'premium':
+        return 'assets/icono-usuario-premium.png';
+      case 'golden':
+        return 'assets/icono-usuario-golden.png';
+      case 'vip':
+        return 'assets/icono-usuario-vip.png';
+      default:
+        return 'assets/icono-usuario-basico.png';
+    }
   }
 }


### PR DESCRIPTION
## Summary
- sustituye el icono de verificado por el de nivel de privilegio en `UsersGrid`
- muestra la insignia del creador en `PlanCard`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d708e71a88332bde6cd144c05a15a