### PR TITLE
Fix compile errors in subscribed and invite screens

### DIFF
--- a/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
@@ -245,6 +245,7 @@ class SubscribedPlansScreen extends StatelessWidget {
     );
   }
 
+  Widget _buildPlanTile(
     BuildContext context,
     Map<String, dynamic> userData,
     PlanModel plan,

--- a/app_src/lib/explore_screen/special_plans/invite_users_to_plan_screen.dart
+++ b/app_src/lib/explore_screen/special_plans/invite_users_to_plan_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:ui' as ui;
 import 'dart:async';
+import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';


### PR DESCRIPTION
## Summary
- arreglar la definición del método `_buildPlanTile`
- importar `dart:typed_data` en `invite_users_to_plan_screen.dart`

## Testing
- `flutter analyze` *(falló: comando no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_684ec95b671483329fe7c75e6b528c21