### PR TITLE
Add English translation for privacy policy

### DIFF
--- a/public/privacy_policy.html
+++ b/public/privacy_policy.html
@@ -60,184 +60,102 @@
       </div>
     </header>
     <main style="padding:1em;">
-    <h1>Privacy Policy</h1>
-    <p>This privacy policy applies to the Plan app (hereby referred to as "Application") for mobile devices that was
-        created by Inan Ilik Ilik (hereby referred to as "Service Provider") as a Freemium service. This service is
-        intended for use "AS IS".</p><br><strong>Information Collection and Use</strong>
-    <p>The Application collects information when you download and use it. This information may include information such
-        as </p>
-    <ul>
-        <li>Your device's Internet Protocol address (e.g. IP address)</li>
-        <li>The pages of the Application that you visit, the time and date of your visit, the time spent on those pages
-        </li>
-        <li>The time spent on the Application</li>
-        <li>The operating system you use on your mobile device</li>
-    </ul>
-    <p></p><br>
-    <p style="display: none;">The Application does not gather precise information about the location of your mobile
-        device.</p>
-    <div style="">
-        <p>The Application collects your device's location, which helps the Service Provider determine your approximate
-            geographical location and make use of in below ways:</p>
-        <ul>
-            <li>Geolocation Services: The Service Provider utilizes location data to provide features such as
-                personalized content, relevant recommendations, and location-based services.</li>
-            <li>Analytics and Improvements: Aggregated and anonymized location data helps the Service Provider to
-                analyze user behavior, identify trends, and improve the overall performance and functionality of the
-                Application.</li>
-            <li>Third-Party Services: Periodically, the Service Provider may transmit anonymized location data to
-                external services. These services assist them in enhancing the Application and optimizing their
-                offerings.</li>
-        </ul>
-    </div><br>
-    <p>The Service Provider may use the information you provided to contact you from time to time to provide you with
-        important information, required notices and marketing promotions.</p><br>
-    <p>For a better experience, while using the Application, the Service Provider may require you to provide us with
-        certain personally identifiable information, including but not limited to Email, name, age, pictures, phone
-        number, location. The information that the Service Provider request will be retained by them and used as
-        described in this privacy policy.</p><br><strong>Third Party Access</strong>
-    <p>Only aggregated, anonymized data is periodically transmitted to external services to aid the Service Provider in
-        improving the Application and their service. The Service Provider may share your information with third parties
-        in the ways that are described in this privacy statement.</p>
-    <div><br>
-        <p>Please note that the Application utilizes third-party services that have their own Privacy Policy about
-            handling data. Below are the links to the Privacy Policy of the third-party service providers used by the
-            Application:</p>
-        <ul>
-            <li><a href="https://www.google.com/policies/privacy/" target="_blank" rel="noopener noreferrer">Google Play
-                    Services</a></li>
-            <li><a href="https://firebase.google.com/support/privacy" target="_blank" rel="noopener noreferrer">Firebase (Authentication, Firestore, Realtime Database, Storage, Cloud Functions y Firebase Analytics)</a></li>
-            <li><a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">Google Sign-In y Firebase Messaging</a></li>
-            <li><a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">Google Maps Platform (API de Places/Geocoding) y Geolocator</a></li>
-            <li><a href="https://developers.google.com/fonts/faq/privacy" target="_blank" rel="noopener noreferrer">Google Fonts (fonts.googleapis.com)</a></li>
-            <li><a href="https://www.hostinger.com/privacy-policy" target="_blank" rel="noopener noreferrer">Hostinger (SMTP para restablecimiento de contraseñas con Nodemailer)</a></li>
-            <li><a href="https://firebase.google.com/support/privacy" target="_blank" rel="noopener noreferrer">Firebase Hosting</a></li>
-        </ul>
-    <p>If you share content or participate in events through the Application, that information may be visible to other users. Please be mindful of the information you disclose.</p>
-    <p>You may review or update your account data in the settings section of the Application. You can also delete your account at any time, which will remove your information from the Service Provider's systems, except where retention is required for legitimate business purposes or legal obligations.</p>
-    </div><br>
-    <p>The Service Provider may disclose User Provided and Automatically Collected Information:</p>
-    <ul>
-        <li>as required by law, such as to comply with a subpoena, or similar legal process;</li>
-        <li>when they believe in good faith that disclosure is necessary to protect their rights, protect your safety or
-            the safety of others, investigate fraud, or respond to a government request;</li>
-        <li>with their trusted services providers who work on their behalf, do not have an independent use of the
-            information we disclose to them, and have agreed to adhere to the rules set forth in this privacy statement.
-        </li>
-    </ul>
-    <p></p><br><strong>Opt-Out Rights</strong>
-    <p>You can stop all collection of information by the Application easily by uninstalling it. You may use the standard
-        uninstall processes as may be available as part of your mobile device or via the mobile application marketplace
-        or network.</p><br><strong>Data Retention Policy</strong>
-    <p>The Service Provider will retain User Provided data for as long as you use the Application and for a reasonable
-        time thereafter. If you'd like them to delete User Provided Data that you have provided via the Application,
-        please contact them at soporte@plansocialapp.es and they will respond in a reasonable time.</p>
-    <br><strong>Children</strong>
-    <p>The Service Provider does not use the Application to knowingly solicit data from or market to children under the
-        age of 13.</p>
-    <div><br>
-        <p>The Application does not address anyone under the age of 13.
-            The Service Provider does not knowingly collect personally
-            identifiable information from children under 13 years of age. In the case
-            the Service Provider discover that a child under 13 has provided
-            personal information, the Service Provider will immediately
-            delete this from their servers. If you are a parent or guardian
-            and you are aware that your child has provided us with
-            personal information, please contact the Service Provider (soporte@plansocialapp.es) so that
-            they will be able to take the necessary actions.</p>
-    </div><br><strong>Security</strong>
-    <p>The Service Provider is concerned about safeguarding the confidentiality of your information. The Service
-        Provider provides physical, electronic, and procedural safeguards to protect information the Service Provider
-        processes and maintains.</p><br><strong>Changes</strong>
-    <p>This Privacy Policy may be updated from time to time for any reason. The Service Provider will notify you of any
-        changes to the Privacy Policy by updating this page with the new Privacy Policy. You are advised to consult this
-        Privacy Policy regularly for any changes, as continued use is deemed approval of all changes.</p><br>
-    <p>This privacy policy is effective as of 2025-05-26</p><br><strong>Your Consent</strong>
-    <p>By using the Application, you are consenting to the processing of your information as set forth in this Privacy
-        Policy now and as amended by us.</p><br><strong>Contact Us</strong>
-    <p>If you have any questions regarding privacy while using the Application, or have questions about the practices,
-        please contact the Service Provider via email at soporte@plansocialapp.es.</p>
-<h2>1. Data Controller</h2>
-<p>Name: Inan Ilik Ilik<br>Email: soporte.es<br>Address: Spain<br>General purpose: Provide, maintain and improve the Application's services.</p>
-<h2>2. Personal data collected</h2>
-<p>The Application may collect identifying data (name, email, age, phone number, profile image), technical data (IP, device, OS, version, timestamps), location data (approximate or precise with your permission) and usage data.</p>
-<h2>3. Purpose of processing</h2>
-<p>The information is used to operate the Application, personalize the experience, analyze usage, send notifications (with consent), manage your account and ensure legal compliance and security.</p>
-<h2>4. Legal basis</h2>
-<p>The processing is based on your consent, the execution of a contract, compliance with legal obligations and the legitimate interest of the Service Provider.</p>
-<h2>5. Third-party services</h2>
-<p>The Application uses third-party services such as Firebase, Google Play Services, Google Sign-In, Firebase Messaging, Google Maps Platform, Geolocator, Google Fonts, Hostinger and Firebase Hosting. Each provider has its own privacy policy.</p>
-<h2>6. Data disclosure</h2>
-<p>Your data is not sold. It may be shared with service providers under contract, competent authorities, analytics or geolocation services in anonymized form and other users when you publish content.</p>
-<h2>7. User rights</h2>
-<p>You may access, rectify or erase your data, restrict or object to processing, request portability and withdraw consent by contacting soporte.es.</p>
-<h2>8. Data retention</h2>
-<p>Data is kept while you have an active account, as needed for the purposes described and for legal obligations. It will be deleted upon request unless there is a legal duty to keep it.</p>
-<h2>9. Account deletion</h2>
-<p>You can delete your account from the settings or by emailing soporte.es.</p>
-<h2>10. Information security</h2>
-<p>The Service Provider applies technical and organizational measures such as encryption, access controls and secure servers.</p>
-<h2>11. Use by minors</h2>
-<p>The Application is not directed to children under 18. If improper use is detected, contact soporte.es for immediate deletion.</p>
-<h2>12. Cookies</h2>
-<p>The Application or third parties may use cookies or similar technologies with your consent.</p>
-<h2>13. Changes</h2>
-<p>This policy may be updated. Important changes will be notified through the Application.</p>
+<h1>Privacy Policy</h1>
+<p>This privacy policy applies to the Plan app (hereinafter "Application") for mobile devices created by Inan Ilik Ilik (hereinafter "Service Provider") as a Freemium service. This service is offered "AS IS."</p><br><strong>Information Collection and Use</strong>
+<p>The Application collects information when you download and use it. This information may include data such as</p>
+<ul>
+  <li>Your device's IP address</li>
+  <li>The pages of the Application you visit, along with the date, time, and the time spent on each page</li>
+  <li>The time you spend on the Application</li>
+  <li>The operating system of your mobile device</li>
+</ul>
+<p>The Application does not collect precise information about the location of your mobile device.</p>
+<div>
+  <p>The Application collects your device's location so that the Service Provider can determine your approximate location and use it as follows:</p>
+  <ul>
+    <li>Geolocation services to provide personalized content, recommendations, and location-based services.</li>
+    <li>Analytics and improvements: aggregated and anonymized location data help the Service Provider analyze user behavior and enhance the Application's performance and functionality.</li>
+    <li>Third-party services: periodically, the Service Provider may transmit anonymized location data to external services to improve the Application and optimize its offerings.</li>
+  </ul>
+</div><br>
+<p>The Service Provider may use the information you provide to contact you occasionally with important information, notices, and marketing promotions.</p>
+<p>For a better experience, while using the Application the Service Provider may require you to provide certain personally identifiable information, including but not limited to email, name, age, images, phone number, and location. The requested information will be retained and used as described in this policy.</p><br><strong>Third-Party Access</strong>
+<p>Only aggregated, anonymized data is periodically transmitted to external services to help the Service Provider improve the Application and its service. The Service Provider may share your information with third parties as described in this privacy policy.</p>
+<div><br>
+  <p>Please note that the Application uses third-party services that have their own Privacy Policy regarding data processing.</p>
+</div><br>
+<h2>1. Data Controller and Contact</h2>
+<p>Name: Inan Ilik Ilik<br>Email: soporte@plansocialapp.es<br>Address: Spain<br>General purpose: To provide, maintain, and improve the services offered by the Application. For any questions about this policy, you can write to this email.</p>
+<h2>2. Personal Data Collected</h2>
+<p>The Application may collect identifying data (name, email, age, phone number, profile image), technical data (IP, device type, operating system, version, access date and time, pages visited, time spent in the app), location data (with prior authorization), and usage data.</p>
+<h2>3. Purpose of Processing</h2>
+<p>The information is used to operate and maintain the Application, personalize the experience, analyze usage, send notifications (with consent), manage your account, and ensure legal compliance and security.</p>
+<h2>4. Legal Basis for Processing</h2>
+<p>Processing is based on your consent, the execution of a contract, compliance with legal obligations, and the Service Provider's legitimate interest.</p>
+<h2>5. Third-Party Services</h2>
+<p>The Application uses the following third-party services, each with its own privacy policy:</p>
+<ol>
+  <li>Google Play Services</li>
+  <li>Firebase (Authentication, Firestore, Realtime Database, Storage, Cloud Functions, and Firebase Analytics)</li>
+  <li>Google Sign-In and Firebase Messaging</li>
+  <li>Google Maps Platform (Places/Geocoding API) and Geolocator</li>
+  <li>Google Fonts (fonts.googleapis.com)</li>
+  <li>Hostinger (SMTP for password resets with Nodemailer)</li>
+  <li>Firebase Hosting</li>
+</ol>
+<h2>6. Data Disclosure and Access</h2>
+<p>Your data is not sold. It is only shared with contracted external providers, competent authorities, analytics or geolocation services in anonymized form, and other users when you publish content.</p>
+<p>If you share content or participate in events through the Application, that information may be visible to other users. Be responsible with the data you publish.</p>
+<p>You can review or update your account data in the Application's settings section. You can also delete your account at any time, which will remove your information from the Service Provider's systems, unless it must be retained for legitimate or legal reasons.</p>
+<p>The Service Provider may disclose User-Provided and Automatically Collected Information:</p>
+<ul>
+  <li>When required by law, to comply with a subpoena or similar legal process</li>
+  <li>When they believe in good faith that disclosure is necessary to protect their rights, your safety or the safety of others, investigate fraud, or respond to a government request</li>
+  <li>With trusted service providers who work on their behalf, do not have an independent use of the information disclosed to them, and have agreed to comply with the rules set forth in this privacy policy</li>
+</ul>
+<h2>7. User Rights</h2>
+<p>You may access, rectify, or delete your data, limit or oppose processing, request portability, and withdraw your consent at any time by writing to soporte@plansocialapp.es.</p>
+<h2>8. Data Retention</h2>
+<p>Data is kept while you maintain an active account, as needed for the purposes described and for legal periods. The Service Provider will keep the data provided by the user while you use the Application and for a reasonable time afterward. If you want the data provided through the Application deleted, contact soporte@plansocialapp.es and they will respond within a reasonable time. Data will be removed upon request unless there is a legal obligation to keep it.</p>
+<h2>9. Account and Data Deletion</h2>
+<p>You can delete your account from the app or by emailing soporte@plansocialapp.es.</p>
+<h2>10. Information Security</h2>
+<p>The Service Provider applies technical and organizational measures such as encryption, access control, and secure servers.</p>
+<h2>11. Use by Minors</h2>
+<p>The Application is not aimed at minors under 18. If a parent or guardian detects improper use, they can write to soporte@plansocialapp.es to remove the data.</p>
+<p>The Service Provider does not use the Application to knowingly solicit data from or market to children under 13 years old. The Application is not directed to children under 13, and no personal information from children of that age is knowingly collected. If the Service Provider discovers that a child under 13 has provided personal information, it will be deleted immediately. If you are a parent or guardian and know that your child has provided us with personal data, contact soporte@plansocialapp.es so that we can take appropriate measures.</p>
+<h2>12. Cookies and Similar Technologies</h2>
+<p>The Application or third-party services may use cookies or other technologies with your consent.</p>
+<h2>13. Opt-Out Rights</h2>
+<p>You can easily stop all collection of information by the Application by uninstalling it. You may use the standard uninstall processes available on your mobile device or through the mobile application marketplace or network.</p>
+<h2>14. Changes to the Policy</h2>
+<p>This policy may be updated. We will notify you of important changes through the Application.</p>
 <p><strong>Last update:</strong> 26/05/2025</p>
