### PR TITLE
Evitar notificaciones duplicadas

### DIFF
--- a/app_src/functions/src/index.ts
+++ b/app_src/functions/src/index.ts
@@ -168,65 +168,9 @@ export const sendPushOnMessage = onDocumentCreated(
   }
 );
 
-export const sendPushOnPlanChat = onDocumentCreated(
-  {region: "europe-west1", document: "/plan_chat/{id}"},
-  async (event: CreatedEvent) => {
-    const m = event.data?.data();
-    if (!m) return;
 
-    const db = getFirestore();
-    const planSnap = await db.doc(`plans/${m.planId}`).get();
-    if (!planSnap.exists) return;
-    const planData = planSnap.data();
-    if (!planData) return;
-
-    const participants: string[] = planData.participants ?? [];
-    const creatorId: string = planData.createdBy;
-    const senderSnap = await db.doc(`users/${m.senderId}`).get();
-    const senderName: string = senderSnap.get("name") ?? "";
-
-    const targets = new Set<string>(participants);
-    targets.add(creatorId);
-    targets.delete(m.senderId);
-
-    for (const uid of Array.from(targets)) {
-      const userSnap = await db.doc(`users/${uid}`).get();
-      const tokens: string[] = userSnap.get("tokens") ?? [];
-      if (tokens.length === 0) continue;
-
-      const resp = await getMessaging().sendEachForMulticast({
-        tokens,
-        notification: {
-          title: "Nuevo comentario",
-          body: `${senderName} comentó en ${planData.type}`,
-        },
-        android: {notification: {channelId: "plan_high"}},
-        data: {
-          type: "plan_chat_message",
-          planId: m.planId ?? "",
-          senderId: m.senderId ?? "",
-        },
-      });
-
-      const invalid: string[] = [];
-      resp.responses.forEach((r, i) => {
-        if (
-          !r.success &&
-          r.error?.code ===
-            "messaging/registration-token-not-registered"
-        ) {
-          invalid.push(tokens[i]);
-        }
-      });
-
-      if (invalid.length) {
-        await userSnap.ref.update({
-          tokens: FieldValue.arrayRemove(...invalid),
-        });
-      }
-    }
-  }
-);
+// Eliminado para evitar notificaciones duplicadas al comentar en un plan.
+// Las notificaciones de comentarios se manejan mediante `sendPushOnNotification`.
 
 export const notifyRemovedParticipants = onDocumentWritten(
   {region: "europe-west1", document: "/plans/{planId}"},


### PR DESCRIPTION
## Summary
- eliminar el envío de push directo al crear mensajes en `plan_chat`

## Testing
- `flutter test` *(falló: comando no encontrado)*
- `npm run lint` *(falló: ESLint no configurado)*

------
https://chatgpt.com/codex/tasks/task_e_684ecb7fc5a08332843f57948b20603a