### PR TITLE
Adjust privilege popup info

### DIFF
--- a/app_src/lib/explore_screen/profile/profile_screen.dart
+++ b/app_src/lib/explore_screen/profile/profile_screen.dart
@@ -439,7 +439,10 @@ class ProfileScreenState extends State<ProfileScreen> {
             alignment: Alignment.center,
             child: Material(
                 color: Colors.transparent,
-                child: PrivilegeLevelDetails(userId: user.uid)),
+                child: PrivilegeLevelDetails(
+                  userId: user.uid,
+                  showAllInfo: true,
+                )),
           ),
         ),
       ),

--- a/app_src/lib/explore_screen/users_managing/privilege_level_details.dart
+++ b/app_src/lib/explore_screen/users_managing/privilege_level_details.dart
@@ -8,10 +8,12 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 
 class PrivilegeLevelDetails extends StatefulWidget {
   final String userId; // ID del usuario para buscar sus datos en Firestore
+  final bool showAllInfo; // controla si se muestran las indicaciones y las insignias
 
   const PrivilegeLevelDetails({
     Key? key,
     required this.userId,
+    this.showAllInfo = true,
   }) : super(key: key);
 
   // MÉTODO ESTÁTICO para actualizar estadísticas de suscripciones
@@ -637,10 +639,12 @@ class _PrivilegeLevelDetailsState extends State<PrivilegeLevelDetails> {
                       ),
                       const SizedBox(height: 14),
                       _buildIndicatorsRow(),
-                      const SizedBox(height: 12),
-                      _buildNextLevelHint(),
-                      const SizedBox(height: 16),
-                      _buildPrivilegeIconsRow(),
+                      if (widget.showAllInfo) ...[
+                        const SizedBox(height: 12),
+                        _buildNextLevelHint(),
+                        const SizedBox(height: 16),
+                        _buildPrivilegeIconsRow(),
+                      ],
                       const SizedBox(height: 20),
                     ],
                   ),

--- a/app_src/lib/explore_screen/users_managing/user_info_check.dart
+++ b/app_src/lib/explore_screen/users_managing/user_info_check.dart
@@ -642,7 +642,10 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
               alignment: Alignment.center,
               child: Material(
                 color: Colors.transparent,
-                child: PrivilegeLevelDetails(userId: widget.userId),
+                child: PrivilegeLevelDetails(
+                  userId: widget.userId,
+                  showAllInfo: false,
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
## Summary
- allow customizing info shown in privilege popup via `showAllInfo`
- hide hint and badges when viewing privilege popup from other profiles
- keep full info when opened from own profile

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ea66d8948332881d007d391cad12