### PR TITLE
Fix overflow when text scale is large

### DIFF
--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -379,7 +379,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
         child: BackdropFilter(
           filter: ui.ImageFilter.blur(sigmaX: 7.5, sigmaY: 7.5),
           child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
             decoration: BoxDecoration(
               color: Colors.black.withOpacity(0.2),
               borderRadius: BorderRadius.circular(30),
@@ -389,14 +389,14 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
               children: [
                 SvgPicture.asset(
                   iconPath,
-                  width: 20,
-                  height: 20,
+                  width: 24,
+                  height: 24,
                   color: iconColor,
                 ),
-                const SizedBox(width: 4),
+                const SizedBox(width: 6),
                 Text(
                   countText,
-                  style: const TextStyle(color: Colors.white, fontSize: 14),
+                  style: const TextStyle(color: Colors.white, fontSize: 16),
                 ),
               ],
             ),
@@ -569,15 +569,29 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
   }
 
   Widget _buildActionButtonsRow(PlanModel plan) {
-    return Row(
-      mainAxisSize: MainAxisSize.min,
+    final textScale = MediaQuery.of(context).textScaleFactor;
+
+    final buttons = <Widget>[
+      _buildLikeButton(),
+      const SizedBox(width: 12),
+      _buildMessageButton(plan),
+      const SizedBox(width: 12),
+      _buildShareButton(plan),
+      const SizedBox(width: 12),
+      _buildViewButton(plan),
+    ];
+
+    if (textScale <= 1.3) {
+      return Row(mainAxisSize: MainAxisSize.min, children: buttons);
+    }
+
+    return Wrap(
+      spacing: 12,
+      runSpacing: 8,
       children: [
         _buildLikeButton(),
-        const SizedBox(width: 8),
         _buildMessageButton(plan),
-        const SizedBox(width: 8),
         _buildShareButton(plan),
-        const SizedBox(width: 8),
         _buildViewButton(plan),
       ],
     );
@@ -960,34 +974,39 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
         displayText = '${displayText.substring(0, cut)}...';
       }
 
+      final maxWidth = MediaQuery.of(context).size.width * 0.55;
+
       return GestureDetector(
         onTap: () async {
           await _showParticipantsModal(participants);
           if (mounted) setState(() {});
         },
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-          decoration: BoxDecoration(
-            color: Colors.black54,
-            borderRadius: BorderRadius.circular(20),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              CircleAvatar(
-                radius: 16,
-                backgroundImage: pic.isNotEmpty ? NetworkImage(pic) : null,
-                backgroundColor: Colors.blueGrey[400],
-              ),
-              const SizedBox(width: 8),
-              Flexible(
-                child: Text(
-                  displayText,
-                  style: const TextStyle(color: Colors.white),
-                  overflow: TextOverflow.ellipsis,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(maxWidth: maxWidth),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            decoration: BoxDecoration(
+              color: Colors.black54,
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                CircleAvatar(
+                  radius: 16,
+                  backgroundImage: pic.isNotEmpty ? NetworkImage(pic) : null,
+                  backgroundColor: Colors.blueGrey[400],
                 ),
-              ),
-            ],
+                const SizedBox(width: 8),
+                Flexible(
+                  child: Text(
+                    displayText,
+                    style: const TextStyle(color: Colors.white),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       );
@@ -1358,8 +1377,11 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
 
               if (textScale <= 1.2) {
                 return Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [actionsRow, corner],
+                  children: [
+                    Expanded(child: actionsRow),
+                    const SizedBox(width: 8),
+                    Flexible(child: corner),
+                  ],
                 );
               }
 

--- a/app_src/lib/explore_screen/plans_managing/plan_card.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_card.dart
@@ -703,31 +703,36 @@ class PlanCardState extends State<PlanCard> {
       String displayText = '$name, $age';
       displayText = _truncate(displayText, maxChars);
 
+      final maxWidth = MediaQuery.of(context).size.width * 0.55;
+
       return GestureDetector(
         onTap: () => _showParticipantsModal(_participants),
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-          decoration: BoxDecoration(
-            color: Colors.black54,
-            borderRadius: BorderRadius.circular(20),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              CircleAvatar(
-                radius: 16,
-                backgroundImage: pic.isNotEmpty ? NetworkImage(pic) : null,
-                backgroundColor: Colors.blueGrey[400],
-              ),
-              const SizedBox(width: 8),
-              Flexible(
-                child: Text(
-                  displayText,
-                  style: const TextStyle(color: Colors.white),
-                  overflow: TextOverflow.ellipsis,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(maxWidth: maxWidth),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+            decoration: BoxDecoration(
+              color: Colors.black54,
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                CircleAvatar(
+                  radius: 16,
+                  backgroundImage: pic.isNotEmpty ? NetworkImage(pic) : null,
+                  backgroundColor: Colors.blueGrey[400],
                 ),
-              ),
-            ],
+                const SizedBox(width: 8),
+                Flexible(
+                  child: Text(
+                    displayText,
+                    style: const TextStyle(color: Colors.white),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       );
@@ -1078,7 +1083,7 @@ class PlanCardState extends State<PlanCard> {
         child: BackdropFilter(
           filter: ui.ImageFilter.blur(sigmaX: 7.5, sigmaY: 7.5),
           child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
             decoration: BoxDecoration(
               color: Colors.black.withOpacity(0.25),
               borderRadius: BorderRadius.circular(30),
@@ -1088,14 +1093,14 @@ class PlanCardState extends State<PlanCard> {
               children: [
                 SvgPicture.asset(
                   iconPath,
-                  width: 20,
-                  height: 20,
+                  width: 24,
+                  height: 24,
                   color: iconColor,
                 ),
-                const SizedBox(width: 4),
+                const SizedBox(width: 6),
                 Text(
                   countText,
-                  style: const TextStyle(color: Colors.white, fontSize: 14),
+                  style: const TextStyle(color: Colors.white, fontSize: 16),
                 ),
               ],
             ),
@@ -1309,18 +1314,24 @@ class PlanCardState extends State<PlanCard> {
 
                         return textScale <= 1.2
                             ? Row(
-                                mainAxisAlignment:
-                                    MainAxisAlignment.spaceBetween,
-                                children: [actions, corner],
+                                children: [
+                                  Expanded(child: actions),
+                                  const SizedBox(width: 8),
+                                  Flexible(child: corner),
+                                ],
                               )
                             : Column(
                                 crossAxisAlignment: CrossAxisAlignment.stretch,
                                 children: [
-                                  actions,
+                                  Align(
+                                    alignment: Alignment.centerLeft,
+                                    child: actions,
+                                  ),
                                   const SizedBox(height: 8),
                                   Align(
-                                      alignment: Alignment.centerRight,
-                                      child: corner),
+                                    alignment: Alignment.centerRight,
+                                    child: corner,
+                                  ),
                                 ],
                               );
                       },


### PR DESCRIPTION
## Summary
- make PlanCard action icons larger
- expand FrostedPlanDialog action icons
- keep actions in a single row until text scale is large

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685187d851a88332a17ec0b2e0776844