### PR TITLE
Add custom interest input with separator

### DIFF
--- a/app_src/lib/start/registration/user_registration_screen.dart
+++ b/app_src/lib/start/registration/user_registration_screen.dart
@@ -862,6 +862,31 @@ class _UserRegistrationScreenState extends State<UserRegistrationScreen> {
                     ],
                   ),
                   const SizedBox(height: 10),
+                  const Center(child: Text('- o -')),
+                  const SizedBox(height: 10),
+                  Container(
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      border: Border.all(
+                        color: MyColors.AppColors.greyBorder,
+                        width: 1,
+                      ),
+                      borderRadius: BorderRadius.circular(30),
+                    ),
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: TextField(
+                      controller: _interestController,
+                      style: const TextStyle(color: Colors.grey),
+                      decoration: InputDecoration(
+                        hintText: 'Añádelos tú...',
+                        hintStyle: TextStyle(
+                          color: Colors.grey,
+                        ),
+                        border: InputBorder.none,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 10),
                   Row(
                     children: [
                       Expanded(


### PR DESCRIPTION
## Summary
- display a separator `- o -` before the custom plan field
- add an input box for custom plans with placeholder "Añádelos tú..."

## Testing
- `dart format app_src/lib/start/registration/user_registration_screen.dart` *(fails: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ecff8f5d483329768cfba427dda8d