### PR TITLE
Add Legal Notice page and update privacy and terms

### DIFF
--- a/public/ayuda.html
+++ b/public/ayuda.html
@@ -39,6 +39,7 @@
           <li><a href="index.html#hero">Inicio</a></li>
           <li><a href="index.html#downloadSection">Descargar</a></li>
           <li><a href="help.html">Ayuda</a></li>
+          <li><a href="legal_notice.html">Aviso Legal</a></li>
           <li><a href="privacy_policy.html">Privacidad</a></li>
           <li><a href="terms_and_conditions.html">Condiciones</a></li>
           <li><a href="cookies.html">Cookies</a></li>

--- a/public/cookies.html
+++ b/public/cookies.html
@@ -48,6 +48,7 @@
             <li><a href="index.html#hero">Home</a></li>
             <li><a href="index.html#downloadSection">Download</a></li>
             <li><a href="help.html">Help</a></li>
+              <li><a href="legal_notice.html">Legal Notice</a></li>
             <li><a href="privacy_policy.html">Privacy</a></li>
             <li><a href="terms_and_conditions.html">Terms</a></li>
             <li><a href="cookies.html">Cookies</a></li>
@@ -98,6 +99,7 @@
             <img class='footer-logo' src='plan-sin-fondo.png' alt='Plan Social'>
             <div class='footer-links'>
                 <a href='help.html'>Help</a>
+                  <a href="legal_notice.html">Legal Notice</a>
                 <a href='privacy_policy.html'>Privacy</a>
                 <a href='terms_and_conditions.html'>Terms</a>
                 <a href='cookies.html'>Cookies</a>
@@ -126,6 +128,7 @@
             <li><a href='index.html#hero'>Inicio</a></li>
             <li><a href='index.html#downloadSection'>Descargar</a></li>
             <li><a href='help.html'>Ayuda</a></li>
+              <li><a href="legal_notice.html">Aviso Legal</a></li>
             <li><a href='privacy_policy.html'>Privacidad</a></li>
             <li><a href='terms_and_conditions.html'>Condiciones</a></li>
             <li><a href='cookies.html'>Cookies</a></li>
@@ -176,6 +179,7 @@
             <img class='footer-logo' src='plan-sin-fondo.png' alt='Plan Social'>
             <div class='footer-links'>
                 <a href='help.html'>Ayuda</a>
+                  <a href="legal_notice.html">Aviso Legal</a>
                 <a href='privacy_policy.html'>Privacidad</a>
                 <a href='terms_and_conditions.html'>Condiciones</a>
                 <a href='cookies.html'>Cookies</a>

--- a/public/help.html
+++ b/public/help.html
@@ -50,6 +50,7 @@
             <li><a href="index.html#hero">Inicio</a></li>
             <li><a href="index.html#downloadSection">Descargar</a></li>
             <li><a href="help.html">Ayuda</a></li>
+              <li><a href="legal_notice.html">Aviso Legal</a></li>
             <li><a href="privacy_policy.html">Privacidad</a></li>
             <li><a href="terms_and_conditions.html">Condiciones</a></li>
             <li><a href="cookies.html">Cookies</a></li>
@@ -134,6 +135,7 @@
       <img class="footer-logo" src="plan-sin-fondo.png" alt="Plan Social">
       <div class="footer-links">
         <a href="help.html">Ayuda</a>
+          <a href="legal_notice.html">Aviso Legal</a>
         <a href="privacy_policy.html">Privacidad</a>
         <a href="terms_and_conditions.html">Condiciones</a>
         <a href="cookies.html">Cookies</a>
@@ -160,6 +162,7 @@
             <li><a href="index.html#hero">Home</a></li>
             <li><a href="index.html#downloadSection">Download</a></li>
             <li><a href="help.html">Help</a></li>
+              <li><a href="legal_notice.html">Legal Notice</a></li>
             <li><a href="privacy_policy.html">Privacy</a></li>
             <li><a href="terms_and_conditions.html">Terms</a></li>
             <li><a href="cookies.html">Cookies</a></li>
