### PR TITLE
Fix cleanup trigger to use v1 auth

### DIFF
--- a/app_src/functions/src/index.ts
+++ b/app_src/functions/src/index.ts
@@ -4,7 +4,7 @@ import {getFirestore, FieldValue} from "firebase-admin/firestore";
 
 import {onDocumentCreated, onDocumentWritten} from "firebase-functions/v2/firestore";
 
-import {onUserDeleted} from "firebase-functions/v2/identity";
+import * as functions from "firebase-functions/v1";
 
 initializeApp();
 
@@ -85,18 +85,18 @@ export const sendPushOnNotification = onDocumentCreated(
   }
 );
 
-export const cleanupUserData = onUserDeleted(
-  {region: "europe-west1"},
-  async (event) => {
-    const uid = event.data.uid;
+export const cleanupUserData = functions
+  .region("europe-west1")
+  .auth.user()
+  .onDelete(async (user) => {
+    const uid = user.uid;
     const db = getFirestore();
     try {
       await db.doc(`users/${uid}`).delete();
     } catch (e) {
       console.error("Failed to clean user data", e);
     }
-  }
-);
+  });
 
 export const sendPushOnMessage = onDocumentCreated(
   {region: "europe-west1", document: "/messages/{id}"},


### PR DESCRIPTION
## Summary
- switch cleanup user function to use v1 auth trigger

## Testing
- `npm run lint --silent` *(fails: ESLint couldn't find configuration file)*
- `npm run build --silent` *(fails: cannot find module declarations)*


------
https://chatgpt.com/codex/tasks/task_e_684d98f8d6708332aaeeadd2d06f5928