### PR TITLE
Fix special plan date and avatars

### DIFF
--- a/app_src/lib/explore_screen/menu_side_bar/my_plans_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/my_plans_screen.dart
@@ -31,6 +31,8 @@ class MyPlansScreen extends StatelessWidget {
 
     final data = doc.data()!;
     final participantUids = List<String>.from(data['participants'] ?? []);
+    final Set<String> processed = {};
+
     for (String uid in participantUids) {
       final userDoc =
           await FirebaseFirestore.instance.collection('users').doc(uid).get();
@@ -43,8 +45,27 @@ class MyPlansScreen extends StatelessWidget {
           'photoUrl': uData['photoUrl'] ?? uData['profilePic'] ?? '',
           'isCreator': (plan.createdBy == uid),
         });
+        processed.add(uid);
       }
     }
+
+    if (!processed.contains(plan.createdBy)) {
+      final creatorDoc = await FirebaseFirestore.instance
+          .collection('users')
+          .doc(plan.createdBy)
+          .get();
+      if (creatorDoc.exists && creatorDoc.data() != null) {
+        final cData = creatorDoc.data()!;
+        participants.add({
+          'uid': plan.createdBy,
+          'name': cData['name'] ?? 'Sin nombre',
+          'age': cData['age']?.toString() ?? '',
+          'photoUrl': cData['photoUrl'] ?? cData['profilePic'] ?? '',
+          'isCreator': true,
+        });
+      }
+    }
+
     return participants;
   }
 

--- a/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
@@ -52,6 +52,8 @@ class SubscribedPlansScreen extends StatelessWidget {
 
     final planData = planDoc.data()!;
     final participantUids = List<String>.from(planData['participants'] ?? []);
+    final Set<String> processed = {};
+
     for (String uid in participantUids) {
       final userDoc =
           await FirebaseFirestore.instance.collection('users').doc(uid).get();
@@ -64,8 +66,27 @@ class SubscribedPlansScreen extends StatelessWidget {
           'photoUrl': uData['photoUrl'] ?? uData['profilePic'] ?? '',
           'isCreator': (plan.createdBy == uid),
         });
+        processed.add(uid);
       }
     }
+
+    if (!processed.contains(plan.createdBy)) {
+      final creatorDoc = await FirebaseFirestore.instance
+          .collection('users')
+          .doc(plan.createdBy)
+          .get();
+      if (creatorDoc.exists && creatorDoc.data() != null) {
+        final cData = creatorDoc.data()!;
+        participants.add({
+          'uid': plan.createdBy,
+          'name': cData['name'] ?? 'Sin nombre',
+          'age': cData['age']?.toString() ?? '',
+          'photoUrl': cData['photoUrl'] ?? cData['profilePic'] ?? '',
+          'isCreator': true,
+        });
+      }
+    }
+
     return participants;
   }
 

--- a/app_src/lib/explore_screen/special_plans/invite_users_to_plan_screen.dart
+++ b/app_src/lib/explore_screen/special_plans/invite_users_to_plan_screen.dart
@@ -1254,7 +1254,7 @@ class _NewPlanInviteContentState extends State<_NewPlanInviteContent> {
         "location": _location ?? '',
         "latitude": _latitude ?? 0.0,
         "longitude": _longitude ?? 0.0,
-        "date": dateTime.toIso8601String(),
+        "start_timestamp": Timestamp.fromDate(dateTime),
         "createdAt": DateTime.now().toIso8601String(),
         "privateInvite": true,
         "invitedUsers": [widget.invitedUserId],

--- a/app_src/lib/models/plan_model.dart
+++ b/app_src/lib/models/plan_model.dart
@@ -175,10 +175,10 @@ class PlanModel {
       longitude: _parseDouble(map['longitude']),
       startTimestamp: map['start_timestamp'] != null
           ? (map['start_timestamp'] as Timestamp).toDate()
-          : null,
+          : _parseDate(map['date']),
       finishTimestamp: map['finish_timestamp'] != null
           ? (map['finish_timestamp'] as Timestamp).toDate()
-          : null,
+          : _parseDate(map['finish_date']),
       createdBy: map['createdBy'] ?? '',
       creatorName: map['creatorName'],
       creatorProfilePic: map['creatorProfilePic'],


### PR DESCRIPTION
## Summary
- store special plan start time in the standard `start_timestamp` field
- support legacy `date` key when creating `PlanModel`
- include the plan creator in the participant avatar list for special plans

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de046ada88332adc74070c054fcdb