@@ -244,6 +247,7 @@
         <img class="footer-logo" src="plan-sin-fondo.png" alt="Plan Social">
         <div class="footer-links">
           <a href="help.html">Help</a>
+            <a href="legal_notice.html">Legal Notice</a>
           <a href="privacy_policy.html">Privacy</a>
           <a href="terms_and_conditions.html">Terms</a>
           <a href="cookies.html">Cookies</a>

--- a/public/index.html
+++ b/public/index.html
@@ -531,6 +531,7 @@
           <li><a href="index.html#hero">Inicio</a></li>
           <li><a href="index.html#downloadSection">Descargar</a></li>
           <li><a href="help.html">Ayuda</a></li>
+            <li><a href="legal_notice.html">Aviso Legal</a></li>
           <li><a href="privacy_policy.html">Privacidad</a></li>
           <li><a href="terms_and_conditions.html">Condiciones</a></li>
           <li><a href="cookies.html">Cookies</a></li>
@@ -597,6 +598,7 @@
       <img class="footer-logo" src="plan-sin-fondo.png" alt="Plan Social">
       <div class="footer-links">
         <a href="help.html">Ayuda</a>
+        <a href="legal_notice.html">Aviso Legal</a>
         <a href="privacy_policy.html">Privacidad</a>
         <a href="terms_and_conditions.html">Condiciones</a>
         <a href="cookies.html">Cookies</a>

