### PR TITLE
Unify special plan UI with standard cards

### DIFF
--- a/app_src/lib/explore_screen/main_screen/notification_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/notification_screen.dart
@@ -355,32 +355,7 @@ class _NotificationScreenState extends State<NotificationScreen> {
     final planData = planDoc.data() as Map<String, dynamic>;
     final plan = PlanModel.fromMap(planData);
 
-    if (plan.special_plan == 1) {
-      final participants = await _fetchAllPlanParticipants(plan);
-      Navigator.push(
-        context,
-        MaterialPageRoute(
-          builder: (_) => Scaffold(
-            backgroundColor: const ui.Color.fromARGB(255, 255, 255, 255),
-            appBar: AppBar(
-              title: const Text("Detalle del Plan"),
-              backgroundColor: const ui.Color.fromARGB(221, 255, 255, 255),
-            ),
-            body: SingleChildScrollView(
-              child: Column(
-                children: [
-                  GestureDetector(
-                    onTap: () => _openFrostedPlanDialog(context, plan),
-                    child: _buildSpecialPlanContainer(plan, participants),
-                  ),
-                  const SizedBox(height: 24),
-                ],
-              ),
-            ),
-          ),
-        ),
-      );
-    } else {
+    {
       // Obtenemos el "userData" del creador, para pasárselo a PlanCard
       final creatorDoc =
           await _firestore.collection('users').doc(plan.createdBy).get();
@@ -402,7 +377,7 @@ class _NotificationScreenState extends State<NotificationScreen> {
                   PlanCard(
                     plan: plan,
                     userData: creatorData,
-                    fetchParticipants: fetchPlanParticipants,
+                    fetchParticipants: _fetchAllPlanParticipants,
                   ),
                   const SizedBox(height: 24),
                 ],
@@ -990,73 +965,6 @@ class _NotificationScreenState extends State<NotificationScreen> {
 
     return participants;
   }
-  Widget _buildSpecialPlanContainer(
-    PlanModel plan,
-    List<Map<String, dynamic>> participants,
-  ) {
-    String iconPath = plan.iconAsset ?? '';
-    for (var item in plansData.plans) {
-      if (plan.iconAsset == item['icon']) {
-        iconPath = item['icon'];
-        break;
-      }
-    }
-
-    final String dateText = plan.formattedDate(plan.startTimestamp);
-
-    return Center(
-      child: Container(
-        width: double.infinity,
-        constraints: const BoxConstraints(minHeight: 80),
-        margin: const EdgeInsets.only(bottom: 15, left: 8, right: 8),
-        padding: const EdgeInsets.all(20),
-        decoration: BoxDecoration(
-          gradient: const LinearGradient(
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            colors: [
-              Color.fromARGB(255, 13, 32, 53),
-              Color.fromARGB(255, 72, 38, 38),
-              Color(0xFF12232E),
-            ],
-          ),
-          borderRadius: BorderRadius.circular(60),
-        ),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                if (iconPath.isNotEmpty)
-                  SvgPicture.asset(
-                    iconPath,
-                    width: 40,
-                    height: 40,
-                    color: Colors.amber,
-                  ),
-                const SizedBox(width: 8),
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      plan.type,
-                      style: const TextStyle(
-                        fontSize: 20,
-                        color: Colors.amber,
-                      ),
-                    ),
-                    Text(
-                      dateText,
-                      style: const TextStyle(
-                        color: Colors.white,
-                      ),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-            const Spacer(),
             _buildOverlappingAvatars(
               participants,
               FirebaseAuth.instance.currentUser?.uid ?? '',

--- a/app_src/lib/explore_screen/menu_side_bar/my_plans_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/my_plans_screen.dart
@@ -160,157 +160,40 @@ class MyPlansScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildPlanTile(BuildContext context, PlanModel plan) {
-    if (plan.special_plan == 1) {
-      // Plan especial
-      return FutureBuilder<List<Map<String, dynamic>>>(
-        future: _fetchAllPlanParticipants(plan),
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return _buildSpecialPlanLoading();
-          }
-          if (snapshot.hasError) {
-            return Center(
-              child: Text('Error al cargar participantes: ${snapshot.error}'),
-            );
-          }
-          final participants = snapshot.data ?? [];
-
-          String iconPath = plan.iconAsset ?? '';
-          for (var item in plansData.plans) {
-            if (plan.iconAsset == item['icon']) {
-              iconPath = item['icon'];
-              break;
-            }
-          }
 
 
-          final String dateText =
-              plan.formattedDate(plan.startTimestamp);
+Widget _buildPlanTile(BuildContext context, PlanModel plan) {
+  return FutureBuilder<DocumentSnapshot>(
+    future: FirebaseFirestore.instance
+        .collection('users')
+        .doc(FirebaseAuth.instance.currentUser!.uid)
+        .get(),
+    builder: (ctx, snap) {
+      if (snap.connectionState == ConnectionState.waiting) {
+        return const SizedBox(
+          height: 330,
+          child: Center(child: CircularProgressIndicator()),
+        );
+      }
+      if (!snap.hasData || !snap.data!.exists) {
+        final fallbackData = {
+          'name': 'Tú',
+          'handle': '@creador',
+          'photoUrl': '',
+        };
+        return _buildMyPlanCard(context, plan, fallbackData);
+      }
+      final data = snap.data!.data() as Map<String, dynamic>;
+      final userData = {
+        'name': data['name'] ?? 'Tú',
+        'handle': data['handle'] ?? '@creador',
 
-          return GestureDetector(
-            onTap: () => _openFrostedPlanDialog(context, plan),
-            child: Center(
-              child: Container(
-                width: double.infinity,
-                constraints: const BoxConstraints(minHeight: 80),
-                margin: const EdgeInsets.only(
-                  bottom: 15,
-                  left: 8,
-                  right: 8,
-                ),
-                padding: const EdgeInsets.all(20),
-                decoration: BoxDecoration(
-                  gradient: const LinearGradient(
-                    begin: Alignment.topLeft,
-                    end: Alignment.bottomRight,
-                    colors: [
-                      Color.fromARGB(255, 13, 32, 53),
-                      Color.fromARGB(255, 72, 38, 38),
-                      Color(0xFF12232E),
-                    ],
-                  ),
-                  borderRadius: BorderRadius.circular(60),
-                ),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        if (iconPath.isNotEmpty)
-                          SvgPicture.asset(
-                            iconPath,
-                            width: 40,
-                            height: 40,
-                            color: Colors.amber,
-                          ),
-                        const SizedBox(width: 8),
-                        Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              plan.type,
-                              style: const TextStyle(
-                                fontSize: 20,
-                                color: Colors.amber,
-                              ),
-                            ),
-                            Text(
-                              dateText,
-                              style: const TextStyle(
-                                color: Colors.white,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
-                    const Spacer(),
-                    _buildOverlappingAvatars(
-                      participants,
-                      FirebaseAuth.instance.currentUser?.uid ?? '',
-                    ),
-                    const SizedBox(width: 12),
-                    GestureDetector(
-                      onTap: () => _confirmDeletePlan(context, plan),
-                      child: ClipOval(
-                        child: BackdropFilter(
-                          filter: ui.ImageFilter.blur(sigmaX: 7.5, sigmaY: 7.5),
-                          child: Container(
-                            width: 40,
-                            height: 40,
-                            decoration: BoxDecoration(
-                              color: Colors.red.withOpacity(0.3),
-                              shape: BoxShape.circle,
-                            ),
-                            child:
-                                const Icon(Icons.delete, color: Colors.white),
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          );
-        },
-      );
-    } else {
-      // Plan normal
-      return FutureBuilder<DocumentSnapshot>(
-        future: FirebaseFirestore.instance
-            .collection('users')
-            .doc(FirebaseAuth.instance.currentUser!.uid)
-            .get(),
-        builder: (ctx, snap) {
-          if (snap.connectionState == ConnectionState.waiting) {
-            return const SizedBox(
-              height: 330,
-              child: Center(child: CircularProgressIndicator()),
-            );
-          }
-          if (!snap.hasData || !snap.data!.exists) {
-            final fallbackData = {
-              'name': 'Tú',
-              'handle': '@creador',
-              'photoUrl': '',
-            };
-            return _buildMyPlanCard(context, plan, fallbackData);
-          }
-          final data = snap.data!.data() as Map<String, dynamic>;
-          final userData = {
-            'name': data['name'] ?? 'Tú',
-            'handle': data['handle'] ?? '@creador',
-            'photoUrl': data['photoUrl'] ?? '',
-          };
-          return _buildMyPlanCard(context, plan, userData);
-        },
-      );
-    }
-  }
-
+        'photoUrl': data['photoUrl'] ?? '',
+      };
+      return _buildMyPlanCard(context, plan, userData);
+    },
+  );
+}
   Widget _buildMyPlanCard(
     BuildContext context,
     PlanModel plan,
@@ -525,23 +408,6 @@ class MyPlansScreen extends StatelessWidget {
             fetchParticipants: _fetchAllPlanParticipants,
           ),
         ),
-      ),
-    );
-  }
-
-  Widget _buildSpecialPlanLoading() {
-    return Center(
-      child: Container(
-        width: 300,
-        height: 100,
-        margin: const EdgeInsets.only(bottom: 15),
-        padding: const EdgeInsets.all(20),
-        decoration: BoxDecoration(
-          color: Colors.blue.withOpacity(0.1),
-          borderRadius: BorderRadius.circular(20),
-          border: Border.all(color: Colors.blueAccent, width: 2),
-        ),
-        child: const Center(child: CircularProgressIndicator()),
       ),
     );
   }

--- a/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
@@ -245,169 +245,45 @@ class SubscribedPlansScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildPlanTile(
     BuildContext context,
     Map<String, dynamic> userData,
     PlanModel plan,
   ) {
-    if (plan.special_plan == 1) {
-      return FutureBuilder<List<Map<String, dynamic>>>(
-        future: _fetchAllPlanParticipants(plan),
-        builder: (context, snapshot) {
-          if (!snapshot.hasData) {
-            return Center(
-              child: Container(
-                width: MediaQuery.of(context).size.width * 0.95,
-                height: 100,
-                margin: const EdgeInsets.only(bottom: 15),
-                padding: const EdgeInsets.all(20),
-                decoration: BoxDecoration(
-                  color: Colors.blue.withOpacity(0.1),
-                  borderRadius: BorderRadius.circular(20),
-                  border: Border.all(color: Colors.blueAccent, width: 2),
-                ),
-                child: const Center(child: CircularProgressIndicator()),
-              ),
-            );
-          }
-          final participants = snapshot.data!;
-
-          String iconPath = plan.iconAsset ?? '';
-          for (var item in plansData.plans) {
-            if (plan.iconAsset == item['icon']) {
-              iconPath = item['icon'];
-              break;
-            }
-          }
-
-          final String dateText =
-              plan.formattedDate(plan.startTimestamp);
-
-          return GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            onTap: () => _showFrostedPlanDialog(context, plan),
-                child: Center(
-                  child: Container(
-                    width: MediaQuery.of(context).size.width * 0.95,
-                    constraints: const BoxConstraints(minHeight: 80),
-                margin: const EdgeInsets.only(bottom: 15),
-                padding: const EdgeInsets.all(20),
-                decoration: BoxDecoration(
-                  gradient: const LinearGradient(
-                    begin: Alignment.topLeft,
-                    end: Alignment.bottomRight,
-                    colors: [
-                      Color.fromARGB(255, 13, 32, 53),
-                      Color.fromARGB(255, 72, 38, 38),
-                      Color(0xFF12232E),
-                    ],
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        PlanCard(
+          plan: plan,
+          userData: userData,
+          fetchParticipants: _fetchAllPlanParticipants,
+          hideJoinButton: true,
+        ),
+        Positioned(
+          top: 14,
+          right: 12,
+          child: GestureDetector(
+            onTap: () => _confirmDeletePlan(context, plan),
+            child: ClipOval(
+              child: BackdropFilter(
+                filter: ui.ImageFilter.blur(sigmaX: 7.5, sigmaY: 7.5),
+                child: Container(
+                  width: 40,
+                  height: 40,
+                  decoration: BoxDecoration(
+                    color: Colors.red.withOpacity(0.3),
+                    shape: BoxShape.circle,
                   ),
-                  borderRadius: BorderRadius.circular(60),
-                ),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        if (iconPath.isNotEmpty)
-                          SvgPicture.asset(
-                            iconPath,
-                            width: 40,
-                            height: 40,
-                            color: Colors.amber,
-                          ),
-                        const SizedBox(width: 8),
-                        Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              plan.type,
-                              style: const TextStyle(
-                                fontSize: 20,
-                                color: Colors.amber,
-                              ),
-                            ),
-                            Text(
-                              dateText,
-                              style: const TextStyle(
-                                color: Colors.white,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
-                    const Spacer(),
-                    _buildOverlappingAvatars(
-                      participants,
-                      userId,
-                    ),
-                    const SizedBox(width: 12),
-                    GestureDetector(
-                      onTap: () => _confirmDeletePlan(context, plan),
-                      child: ClipOval(
-                        child: BackdropFilter(
-                          filter: ui.ImageFilter.blur(sigmaX: 7.5, sigmaY: 7.5),
-                          child: Container(
-                            width: 40,
-                            height: 40,
-                            decoration: BoxDecoration(
-                              color: Colors.red.withOpacity(0.3),
-                              shape: BoxShape.circle,
-                            ),
-                            child: const Icon(
-                              Icons.exit_to_app,
-                              color: Colors.white,
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          );
-        },
-      );
-    } else {
-      return Stack(
-        clipBehavior: Clip.none,
-        children: [
-          PlanCard(
-            plan: plan,
-            userData: userData,
-            fetchParticipants: _fetchAllPlanParticipants,
-            hideJoinButton: true,
-          ),
-          Positioned(
-            top: 14,
-            right: 12,
-            child: GestureDetector(
-              onTap: () => _confirmDeletePlan(context, plan),
-              child: ClipOval(
-                child: BackdropFilter(
-                  filter: ui.ImageFilter.blur(sigmaX: 7.5, sigmaY: 7.5),
-                  child: Container(
-                    width: 40,
-                    height: 40,
-                    decoration: BoxDecoration(
-                      color: Colors.red.withOpacity(0.3),
-                      shape: BoxShape.circle,
-                    ),
-                    child: const Icon(
-                      Icons.exit_to_app,
-                      color: Colors.white,
-                    ),
+                  child: const Icon(
+                    Icons.exit_to_app,
+                    color: Colors.white,
                   ),
                 ),
               ),
             ),
           ),
-        ],
-      );
-    }
+        ),
+      ],
+    );
   }
 
   @override

--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -1457,59 +1457,10 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                 child: Column(
                   children: [
                     _buildHeaderRow(),
-                    if (plan.special_plan != 1)
-                      _buildMediaSection(
-                        plan,
-                        allParts,
-                        isUserCreator: isUserCreator,
-                      )
-                    else
-                      const SizedBox(height: 10),
-                    Center(
-                      child: Container(
-                        width: MediaQuery.of(context).size.width * 0.95,
-                        margin: const EdgeInsets.symmetric(vertical: 12),
-                        child: ClipRRect(
-                          borderRadius: BorderRadius.circular(24),
-                          child: BackdropFilter(
-                            filter: ui.ImageFilter.blur(sigmaX: 12, sigmaY: 12),
-                            child: Container(
-                              decoration: BoxDecoration(
-                                borderRadius: BorderRadius.circular(24),
-                                border: Border.all(
-                                  color: Colors.white.withOpacity(0.2),
-                                  width: 1,
-                                ),
-                              ),
-                              padding: const EdgeInsets.all(16),
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Center(
-                                    child: Text(
-                                      plan.type,
-                                      style: const TextStyle(
-                                        color: Colors.amber,
-                                        fontSize: 20,
-                                        fontWeight: FontWeight.bold,
-                                      ),
-                                    ),
-                                  ),
-                                  const SizedBox(height: 12),
-                                  Text(
-                                    plan.description,
-                                    style: const TextStyle(
-                                      color: Colors.white,
-                                      fontSize: 14,
-                                      height: 1.3,
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
+                    _buildMediaSection(
+                      plan,
+                      allParts,
+                      isUserCreator: isUserCreator,
                     ),
                     _buildLocationArea(plan),
                     const SizedBox(height: 16),


### PR DESCRIPTION
## Summary
- display all plans using `PlanCard`
- allow background image when creating invited plans
- show plan media for every plan type
- simplify notification details view

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ec1d36374833299aaab2c015ad6bd