### PR TITLE
Fix layout overflow on large text scale

### DIFF
--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -1340,36 +1340,19 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
         pageIndicator,
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-          child: Builder(
-            builder: (context) {
-              final textScale = MediaQuery.of(context).textScaleFactor;
-
-              final actions = Expanded(
-                child: SingleChildScrollView(
+          child: FittedBox(
+            fit: BoxFit.scaleDown,
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                SingleChildScrollView(
                   scrollDirection: Axis.horizontal,
                   child: _buildActionButtonsRow(plan),
                 ),
-              );
-              final corner = _buildParticipantsCorner(participants);
-
-              if (textScale <= 1.2) {
-                return Row(
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [actions, const SizedBox(width: 8), corner],
-                );
-              }
-
-              return Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Row(
-                    children: [actions],
-                  ),
-                  const SizedBox(height: 8),
-                  Align(alignment: Alignment.centerRight, child: corner),
-                ],
-              );
-            },
+                const SizedBox(width: 8),
+                _buildParticipantsCorner(participants),
+              ],
+            ),
           ),
         ),
         if (!isUserCreator)
@@ -1397,9 +1380,11 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
       },
       child: Padding(
         padding: const EdgeInsets.all(16.0),
-        child: Row(
-          children: [
-            CircleAvatar(
+        child: FittedBox(
+          fit: BoxFit.scaleDown,
+          child: Row(
+            children: [
+              CircleAvatar(
               radius: 20,
               backgroundColor: Colors.blueGrey[400],
               child: ClipOval(
@@ -1418,24 +1403,26 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                       )
                     : const Icon(Icons.person, color: Colors.white),
               ),
-            ),
-            const SizedBox(width: 8),
-            Expanded(
-              child: Text(
-                age.isNotEmpty ? '$name, $age' : name,
-                style: const TextStyle(
-                  color: Colors.white,
-                  fontWeight: FontWeight.bold,
-                  fontSize: 14,
-                ),
-                overflow: TextOverflow.ellipsis,
               ),
             ),
-            IconButton(
-              icon: const Icon(Icons.arrow_back_rounded, color: Colors.white),
-              onPressed: () => Navigator.pop(context),
-            ),
-          ],
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  age.isNotEmpty ? '$name, $age' : name,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                    fontSize: 14,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.arrow_back_rounded, color: Colors.white),
+                onPressed: () => Navigator.pop(context),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/app_src/lib/explore_screen/plans_managing/plan_card.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_card.dart
@@ -324,11 +324,12 @@ class PlanCardState extends State<PlanCard> {
         // Header
         Padding(
           padding: const EdgeInsets.all(8.0),
-          child: Row(
-            children: [
-              const SizedBox(width: 48),
-              const Expanded(
-                child: Text(
+          child: FittedBox(
+            fit: BoxFit.scaleDown,
+            child: Row(
+              children: [
+                const SizedBox(width: 48),
+                const Text(
                   "Chat del Plan",
                   textAlign: TextAlign.center,
                   style: TextStyle(
@@ -337,12 +338,12 @@ class PlanCardState extends State<PlanCard> {
                     fontWeight: FontWeight.bold,
                   ),
                 ),
-              ),
-              IconButton(
-                icon: const Icon(Icons.close, color: AppColors.planColor),
-                onPressed: () => Navigator.pop(context),
-              ),
-            ],
+                IconButton(
+                  icon: const Icon(Icons.close, color: AppColors.planColor),
+                  onPressed: () => Navigator.pop(context),
+                ),
+              ],
+            ),
           ),
         ),
         const Divider(color: AppColors.planColor),
@@ -1174,24 +1175,27 @@ class PlanCardState extends State<PlanCard> {
                   // Fila superior (creador + botón unirse)
                   Padding(
                     padding: const EdgeInsets.fromLTRB(10, 8, 10, 8),
-                    child: Row(
-                      children: [
-                        GestureDetector(
-                          onTap: () async {
-                            final creatorUid = plan.createdBy;
-                            final currentUid =
-                                FirebaseAuth.instance.currentUser?.uid;
-                            if (creatorUid.isNotEmpty &&
-                                creatorUid != currentUid) {
-                              await UserInfoCheck.open(context, creatorUid);
-                              if (mounted) setState(() {});
-                            }
-                          },
-                          child: _buildCreatorFrosted(name, fallbackPhotoUrl),
-                        ),
-                        const Spacer(),
-                        _buildJoinFrosted(),
-                      ],
+                    child: FittedBox(
+                      fit: BoxFit.scaleDown,
+                      child: Row(
+                        children: [
+                          GestureDetector(
+                            onTap: () async {
+                              final creatorUid = plan.createdBy;
+                              final currentUid =
+                                  FirebaseAuth.instance.currentUser?.uid;
+                              if (creatorUid.isNotEmpty &&
+                                  creatorUid != currentUid) {
+                                await UserInfoCheck.open(context, creatorUid);
+                                if (mounted) setState(() {});
+                              }
+                            },
+                            child: _buildCreatorFrosted(name, fallbackPhotoUrl),
+                          ),
+                          const Spacer(),
+                          _buildJoinFrosted(),
+                        ],
+                      ),
                     ),
                   ),
 
@@ -1229,18 +1233,20 @@ class PlanCardState extends State<PlanCard> {
                       top: 8,
                       bottom: 8,
                     ),
-                    child: Builder(
-                      builder: (context) {
-                        final textScale = MediaQuery.of(context).textScaleFactor;
-                        final actions = SingleChildScrollView(
-                          scrollDirection: Axis.horizontal,
-                          child: Row(
-                            children: [
-                              _buildFrostedAction(
-                                iconPath: 'assets/corazon.svg',
-                                countText: '$_likeCount',
-                                onTap: _toggleLike,
-                                iconColor: _liked ? Colors.red : Colors.white,
+                    child: FittedBox(
+                      fit: BoxFit.scaleDown,
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          SingleChildScrollView(
+                            scrollDirection: Axis.horizontal,
+                            child: Row(
+                              children: [
+                                _buildFrostedAction(
+                                  iconPath: 'assets/corazon.svg',
+                                  countText: '$_likeCount',
+                                  onTap: _toggleLike,
+                                  iconColor: _liked ? Colors.red : Colors.white,
                               ),
                               const SizedBox(width: 8),
                               StreamBuilder<DocumentSnapshot>(
@@ -1306,28 +1312,13 @@ class PlanCardState extends State<PlanCard> {
                                   );
                                 },
                               ),
-                            ],
+                              ],
+                            ),
                           ),
-                        );
-
-                        final corner = _buildParticipantsCorner();
-
-                        if (textScale <= 1.2) {
-                          return Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [actions, corner],
-                          );
-                        }
-
-                        return Column(
-                          crossAxisAlignment: CrossAxisAlignment.stretch,
-                          children: [
-                            actions,
-                            const SizedBox(height: 8),
-                            Align(alignment: Alignment.centerRight, child: corner),
-                          ],
-                        );
-                      },
+                          const SizedBox(width: 8),
+                          _buildParticipantsCorner(),
+                        ],
+                      ),
                     ),
                   ),
 


### PR DESCRIPTION
## Summary
- use `FittedBox` to keep the plan chat header on one line
- wrap creator row and action buttons with `FittedBox` to avoid overflow
- apply the same fix to `FrostedPlanDialogState`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68507745328c8332bc5990b6eb570a60