--- a/public/legal_notice.html
+++ b/public/legal_notice.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset='utf-8'>
+    <meta name='viewport' content='width=device-width'>
+    <title>Legal Notice</title>
+    <style>
+        body {font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;margin:0;padding:72px 1em 0;}
+        body a{text-decoration:none;color:inherit;}
+        header{position:fixed;top:0;width:100%;height:72px;background:#fff;border-bottom:1px solid #eee;z-index:100;}
+        .nav-container{max-width:1200px;margin:auto;height:100%;display:grid;grid-template-columns:1fr auto 1fr;align-items:center;padding:0 1rem;position:relative;}
+        .nav-logo{margin:0;position:static;justify-self:center;}
+        header .nav-logo img{height:64px;margin-top:4px;}
+        .btn-download{background:#5D17EB;color:#fff;padding:.6rem 1.2rem;border-radius:24px;font-weight:600;transition:background .2s,transform .2s,box-shadow .2s;justify-self:end;box-shadow:0 8px 16px rgba(0,0,0,.15);}
+        .btn-download:hover{background:#4D07DB;transform:translateY(-2px);box-shadow:0 12px 20px rgba(0,0,0,.2);}
+        nav ul{display:flex;gap:1.5rem;list-style:none;}
+        nav ul li a{font-weight:500;color:#fff;transition:color .2s;}
+        nav ul li a:hover,nav ul li a:active,nav ul li a:focus{color:#5D17EB;}
+        .nav-toggle{display:none;background:none;border:none;font-size:1.5rem;cursor:pointer;justify-self:start;}
+        @media(max-width:768px){
+            .nav-toggle{display:block;order:1;}
+            nav ul .nav-close{display:block;position:absolute;top:.5rem;right:.5rem;background:none;border:none;color:#fff;font-size:1.5rem;z-index:101;}
+            .nav-logo{order:2;margin:0;position:static;justify-self:center;}
+            .btn-download{order:3;margin:0;justify-self:end;}
+            nav{order:4;}
+            nav ul{position:fixed;top:72px;left:-100%;width:200px;height:calc(100% - 72px);background:#000;flex-direction:column;align-items:flex-start;padding:3rem 1rem 1rem;gap:1rem;transition:left .3s ease;box-shadow:4px 0 8px rgba(0,0,0,.1);}
+            nav ul.open{left:0;}
+        }
+        .site-footer{background:#000;color:#fff;padding:2rem 1rem;text-align:center;margin-left:-1em;margin-right:-1em;}
+        .footer-container{max-width:1200px;margin:auto;display:flex;flex-direction:column;align-items:center;gap:1rem;}
+        .footer-links{display:flex;gap:1rem;flex-wrap:wrap;align-items:center;}
+        .footer-links a{color:#fff;font-size:.875rem;}
+        .footer-logo{height:40px;}
+        .lang-select{background:#000;color:#fff;border:1px solid #fff;padding:.3rem;}
+        .footer-social{display:flex;flex-direction:column;gap:.5rem;align-items:center;font-size:.875rem;}
+        .social-icon{height:20px;}
+    </style>
+</head>
+<body>
+  <div data-lang="en">
+    <header>
+      <div class="nav-container">
+        <button class="nav-toggle" aria-label="Open menu">☰</button>
+        <div class="nav-logo"><img src="plan-sin-fondo.png" alt="Plan Social"></div>
+        <nav>
+          <ul>
+            <li><button class="nav-close" aria-label="Close menu">×</button></li>
+            <li><a href="index.html#hero">Home</a></li>
+            <li><a href="index.html#downloadSection">Download</a></li>
+            <li><a href="help.html">Help</a></li>
+            <li><a href="legal_notice.html">Legal Notice</a></li>
+            <li><a href="privacy_policy.html">Privacy</a></li>
+            <li><a href="terms_and_conditions.html">Terms</a></li>
+            <li><a href="cookies.html">Cookies</a></li>
+          </ul>
+        </nav>
+        <a href="index.html#downloadSection" class="btn-download">Download</a>
+      </div>
+    </header>
+    <main style="padding:1em;">
+      <h1>Legal Notice</h1>
+      <p><strong>Application Owner:</strong><br>
+      Name: Inan Ilik Ilik<br>
+      Email: soporte@plansocialapp.es<br>
+      Address: Spain</p>
+      <h2>1. Purpose of this notice</h2>
+      <p>This Legal Notice governs access, browsing and use of the Application, as well as the responsibilities derived from the use of its contents.</p>
+      <h2>2. Owner's responsibility</h2>
+      <p>The owner is not responsible for:</p>
+      <ul>
+        <li>The technical quality of access, continuity or availability of the service.</li>
+        <li>The existence of viruses, malware or harmful elements that may affect the user's system.</li>
+        <li>The use that users make of the contents or external links that may appear in the Application.</li>
+      </ul>
+      <p>The owner reserves the right to make modifications without prior notice.</p>
+      <h2>3. Intellectual and industrial property</h2>
+      <p>All elements of the Application are protected by intellectual and industrial property rights. Their reproduction, distribution or transformation is prohibited without express authorization from the owner or rightful holders.</p>
+      <h2>4. Data protection</h2>
+      <p>Personal data processed through the Application are governed by the service's Privacy Policy, in compliance with Regulation (EU) 2016/679 (GDPR) and the Spanish data protection law.</p>
+      <h2>5. Third-party links</h2>
+      <p>The Application may contain links to third-party pages or services. The owner is not responsible for the content, policies or practices of such external sites.</p>
+      <h2>6. Applicable law and jurisdiction</h2>
+      <p>This Legal Notice is governed by Spanish law. For dispute resolution, the provisions regarding applicable jurisdiction shall apply.</p>
+    </main>
+    <footer class="site-footer">
+      <div class="footer-container">
+        <img class="footer-logo" src="plan-sin-fondo.png" alt="Plan Social">
+        <div class="footer-links">
+          <a href="help.html">Help</a>
+          <a href="legal_notice.html">Legal Notice</a>
+          <a href="privacy_policy.html">Privacy</a>
+          <a href="terms_and_conditions.html">Terms</a>
+          <a href="cookies.html">Cookies</a>
+          <select class="lang-select">
+            <option value="es">Español</option>
+            <option value="en">English</option>
+          </select>
+          <div class="footer-social">
+            <div>Follow us on <button onclick="window.open('https://www.instagram.com/plansocialappspain/', '_blank')" style="background:none;border:none;padding:0"><img src="instagram.png" alt="Instagram" class="social-icon"></button> <button onclick="window.open('https://www.linkedin.com/in/plan-social-app-54165536a', '_blank')" style="background:none;border:none;padding:0"><img src="linkedin.png" alt="LinkedIn" class="social-icon"></button></div>
+          </div>
+        </div>
+        <p>© 2025 Plan</p>
+      </div>
+    </footer>
+  </div>
+  <div data-lang="es">
+    <header>
+      <div class="nav-container">
+        <button class="nav-toggle" aria-label="Abrir menú">☰</button>
+        <div class="nav-logo"><img src="plan-sin-fondo.png" alt="Plan Social"></div>
+        <nav>
+          <ul>
+            <li><button class="nav-close" aria-label="Cerrar menú">×</button></li>
+            <li><a href="index.html#hero">Inicio</a></li>
+            <li><a href="index.html#downloadSection">Descargar</a></li>
+            <li><a href="help.html">Ayuda</a></li>
+            <li><a href="legal_notice.html">Aviso Legal</a></li>
+            <li><a href="privacy_policy.html">Privacidad</a></li>
+            <li><a href="terms_and_conditions.html">Condiciones</a></li>
+            <li><a href="cookies.html">Cookies</a></li>
+          </ul>
+        </nav>
+        <a href="index.html#downloadSection" class="btn-download">Descargar</a>
+      </div>
+    </header>
+    <main style="padding:1em;">
+      <h1>Aviso Legal</h1>
+      <p><strong>Titular de la Aplicación:</strong><br>
+      Nombre: Inan Ilik Ilik<br>
+      Correo electrónico: soporte@plansocialapp.es<br>
+      Domicilio: España</p>
+      <h2>1. Objeto del aviso</h2>
+      <p>El presente Aviso Legal regula el acceso, la navegación y el uso de la Aplicación, así como las responsabilidades derivadas del uso de sus contenidos.</p>
+      <h2>2. Responsabilidad del titular</h2>
+      <p>El titular no se responsabiliza de:</p>
+      <ul>
+        <li>La calidad técnica del acceso, continuidad o disponibilidad del servicio.</li>
+        <li>La existencia de virus, malware o elementos dañinos que afecten al sistema del usuario.</li>
+        <li>El uso que los usuarios hagan de los contenidos o enlaces externos que puedan aparecer en la Aplicación.</li>
+      </ul>
+      <p>El titular se reserva el derecho a realizar modificaciones sin previo aviso.</p>
+      <h2>3. Propiedad intelectual e industrial</h2>
+      <p>Todos los elementos que forman parte de la Aplicación están protegidos por derechos de propiedad intelectual e industrial. Queda prohibida su reproducción, distribución o transformación sin autorización expresa del titular o de los legítimos propietarios.</p>
+      <h2>4. Protección de datos</h2>
+      <p>Los datos personales tratados a través de la Aplicación se rigen por la Política de Privacidad del servicio, en cumplimiento del Reglamento (UE) 2016/679 (RGPD) y la Ley Orgánica de protección de datos española.</p>
+      <h2>5. Enlaces a terceros</h2>
+      <p>La Aplicación puede contener enlaces a páginas o servicios de terceros. El titular no se responsabiliza del contenido, políticas ni prácticas de dichos sitios externos.</p>
+      <h2>6. Legislación aplicable y jurisdicción</h2>
+      <p>Este Aviso Legal se rige por la legislación española. Para la resolución de conflictos se estará a lo dispuesto por la normativa en materia de jurisdicción aplicable.</p>
+    </main>
+    <footer class="site-footer">
+      <div class="footer-container">
+        <img class="footer-logo" src="plan-sin-fondo.png" alt="Plan Social">
+        <div class="footer-links">
+          <a href="help.html">Ayuda</a>
+          <a href="legal_notice.html">Aviso Legal</a>
+          <a href="privacy_policy.html">Privacidad</a>
+          <a href="terms_and_conditions.html">Condiciones</a>
+          <a href="cookies.html">Cookies</a>
+          <select class="lang-select">
+            <option value="es">Español</option>
+            <option value="en">English</option>
+          </select>
+          <div class="footer-social">
+            <div>Síguenos en <button onclick="window.open('https://www.instagram.com/plansocialappspain/', '_blank')" style="background:none;border:none;padding:0"><img src="instagram.png" alt="Instagram" class="social-icon"></button> <button onclick="window.open('https://www.linkedin.com/in/plan-social-app-54165536a', '_blank')" style="background:none;border:none;padding:0"><img src="linkedin.png" alt="LinkedIn" class="social-icon"></button></div>
+          </div>
+        </div>
+        <p>© 2025 Plan</p>
+      </div>
+    </footer>
+  </div>
+  <script>
+  (function(){
+    const selects=document.querySelectorAll('.lang-select');
+      function setLang(l){
+        document.documentElement.lang=l;
+        document.querySelectorAll('[data-lang]').forEach(el=>{
+          el.style.display=el.getAttribute('data-lang')===l?'':'none';
+        });
+        selects.forEach(s=>s.value=l);
+      }
+      const initial=((navigator.language||navigator.userLanguage)||'en').startsWith('es')?'es':'en';
+      setLang(initial);
+    selects.forEach(sel=>sel.addEventListener('change',e=>setLang(e.target.value)));
+  })();
+  </script>
+  <script>
+    document.querySelectorAll('.nav-container').forEach(nav=>{
+      const toggle=nav.querySelector('.nav-toggle');
+      const close=nav.querySelector('.nav-close');
+      const list=nav.querySelector('nav ul');
+      toggle.addEventListener('click',()=>list.classList.toggle('open'));
+      close.addEventListener('click',()=>list.classList.remove('open'));
+    });
+  </script>
+</body>
+</html>

--- a/public/privacy_policy.html
+++ b/public/privacy_policy.html
@@ -50,6 +50,7 @@
             <li><a href="index.html#hero">Home</a></li>
             <li><a href="index.html#downloadSection">Download</a></li>
             <li><a href="help.html">Help</a></li>
+              <li><a href="legal_notice.html">Legal Notice</a></li>
             <li><a href="privacy_policy.html">Privacy</a></li>
             <li><a href="terms_and_conditions.html">Terms</a></li>
             <li><a href="cookies.html">Cookies</a></li>
@@ -156,12 +157,71 @@
         Policy now and as amended by us.</p><br><strong>Contact Us</strong>
     <p>If you have any questions regarding privacy while using the Application, or have questions about the practices,
         please contact the Service Provider via email at soporte@plansocialapp.es.</p>
+<h2>1. Data Controller</h2>
+<p>Name: Inan Ilik Ilik<br>Email: soporte.es<br>Address: Spain<br>General purpose: Provide, maintain and improve the Application's services.</p>
+<h2>2. Personal data collected</h2>
+<p>The Application may collect identifying data (name, email, age, phone number, profile image), technical data (IP, device, OS, version, timestamps), location data (approximate or precise with your permission) and usage data.</p>
+<h2>3. Purpose of processing</h2>
+<p>The information is used to operate the Application, personalize the experience, analyze usage, send notifications (with consent), manage your account and ensure legal compliance and security.</p>
+<h2>4. Legal basis</h2>
+<p>The processing is based on your consent, the execution of a contract, compliance with legal obligations and the legitimate interest of the Service Provider.</p>
+<h2>5. Third-party services</h2>
+<p>The Application uses third-party services such as Firebase, Google Play Services, Google Sign-In, Firebase Messaging, Google Maps Platform, Geolocator, Google Fonts, Hostinger and Firebase Hosting. Each provider has its own privacy policy.</p>
+<h2>6. Data disclosure</h2>
+<p>Your data is not sold. It may be shared with service providers under contract, competent authorities, analytics or geolocation services in anonymized form and other users when you publish content.</p>
+<h2>7. User rights</h2>
+<p>You may access, rectify or erase your data, restrict or object to processing, request portability and withdraw consent by contacting soporte.es.</p>
+<h2>8. Data retention</h2>
+<p>Data is kept while you have an active account, as needed for the purposes described and for legal obligations. It will be deleted upon request unless there is a legal duty to keep it.</p>
+<h2>9. Account deletion</h2>
+<p>You can delete your account from the settings or by emailing soporte.es.</p>
+<h2>10. Information security</h2>
+<p>The Service Provider applies technical and organizational measures such as encryption, access controls and secure servers.</p>
+<h2>11. Use by minors</h2>
+<p>The Application is not directed to children under 18. If improper use is detected, contact soporte.es for immediate deletion.</p>
+<h2>12. Cookies</h2>
+<p>The Application or third parties may use cookies or similar technologies with your consent.</p>
+<h2>13. Changes</h2>
+<p>This policy may be updated. Important changes will be notified through the Application.</p>
+<p><strong>Last update:</strong> 26/05/2025</p>
+<h2>14. Contact</h2>
+<p>Email: soporte.es</p>
+<h2>1. Data Controller</h2>
+<p>Name: Inan Ilik Ilik<br>Email: soporte@plansocialapp.es<br>Address: Spain<br>General purpose: Provide, maintain and improve the Application's services.</p>
+<h2>2. Personal data collected</h2>
+<p>The Application may collect identifying data (name, email, age, phone number, profile image), technical data (IP, device, OS, version, timestamps), location data (approximate or precise with your permission) and usage data.</p>
+<h2>3. Purpose of processing</h2>
+<p>The information is used to operate the Application, personalize the experience, analyze usage, send notifications (with consent), manage your account and ensure legal compliance and security.</p>
+<h2>4. Legal basis</h2>
+<p>The processing is based on your consent, the execution of a contract, compliance with legal obligations and the legitimate interest of the Service Provider.</p>
+<h2>5. Third-party services</h2>
+<p>The Application uses third-party services such as Firebase, Google Play Services, Google Sign-In, Firebase Messaging, Google Maps Platform, Geolocator, Google Fonts, Hostinger and Firebase Hosting. Each provider has its own privacy policy.</p>
+<h2>6. Data disclosure</h2>
+<p>Your data is not sold. It may be shared with service providers under contract, competent authorities, analytics or geolocation services in anonymized form and other users when you publish content.</p>
+<h2>7. User rights</h2>
+<p>You may access, rectify or erase your data, restrict or object to processing, request portability and withdraw consent by contacting soporte@plansocialapp.es.</p>
+<h2>8. Data retention</h2>
+<p>Data is kept while you have an active account, as needed for the purposes described and for legal obligations. It will be deleted upon request unless there is a legal duty to keep it.</p>
+<h2>9. Account deletion</h2>
+<p>You can delete your account from the settings or by emailing soporte@plansocialapp.es.</p>
+<h2>10. Information security</h2>
+<p>The Service Provider applies technical and organizational measures such as encryption, access controls and secure servers.</p>
+<h2>11. Use by minors</h2>
+<p>The Application is not directed to children under 18. If improper use is detected, contact soporte@plansocialapp.es for immediate deletion.</p>
+<h2>12. Cookies</h2>
+<p>The Application or third parties may use cookies or similar technologies with your consent.</p>
+<h2>13. Changes</h2>
+<p>This policy may be updated. Important changes will be notified through the Application.</p>
+<p><strong>Last update:</strong> 26/05/2025</p>
+<h2>14. Contact</h2>
+<p>Email: soporte@plansocialapp.es</p>
     <hr>
     <footer class="site-footer">
         <div class="footer-container">
             <img class="footer-logo" src="plan-sin-fondo.png" alt="Plan Social">
             <div class="footer-links">
                 <a href="help.html">Ayuda</a>
+                  <a href="legal_notice.html">Aviso Legal</a>
                 <a href="privacy_policy.html">Privacidad</a>
                 <a href="terms_and_conditions.html">Condiciones</a>
                 <a href="cookies.html">Cookies</a>
@@ -189,6 +249,7 @@
             <li><a href="index.html#hero">Inicio</a></li>
             <li><a href="index.html#downloadSection">Descargar</a></li>
             <li><a href="help.html">Ayuda</a></li>
+              <li><a href="legal_notice.html">Aviso Legal</a></li>
             <li><a href="privacy_policy.html">Privacidad</a></li>
             <li><a href="terms_and_conditions.html">Condiciones</a></li>
             <li><a href="cookies.html">Cookies</a></li>
@@ -223,6 +284,35 @@
         <p>Ten en cuenta que la Aplicación utiliza servicios de terceros que tienen su propia Política de Privacidad acerca del tratamiento de datos. A continuación se muestran los enlaces a la Política de Privacidad de los proveedores de servicios utilizados por la Aplicación:</p>
         <ul>
             <li><a href="https://www.google.com/policies/privacy/" target="_blank" rel="noopener noreferrer">Google Play Services</a></li>
+<h2>1. Responsable del tratamiento</h2>
+<p>Nombre: Inan Ilik Ilik<br>Correo electrónico: soporte@plansocialapp.es<br>Domicilio: España<br>Finalidad general: Proporcionar, mantener y mejorar los servicios ofrecidos por la Aplicación.</p>
+<h2>2. Datos personales recopilados</h2>
+<p>La Aplicación puede recopilar datos identificativos (nombre, correo electrónico, edad, teléfono, imagen de perfil), datos técnicos (IP, tipo de dispositivo, sistema operativo, versión, fecha y hora de acceso, páginas visitadas, tiempo en la app), datos de localización (previa autorización) y datos de uso.</p>
+<h2>3. Finalidad del tratamiento</h2>
+<p>La información se utiliza para prestar y mantener la Aplicación, personalizar la experiencia, analizar el uso, enviar notificaciones (con consentimiento), gestionar tu cuenta y garantizar el cumplimiento legal y la seguridad.</p>
+<h2>4. Base legal para el tratamiento</h2>
+<p>El tratamiento se fundamenta en tu consentimiento, la ejecución de un contrato, el cumplimiento de obligaciones legales y el interés legítimo del Proveedor del Servicio.</p>
+<h2>5. Servicios de terceros</h2>
+<p>La Aplicación utiliza servicios de terceros como Firebase, Google Play Services, Google Sign-In, Firebase Messaging, Google Maps Platform, Geolocator, Google Fonts, Hostinger y Firebase Hosting. Cada proveedor cuenta con su propia política de privacidad.</p>
+<h2>6. Cesión y acceso a datos</h2>
+<p>No se venden tus datos. Solo se comparten con proveedores externos bajo contrato, autoridades competentes, servicios de analítica o geolocalización de forma anonimizada y otros usuarios en caso de publicaciones.</p>
+<h2>7. Derechos del usuario</h2>
+<p>Puedes acceder, rectificar o suprimir tus datos, limitar u oponerte al tratamiento, solicitar la portabilidad y retirar tu consentimiento en cualquier momento escribiendo a soporte@plansocialapp.es.</p>
+<h2>8. Conservación de datos</h2>
+<p>Los datos se conservarán mientras mantengas una cuenta activa, mientras sean necesarios para las finalidades descritas y durante los plazos legales. Se eliminarán si lo solicitas salvo obligación legal de conservación.</p>
+<h2>9. Eliminación de cuenta y datos</h2>
+<p>Puedes eliminar tu cuenta desde la aplicación o solicitándolo por correo a soporte@plansocialapp.es.</p>
+<h2>10. Seguridad de la información</h2>
+<p>El Proveedor del Servicio aplica medidas técnicas y organizativas como cifrado, control de accesos y servidores seguros.</p>
+<h2>11. Uso por menores de edad</h2>
+<p>La Aplicación no está dirigida a menores de 18 años. Si un padre, madre o tutor detecta un uso indebido puede escribir a soporte@plansocialapp.es para eliminar los datos.</p>
+<h2>12. Cookies y tecnologías similares</h2>
+<p>La Aplicación o servicios de terceros pueden emplear cookies u otras tecnologías con tu consentimiento.</p>
+<h2>13. Cambios en la política</h2>
+<p>Esta política puede actualizarse. Notificaremos los cambios importantes mediante la Aplicación.</p>
+<p><strong>Fecha de última actualización:</strong> 26/05/2025</p>
+<h2>14. Contacto</h2>
+<p>Correo: soporte@plansocialapp.es</p>
             <li><a href="https://firebase.google.com/support/privacy" target="_blank" rel="noopener noreferrer">Firebase (Authentication, Firestore, Realtime Database, Storage, Cloud Functions y Firebase Analytics)</a></li>
             <li><a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">Google Sign-In y Firebase Messaging</a></li>
             <li><a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">Google Maps Platform (API de Places/Geocoding) y Geolocator</a></li>
@@ -258,6 +348,7 @@
             <img class="footer-logo" src="plan-sin-fondo.png" alt="Plan Social">
             <div class="footer-links">
                 <a href="help.html">Ayuda</a>
+                  <a href="legal_notice.html">Aviso Legal</a>
                 <a href="privacy_policy.html">Privacidad</a>
                 <a href="terms_and_conditions.html">Condiciones</a>
                 <a href="cookies.html">Cookies</a>

--- a/public/terms_and_conditions.html
+++ b/public/terms_and_conditions.html
@@ -49,6 +49,7 @@
             <li><a href="index.html#hero">Home</a></li>
             <li><a href="index.html#downloadSection">Download</a></li>
             <li><a href="help.html">Help</a></li>
+              <li><a href="legal_notice.html">Legal Notice</a></li>
             <li><a href="privacy_policy.html">Privacy</a></li>
             <li><a href="terms_and_conditions.html">Terms</a></li>
             <li><a href="cookies.html">Cookies</a></li>
@@ -134,6 +135,7 @@
             <img class="footer-logo" src="plan-sin-fondo.png" alt="Plan Social">
             <div class="footer-links">
                 <a href="help.html">Ayuda</a>
+                  <a href="legal_notice.html">Aviso Legal</a>
                 <a href="privacy_policy.html">Privacidad</a>
                 <a href="terms_and_conditions.html">Condiciones</a>
                 <a href="cookies.html">Cookies</a>
@@ -160,6 +162,7 @@
             <li><a href="index.html#hero">Inicio</a></li>
             <li><a href="index.html#downloadSection">Descargar</a></li>
             <li><a href="help.html">Ayuda</a></li>
+              <li><a href="legal_notice.html">Aviso Legal</a></li>
             <li><a href="privacy_policy.html">Privacidad</a></li>
             <li><a href="terms_and_conditions.html">Condiciones</a></li>
             <li><a href="cookies.html">Cookies</a></li>
@@ -200,6 +203,7 @@
             <img class="footer-logo" src="plan-sin-fondo.png" alt="Plan Social">
             <div class="footer-links">
                 <a href="help.html">Ayuda</a>
+                  <a href="legal_notice.html">Aviso Legal</a>
                 <a href="privacy_policy.html">Privacidad</a>
                 <a href="terms_and_conditions.html">Condiciones</a>
                 <a href="cookies.html">Cookies</a>


### PR DESCRIPTION
## Summary
- add new `legal_notice.html` with English and Spanish content
- include link to the new page in all navigation menus and footers
- complement privacy policy with detailed sections
- update terms and conditions and other pages with link

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685306e8f8648332a0b20f466ae0a9cb