### PR TITLE
Fix participant removal notifications

### DIFF
--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -918,9 +918,12 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
   Future<void> _removeParticipant(String uid) async {
     try {
       await FirebaseFirestore.instance.collection('plans').doc(widget.plan.id).update({
-        'participants': FieldValue.arrayRemove([uid])
+        'participants': FieldValue.arrayRemove([uid]),
+        'removedParticipants': FieldValue.arrayUnion([uid])
       });
+    } catch (e) {}
 
+    try {
       final q = await FirebaseFirestore.instance
           .collection('subscriptions')
           .where('id', isEqualTo: widget.plan.id)
@@ -929,7 +932,9 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
       for (final d in q.docs) {
         await d.reference.delete();
       }
+    } catch (e) {}
 
+    try {
       final currentUser = FirebaseAuth.instance.currentUser;
       if (currentUser != null) {
         final creatorDoc = await FirebaseFirestore.instance
@@ -953,8 +958,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
           'read': false,
         });
       }
-    } catch (e) {
-    }
+    } catch (e) {}
   }
 
   Widget _buildParticipantsCorner(List<Map<String, dynamic>> participants) {

--- a/app_src/lib/explore_screen/plans_managing/plan_card.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_card.dart
@@ -261,9 +261,12 @@ class PlanCardState extends State<PlanCard> {
   Future<void> _removeParticipant(String uid) async {
     try {
       await FirebaseFirestore.instance.collection('plans').doc(widget.plan.id).update({
-        'participants': FieldValue.arrayRemove([uid])
+        'participants': FieldValue.arrayRemove([uid]),
+        'removedParticipants': FieldValue.arrayUnion([uid])
       });
+    } catch (e) {}
 
+    try {
       final q = await FirebaseFirestore.instance
           .collection('subscriptions')
           .where('id', isEqualTo: widget.plan.id)
@@ -272,7 +275,9 @@ class PlanCardState extends State<PlanCard> {
       for (final d in q.docs) {
         await d.reference.delete();
       }
+    } catch (e) {}
 
+    try {
       final currentUser = FirebaseAuth.instance.currentUser;
       if (currentUser != null) {
         final creatorDoc = await FirebaseFirestore.instance
@@ -296,8 +301,7 @@ class PlanCardState extends State<PlanCard> {
           'read': false,
         });
       }
-    } catch (e) {
-    }
+    } catch (e) {}
   }
 
   // ─────────────────────────────────────────────────────────────

--- a/app_src/lib/models/plan_model.dart
+++ b/app_src/lib/models/plan_model.dart
@@ -32,6 +32,7 @@ class PlanModel {
   String? visibility;
   String? iconAsset;
   List<String>? participants;
+  List<String>? removedParticipants;
   List<String>? invitedUsers;
   int likes;
   int special_plan;
@@ -78,6 +79,7 @@ class PlanModel {
     this.visibility,
     this.iconAsset,
     this.participants,
+    this.removedParticipants,
     this.likes = 0,
     this.special_plan = 0,
     this.views = 0,
@@ -138,6 +140,7 @@ class PlanModel {
       'visibility': visibility,
       'iconAsset': iconAsset,
       'participants': participants ?? [],
+      'removedParticipants': removedParticipants ?? [],
       'invitedUsers': invitedUsers ?? [],
       'likes': likes,
       'special_plan': special_plan,
@@ -185,6 +188,9 @@ class PlanModel {
       iconAsset: map['iconAsset'],
       participants: map['participants'] != null
           ? List<String>.from(map['participants'] as List)
+          : <String>[],
+      removedParticipants: map['removedParticipants'] != null
+          ? List<String>.from(map['removedParticipants'] as List)
           : <String>[],
       invitedUsers: map['invitedUsers'] != null
           ? List<String>.from(map['invitedUsers'] as List)
@@ -312,6 +318,7 @@ class PlanModel {
       visibility: visibility,
       iconAsset: iconAsset,
       participants: [],
+      removedParticipants: [],
       invitedUsers: [],
       likes: 0,
       special_plan: special_plan,

--- a/firestore.rules
+++ b/firestore.rules
@@ -16,7 +16,7 @@ service cloud.firestore {
       allow update, delete: if request.auth.uid == resource.data.createdBy
         || ((request.auth.uid in resource.data.invitedUsers
             || request.auth.uid in resource.data.participants)
-            && request.resource.data.diff(resource.data).changedKeys().hasOnly(['participants', 'invitedUsers']));
+            && request.resource.data.diff(resource.data).changedKeys().hasOnly(['participants', 'invitedUsers', 'removedParticipants']));
     }
 
     match /notifications/{id} {


### PR DESCRIPTION
## Summary
- track removed participants in PlanModel
- send notification even if deleting subscriptions fails
- include `removedParticipants` in plan updates
- allow updating `removedParticipants` in Firestore rules

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_684d9b3076cc833293db0e575980c6d7