### PR TITLE
Fix overflow issues for high text scaling

### DIFF
--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -975,7 +975,15 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                 backgroundColor: Colors.blueGrey[400],
               ),
               const SizedBox(width: 8),
-              Text(displayText, style: const TextStyle(color: Colors.white)),
+              FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Text(
+                  displayText,
+                  style: const TextStyle(color: Colors.white),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
             ],
           ),
         ),

--- a/app_src/lib/explore_screen/plans_managing/plan_card.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_card.dart
@@ -715,7 +715,15 @@ class PlanCardState extends State<PlanCard> {
                 backgroundColor: Colors.blueGrey[400],
               ),
               const SizedBox(width: 8),
-              Text(displayText, style: const TextStyle(color: Colors.white)),
+              FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Text(
+                  displayText,
+                  style: const TextStyle(color: Colors.white),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
             ],
           ),
         ),

--- a/app_src/lib/explore_screen/users_managing/user_info_check.dart
+++ b/app_src/lib/explore_screen/users_managing/user_info_check.dart
@@ -825,8 +825,10 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
   // Botones principales: Invitar, Mensaje, Seguir
   //----------------------------------------------------------------------------
   Widget _buildActionButtons(String otherUserId) {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
+    return Wrap(
+      alignment: WrapAlignment.center,
+      spacing: 12,
+      runSpacing: 12,
       children: [
         _buildActionButton(
           iconPath: 'assets/union.svg',
@@ -835,7 +837,6 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
               ? _showPrivateToast
               : () => InviteUsersToPlanScreen.showPopup(context, otherUserId),
         ),
-        const SizedBox(width: 12),
         _buildActionButton(
           iconPath: 'assets/mensaje.svg',
           label: 'Enviar Mensaje',
@@ -858,7 +859,6 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
             }
           },
         ),
-        const SizedBox(width: 12),
         _buildActionButton(
           iconPath: _getFollowIcon(),
           label: _getFollowLabel(),


### PR DESCRIPTION
## Summary
- avoid overflow in profile action buttons using `Wrap`
- clamp participant info text with `FittedBox` to keep it inside card and dialog when scaling

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_684f1151b1e88332a84ee648ecd4b947