-<h2>14. Contact</h2>
-<p>Email: soporte.es</p>
-<h2>1. Data Controller</h2>
-<p>Name: Inan Ilik Ilik<br>Email: soporte@plansocialapp.es<br>Address: Spain<br>General purpose: Provide, maintain and improve the Application's services.</p>
-<h2>2. Personal data collected</h2>
-<p>The Application may collect identifying data (name, email, age, phone number, profile image), technical data (IP, device, OS, version, timestamps), location data (approximate or precise with your permission) and usage data.</p>
-<h2>3. Purpose of processing</h2>
-<p>The information is used to operate the Application, personalize the experience, analyze usage, send notifications (with consent), manage your account and ensure legal compliance and security.</p>
-<h2>4. Legal basis</h2>
-<p>The processing is based on your consent, the execution of a contract, compliance with legal obligations and the legitimate interest of the Service Provider.</p>
-<h2>5. Third-party services</h2>
-<p>The Application uses third-party services such as Firebase, Google Play Services, Google Sign-In, Firebase Messaging, Google Maps Platform, Geolocator, Google Fonts, Hostinger and Firebase Hosting. Each provider has its own privacy policy.</p>
-<h2>6. Data disclosure</h2>
-<p>Your data is not sold. It may be shared with service providers under contract, competent authorities, analytics or geolocation services in anonymized form and other users when you publish content.</p>
-<h2>7. User rights</h2>
-<p>You may access, rectify or erase your data, restrict or object to processing, request portability and withdraw consent by contacting soporte@plansocialapp.es.</p>
-<h2>8. Data retention</h2>
-<p>Data is kept while you have an active account, as needed for the purposes described and for legal obligations. It will be deleted upon request unless there is a legal duty to keep it.</p>
-<h2>9. Account deletion</h2>
-<p>You can delete your account from the settings or by emailing soporte@plansocialapp.es.</p>
-<h2>10. Information security</h2>
-<p>The Service Provider applies technical and organizational measures such as encryption, access controls and secure servers.</p>
-<h2>11. Use by minors</h2>
-<p>The Application is not directed to children under 18. If improper use is detected, contact soporte@plansocialapp.es for immediate deletion.</p>
-<h2>12. Cookies</h2>
-<p>The Application or third parties may use cookies or similar technologies with your consent.</p>
-<h2>13. Changes</h2>
-<p>This policy may be updated. Important changes will be notified through the Application.</p>
-<p><strong>Last update:</strong> 26/05/2025</p>
-<h2>14. Contact</h2>
-<p>Email: soporte@plansocialapp.es</p>
-    <hr>
-    <footer class="site-footer">
-        <div class="footer-container">
-            <img class="footer-logo" src="plan-sin-fondo.png" alt="Plan Social">
-            <div class="footer-links">
-                <a href="help.html">Ayuda</a>
-                  <a href="legal_notice.html">Aviso Legal</a>
-                <a href="privacy_policy.html">Privacidad</a>
-                <a href="terms_and_conditions.html">Condiciones</a>
-                <a href="cookies.html">Cookies</a>
-                <select class="lang-select">
-                    <option value="es">Español</option>
-                    <option value="en">English</option>
-                </select>
-                <div class="footer-social">
-                <div>Síguenos en <button onclick="window.open('https://www.instagram.com/plansocialappspain/', '_blank')" style="background:none;border:none;padding:0"><img src="instagram.png" alt="Instagram" class="social-icon"></button> <button onclick="window.open('https://www.linkedin.com/in/plan-social-app-54165536a', '_blank')" style="background:none;border:none;padding:0"><img src="linkedin.png" alt="LinkedIn" class="social-icon"></button></div>
-                </div>
-                </div>
-            <p>© 2025 Plan</p>
-        </div>
-    </footer>
-    </main>
-  </div>
+<h2>15. Your Consent</h2>
+<p>By using the Application, you consent to the processing of your information as set forth in this Privacy Policy now and as amended by us.</p>
+<hr>
+<footer class="site-footer">
+    <div class="footer-container">
+        <img class="footer-logo" src="plan-sin-fondo.png" alt="Plan Social">
+        <div class="footer-links">
+            <a href="help.html">Ayuda</a>
+              <a href="legal_notice.html">Aviso Legal</a>
+            <a href="privacy_policy.html">Privacidad</a>
+            <a href="terms_and_conditions.html">Condiciones</a>
+            <a href="cookies.html">Cookies</a>
+            <select class="lang-select">
+                <option value="es">Español</option>
+                <option value="en">English</option>
+            </select>
+            <div class="footer-social">
+            <div>Síguenos en <button onclick="window.open('https://www.instagram.com/plansocialappspain/', '_blank')" style="background:none;border:none;padding:0"><img src="instagram.png" alt="Instagram" class="social-icon"></button> <button onclick="window.open('https://www.linkedin.com/in/plan-social-app-54165536a', '_blank')" style="background:none;border:none;padding:0"><img src="linkedin.png" alt="LinkedIn" class="social-icon"></button></div>
+            </div>
+            </div>
+        <p>© 2025 Plan</p>
+    </div>
+</footer>
+</main>
+</div>
   <div data-lang="es">
     <header>
       <div class="nav-container">


### PR DESCRIPTION
## Summary
- integrate English version of privacy policy on landing page

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531870cc948332a85cd773e6841e24