### PR TITLE
Fix layout overflow on large text scale

### DIFF
--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -1397,9 +1397,11 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
       },
       child: Padding(
         padding: const EdgeInsets.all(16.0),
-        child: Row(
-          children: [
-            CircleAvatar(
+        child: Builder(
+          builder: (context) {
+            final textScale = MediaQuery.of(context).textScaleFactor;
+
+            final avatar = CircleAvatar(
               radius: 20,
               backgroundColor: Colors.blueGrey[400],
               child: ClipOval(
@@ -1418,9 +1420,9 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                       )
                     : const Icon(Icons.person, color: Colors.white),
               ),
-            ),
-            const SizedBox(width: 8),
-            Expanded(
+            );
+
+            final nameWidget = Expanded(
               child: Text(
                 age.isNotEmpty ? '$name, $age' : name,
                 style: const TextStyle(
@@ -1430,12 +1432,28 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                 ),
                 overflow: TextOverflow.ellipsis,
               ),
-            ),
-            IconButton(
+            );
+
+            final backBtn = IconButton(
               icon: const Icon(Icons.arrow_back_rounded, color: Colors.white),
               onPressed: () => Navigator.pop(context),
-            ),
-          ],
+            );
+
+            if (textScale <= 1.2) {
+              return Row(
+                children: [avatar, const SizedBox(width: 8), nameWidget, backBtn],
+              );
+            }
+
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Row(children: [avatar, const SizedBox(width: 8), nameWidget]),
+                const SizedBox(height: 8),
+                Align(alignment: Alignment.centerRight, child: backBtn),
+              ],
+            );
+          },
         ),
       ),
     );

--- a/app_src/lib/explore_screen/plans_managing/plan_card.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_card.dart
@@ -324,25 +324,42 @@ class PlanCardState extends State<PlanCard> {
         // Header
         Padding(
           padding: const EdgeInsets.all(8.0),
-          child: Row(
-            children: [
-              const SizedBox(width: 48),
-              const Expanded(
-                child: Text(
-                  "Chat del Plan",
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    color: AppColors.planColor,
-                    fontSize: 18,
-                    fontWeight: FontWeight.bold,
-                  ),
+          child: Builder(
+            builder: (context) {
+              final textScale = MediaQuery.of(context).textScaleFactor;
+
+              final title = const Text(
+                "Chat del Plan",
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: AppColors.planColor,
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
                 ),
-              ),
-              IconButton(
+              );
+              final closeBtn = IconButton(
                 icon: const Icon(Icons.close, color: AppColors.planColor),
                 onPressed: () => Navigator.pop(context),
-              ),
-            ],
+              );
+
+              if (textScale <= 1.2) {
+                return Row(
+                  children: [
+                    const SizedBox(width: 48),
+                    const Expanded(child: title),
+                    closeBtn,
+                  ],
+                );
+              }
+
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Row(children: [const SizedBox(width: 48), Expanded(child: title)]),
+                  Align(alignment: Alignment.centerRight, child: closeBtn),
+                ],
+              );
+            },
           ),
         ),
         const Divider(color: AppColors.planColor),
@@ -1174,9 +1191,12 @@ class PlanCardState extends State<PlanCard> {
                   // Fila superior (creador + botón unirse)
                   Padding(
                     padding: const EdgeInsets.fromLTRB(10, 8, 10, 8),
-                    child: Row(
-                      children: [
-                        GestureDetector(
+                    child: Builder(
+                      builder: (context) {
+                        final textScale =
+                            MediaQuery.of(context).textScaleFactor;
+
+                        final creator = GestureDetector(
                           onTap: () async {
                             final creatorUid = plan.createdBy;
                             final currentUid =
@@ -1188,10 +1208,27 @@ class PlanCardState extends State<PlanCard> {
                             }
                           },
                           child: _buildCreatorFrosted(name, fallbackPhotoUrl),
-                        ),
-                        const Spacer(),
-                        _buildJoinFrosted(),
-                      ],
+                        );
+                        final joinButton = _buildJoinFrosted();
+
+                        if (textScale <= 1.2) {
+                          return Row(
+                            children: [creator, const Spacer(), joinButton],
+                          );
+                        }
+
+                        return Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            Row(children: [creator]),
+                            const SizedBox(height: 8),
+                            Align(
+                              alignment: Alignment.centerRight,
+                              child: joinButton,
+                            ),
+                          ],
+                        );
+                      },
                     ),
                   ),
 


### PR DESCRIPTION
## Summary
- ensure the join button and creator info wrap correctly in `PlanCard`
- avoid overflow in `PlanCard` chat popup header
- wrap the header row in `FrostedPlanDialog` when text zoom is high

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68507745328c8332bc5990b6eb570a60