### PR TITLE
Fix plan comments counter

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -16,7 +16,7 @@ service cloud.firestore {
       allow update, delete: if request.auth.uid == resource.data.createdBy
         || ((request.auth.uid in resource.data.invitedUsers
             || request.auth.uid in resource.data.participants)
-            && request.resource.data.diff(resource.data).changedKeys().hasOnly(['participants', 'invitedUsers', 'removedParticipants']));
+            && request.resource.data.diff(resource.data).changedKeys().hasOnly(['participants', 'invitedUsers', 'removedParticipants', 'commentsCount']));
     }
 
     match /notifications/{id} {


### PR DESCRIPTION
## Summary
- allow usuarios participantes modificar el campo `commentsCount` en documentos de `plans`.

## Testing
- `npm --prefix app_src/functions run lint` *(falla: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_684ecefd9f98833282298c222a5c34db