### PR TITLE
Adjust subscriptions permissions

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -65,13 +65,21 @@ service cloud.firestore {
         && request.auth.uid == resource.data.blockerId;
     }
 
+    function isPlanCreator(planId) {
+      return request.auth != null
+        && get(/databases/$(database)/documents/plans/$(planId)).data.createdBy ==
+          request.auth.uid;
+    }
+
     match /subscriptions/{docId} {
       allow create: if request.auth != null
         && (request.auth.uid == request.resource.data.userId
-            || request.auth.uid == request.resource.data.createdBy);
+            || request.auth.uid == request.resource.data.createdBy
+            || isPlanCreator(request.resource.data.id));
       allow read, update, delete: if request.auth != null
         && (request.auth.uid == resource.data.userId
-            || request.auth.uid == resource.data.createdBy);
+            || request.auth.uid == resource.data.createdBy
+            || isPlanCreator(resource.data.id));
     }
 
     match /reports/{docId} {


### PR DESCRIPTION
## Summary
- expand `/subscriptions` permissions so plan owners always have access

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d961b45c083328bcbc0c09ca53734