### PR TITLE
Add removed_from_plan notifications

### DIFF
--- a/app_src/functions/src/index.ts
+++ b/app_src/functions/src/index.ts
@@ -20,6 +20,7 @@ const titles: Record<string, string> = {
   plan_chat_message: "Nuevo comentario",
   welcome: "Bienvenido a Plan",
   plan_left: "Participante ha abandonado",
+  removed_from_plan: "Eliminado del plan",
 };
 
 export const sendPushOnNotification = onDocumentCreated(

--- a/app_src/lib/explore_screen/main_screen/notification_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/notification_screen.dart
@@ -45,6 +45,7 @@ class _NotificationScreenState extends State<NotificationScreen> {
       'plan_chat_message',
       'welcome',
       'plan_left',
+      'removed_from_plan',
     ]).snapshots();
   }
 
@@ -818,6 +819,22 @@ class _NotificationScreenState extends State<NotificationScreen> {
                                 leading: leadingAvatar,
                                 title: Text(
                                   "$senderName ha decidido abandonar tu plan.",
+                                ),
+                                subtitle: buildSubtitle("Plan: $planType"),
+                                isThreeLine: true,
+                                onTap: () => _showPlanDetails(context, planId),
+                                trailing: IconButton(
+                                  icon: const Icon(Icons.delete,
+                                      color: Colors.red),
+                                  onPressed: () =>
+                                      _handleDeleteNotification(doc),
+                                ),
+                              );
+                            case 'removed_from_plan':
+                              return ListTile(
+                                leading: leadingAvatar,
+                                title: Text(
+                                  "$senderName te ha eliminado de su plan.",
                                 ),
                                 subtitle: buildSubtitle("Plan: $planType"),
                                 isThreeLine: true,

--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -929,6 +929,29 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
       for (final d in q.docs) {
         await d.reference.delete();
       }
+
+      final currentUser = FirebaseAuth.instance.currentUser;
+      if (currentUser != null) {
+        final creatorDoc = await FirebaseFirestore.instance
+            .collection('users')
+            .doc(currentUser.uid)
+            .get();
+        final senderName = creatorDoc.data()?['name'] ?? '';
+        final senderPhoto = creatorDoc.data()?['photoUrl'] ?? '';
+        final planType = widget.plan.type.isNotEmpty ? widget.plan.type : 'Plan';
+
+        await FirebaseFirestore.instance.collection('notifications').add({
+          'type': 'removed_from_plan',
+          'receiverId': uid,
+          'senderId': currentUser.uid,
+          'planId': widget.plan.id,
+          'planType': planType,
+          'senderProfilePic': senderPhoto,
+          'senderName': senderName,
+          'timestamp': FieldValue.serverTimestamp(),
+          'read': false,
+        });
+      }
     } catch (e) {
     }
   }

--- a/app_src/lib/explore_screen/plans_managing/plan_card.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_card.dart
@@ -272,6 +272,29 @@ class PlanCardState extends State<PlanCard> {
       for (final d in q.docs) {
         await d.reference.delete();
       }
+
+      final currentUser = FirebaseAuth.instance.currentUser;
+      if (currentUser != null) {
+        final creatorDoc = await FirebaseFirestore.instance
+            .collection('users')
+            .doc(currentUser.uid)
+            .get();
+        final senderName = creatorDoc.data()?['name'] ?? '';
+        final senderPhoto = creatorDoc.data()?['photoUrl'] ?? '';
+        final planType = widget.plan.type.isNotEmpty ? widget.plan.type : 'Plan';
+
+        await FirebaseFirestore.instance.collection('notifications').add({
+          'type': 'removed_from_plan',
+          'receiverId': uid,
+          'senderId': currentUser.uid,
+          'planId': widget.plan.id,
+          'planType': planType,
+          'senderProfilePic': senderPhoto,
+          'senderName': senderName,
+          'timestamp': FieldValue.serverTimestamp(),
+          'read': false,
+        });
+      }
     } catch (e) {
     }
   }


### PR DESCRIPTION
## Summary
- send `removed_from_plan` notification when a user is kicked from a plan
- display notification in `NotificationScreen`
- include new type in Cloud Functions push titles

## Testing
- `flutter test` *(fails: command not found)*
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d7aa8b91883328610e6bd23cce228