### PR TITLE
Mostrar checkbox de recordar inicio sesión en login

### DIFF
--- a/app_src/lib/start/login/login_screen.dart
+++ b/app_src/lib/start/login/login_screen.dart
@@ -517,10 +517,8 @@ class _LoginScreenState extends State<LoginScreen> {
               ),
             const SizedBox(height: 20),
             _inputField(controller: passwordController, hint: 'Contraseña', obscure: true),
-            if (_isEmail) ...[
-              const SizedBox(height: 10),
-              _rememberCheckbox(),
-            ],
+            const SizedBox(height: 10),
+            _rememberCheckbox(),
             const SizedBox(height: 20),
             SizedBox(
               width: 200,


### PR DESCRIPTION
## Summary
- display the "Recordar datos de inicio de sesión" checkbox when logging in with email or phone

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b74c9b5483329fb4b175debd6cda