### PR TITLE
Enable per-user notifications by default

### DIFF
--- a/app_src/lib/explore_screen/chats/chat_screen.dart
+++ b/app_src/lib/explore_screen/chats/chat_screen.dart
@@ -61,7 +61,8 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
   bool _localeInitialized = false;
 
   // Para notificaciones en este chat (manejo local, sin persistir)
-  bool _notificationsEnabled = false;
+  // Por defecto se encuentran habilitadas hasta que el usuario decida lo contrario
+  bool _notificationsEnabled = true;
 
   // Para saber si yo tengo bloqueado a mi chatPartner
   bool _isPartnerBlocked = false;

--- a/app_src/lib/explore_screen/users_managing/user_info_check.dart
+++ b/app_src/lib/explore_screen/users_managing/user_info_check.dart
@@ -69,7 +69,8 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
 
   // Otras banderas
   bool isFollowing = false;
-  bool _notificationsEnabled = false;
+  // Por defecto las notificaciones individuales están activadas
+  bool _notificationsEnabled = true;
   bool _isRequestPending = false;
 
   // Future para cargar todo


### PR DESCRIPTION
## Summary
- ensure chat and profile notifications start enabled

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d7815685c83328d644107014574d2