### PR TITLE
Desactivar check-in en planes especiales

### DIFF
--- a/app_src/lib/explore_screen/plans_managing/attendance_managing.dart
+++ b/app_src/lib/explore_screen/plans_managing/attendance_managing.dart
@@ -22,6 +22,9 @@ class AttendanceManaging {
     final planRef = FirebaseFirestore.instance.collection('plans').doc(planId);
     final randomCode = _generateRandomCode(6);
 
+    final planDoc = await planRef.get();
+    if (planDoc.data()?['special_plan'] == 1) return;
+
     await planRef.set({
       'checkInActive': true,
       'checkInCode': randomCode,
@@ -32,6 +35,8 @@ class AttendanceManaging {
   /// Finaliza el check-in de un plan (desactiva la bandera en Firestore).
   static Future<void> finalizeCheckIn(String planId) async {
     final planRef = FirebaseFirestore.instance.collection('plans').doc(planId);
+    final planDoc = await planRef.get();
+    if (planDoc.data()?['special_plan'] == 1) return;
     await planRef.set({
       'checkInActive': false,
     }, SetOptions(merge: true));
@@ -43,6 +48,8 @@ class AttendanceManaging {
   static Future<void> rotateCheckInCode(String planId) async {
     final planRef = FirebaseFirestore.instance.collection('plans').doc(planId);
     final randomCode = _generateRandomCode(6);
+    final planDoc = await planRef.get();
+    if (planDoc.data()?['special_plan'] == 1) return;
     await planRef.set({
       'checkInCode': randomCode,
       'checkInCodeTimestamp': FieldValue.serverTimestamp(),
@@ -53,6 +60,8 @@ class AttendanceManaging {
   /// - Se añade su uid a "checkedInUsers" en el documento del plan.
   static Future<void> confirmAttendance(String planId, String uid) async {
     final planRef = FirebaseFirestore.instance.collection('plans').doc(planId);
+    final planDoc = await planRef.get();
+    if (planDoc.data()?['special_plan'] == 1) return;
     await planRef.update({
       'checkedInUsers': FieldValue.arrayUnion([uid]),
     });
@@ -65,6 +74,8 @@ class AttendanceManaging {
     final planRef = FirebaseFirestore.instance.collection('plans').doc(planId);
     final doc = await planRef.get();
     if (!doc.exists) return false;
+
+    if (doc.data()?['special_plan'] == 1) return false;
 
     final data = doc.data()!;
     final currentCode = data['checkInCode'] ?? '';

--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -1054,14 +1054,16 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
   Future<void> _showParticipantsModal(
       List<Map<String, dynamic>> participants) async {
     List checkedInUsers = [];
-    try {
-      final planSnap = await FirebaseFirestore.instance
-          .collection('plans')
-          .doc(widget.plan.id)
-          .get();
-      final planData = planSnap.data();
-      checkedInUsers = planData?['checkedInUsers'] ?? [];
-    } catch (e) {
+    if (widget.plan.special_plan != 1) {
+      try {
+        final planSnap = await FirebaseFirestore.instance
+            .collection('plans')
+            .doc(widget.plan.id)
+            .get();
+        final planData = planSnap.data();
+        checkedInUsers = planData?['checkedInUsers'] ?? [];
+      } catch (e) {
+      }
     }
 
     showDialog(
@@ -1144,7 +1146,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                             fontWeight: FontWeight.bold,
                           ),
                         ),
-                        trailing: isCheckedIn
+                        trailing: (widget.plan.special_plan != 1 && isCheckedIn)
                             ? Container(
                                 padding: const EdgeInsets.symmetric(
                                     horizontal: 8, vertical: 4),
@@ -1483,6 +1485,9 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
     List<Map<String, dynamic>> participants,
     bool isCreator,
   ) {
+    if (plan.special_plan == 1) {
+      return const SizedBox.shrink();
+    }
     final bool isParticipant =
         participants.any((p) => p['uid'] == _currentUser?.uid);
 

--- a/app_src/lib/explore_screen/plans_managing/plan_card.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_card.dart
@@ -797,16 +797,18 @@ class PlanCardState extends State<PlanCard> {
   Future<void> _showParticipantsModal(
     List<Map<String, dynamic>> participants,
   ) async {
-    // Revisamos quién ha hecho check-in
+    // Revisamos quién ha hecho check-in (solo planes generales)
     List checkedInUsers = [];
-    try {
-      final planSnap = await FirebaseFirestore.instance
-          .collection('plans')
-          .doc(widget.plan.id)
-          .get();
-      final planData = planSnap.data();
-      checkedInUsers = planData?['checkedInUsers'] ?? [];
-    } catch (e) {
+    if (widget.plan.special_plan != 1) {
+      try {
+        final planSnap = await FirebaseFirestore.instance
+            .collection('plans')
+            .doc(widget.plan.id)
+            .get();
+        final planData = planSnap.data();
+        checkedInUsers = planData?['checkedInUsers'] ?? [];
+      } catch (e) {
+      }
     }
 
     showDialog(
@@ -894,7 +896,7 @@ class PlanCardState extends State<PlanCard> {
                             fontWeight: FontWeight.bold,
                           ),
                         ),
-                        trailing: isCheckedIn
+                        trailing: (widget.plan.special_plan != 1 && isCheckedIn)
                             ? Container(
                                 padding: const EdgeInsets.symmetric(
                                     horizontal: 8, vertical: 4),


### PR DESCRIPTION
## Summary
- evitar inicio de check-in en planes especiales
- omitir UI de check-in en `FrostedPlanDialog` y en las listas de participantes
- mostrar marca de "ASISTE" solo en planes generales

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart format lib` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f03bb36d0833283d558842258fd41