### PR TITLE
feat: use navigator key for update guard dialog

### DIFF
--- a/app_src/lib/main.dart
+++ b/app_src/lib/main.dart
@@ -161,22 +161,25 @@ class _MyAppState extends State<MyApp> {
     return ValueListenableBuilder<Locale>(
       valueListenable: LanguageService.locale,
       builder: (context, locale, _) {
-        return ForceUpdateGuard(child: MaterialApp(
+        return ForceUpdateGuard(
           navigatorKey: _navigatorKey,
-          locale: locale,
-          supportedLocales: const [Locale('es'), Locale('en')],
-          localizationsDelegates: const [
-            AppLocalizations.delegate,
-            GlobalMaterialLocalizations.delegate,
-            GlobalWidgetsLocalizations.delegate,
-            GlobalCupertinoLocalizations.delegate,
-          ],
-          title: 'Plan',
-          theme: ThemeData(primarySwatch: Colors.pink),
-          // Always start at WelcomeScreen. It handles auth changes internally.
-          // This ensures that every app launch shows the welcome screen first.
-          home: const WelcomeScreen(),
-        ));
+          child: MaterialApp(
+            navigatorKey: _navigatorKey,
+            locale: locale,
+            supportedLocales: const [Locale('es'), Locale('en')],
+            localizationsDelegates: const [
+              AppLocalizations.delegate,
+              GlobalMaterialLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+            ],
+            title: 'Plan',
+            theme: ThemeData(primarySwatch: Colors.pink),
+            // Always start at WelcomeScreen. It handles auth changes internally.
+            // This ensures that every app launch shows the welcome screen first.
+            home: const WelcomeScreen(),
+          ),
+        );
       },
     );
   }

--- a/app_src/lib/services/update_service.dart
+++ b/app_src/lib/services/update_service.dart
@@ -29,8 +29,14 @@ class UpdateService {
 }
 
 class ForceUpdateGuard extends StatelessWidget {
-  const ForceUpdateGuard({super.key, required this.child});
+  const ForceUpdateGuard({
+    super.key,
+    required this.child,
+    required this.navigatorKey,
+  });
+
   final Widget child;
+  final GlobalKey<NavigatorState> navigatorKey;
 
   @override
   Widget build(BuildContext context) {
@@ -41,7 +47,7 @@ class ForceUpdateGuard extends StatelessWidget {
         if (mustUpdate) {
           WidgetsBinding.instance.addPostFrameCallback((_) {
             showDialog<void>(
-              context: context,
+              context: navigatorKey.currentContext!,
               barrierDismissible: false,
               builder: (_) => WillPopScope(
                 onWillPop: () async {


### PR DESCRIPTION
## Summary
- pass the navigator key to `ForceUpdateGuard`
- show update dialog using the global navigator context
- wire `ForceUpdateGuard` with the navigator key in `main.dart`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855474d0118833282e87af439dc5b93