### PR TITLE
Alinea indicadores de privilegio

### DIFF
--- a/app_src/lib/explore_screen/users_managing/privilege_level_details.dart
+++ b/app_src/lib/explore_screen/users_managing/privilege_level_details.dart
@@ -184,98 +184,106 @@ class _PrivilegeLevelDetailsState extends State<PrivilegeLevelDetails> {
     final int maxMaxPartsBar = thresholdReq.minMaxParts;
     final int maxTotalPartsBar = thresholdReq.minTotalParts;
 
-    return Column(
+    Widget createdPlansText = Column(
+      children: const [
+        Text(
+          "Planes creados",
+          style: TextStyle(color: Colors.white, fontSize: 10),
+          textAlign: TextAlign.center,
+        ),
+      ],
+    );
+
+    Widget maxPartsText = Column(
+      children: const [
+        Text(
+          "Máx. participantes",
+          style: TextStyle(color: Colors.white, fontSize: 10),
+          textAlign: TextAlign.center,
+        ),
+        Text(
+          "en un plan",
+          style: TextStyle(color: Colors.white, fontSize: 10),
+          textAlign: TextAlign.center,
+        ),
+      ],
+    );
+
+    Widget totalPartsText = Column(
+      children: const [
+        Text(
+          "Total de participantes",
+          style: TextStyle(color: Colors.white, fontSize: 10),
+          textAlign: TextAlign.center,
+        ),
+        Text(
+          "reunidos hasta ahora",
+          style: TextStyle(color: Colors.white, fontSize: 10),
+          textAlign: TextAlign.center,
+        ),
+      ],
+    );
+
+    Widget firstColumn = SizedBox(
+      width: w,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _buildTriangleIcon(),
+          const SizedBox(height: 8),
+          _buildProgressWithText(
+            currentValue: _totalCreatedPlans,
+            maxValue: maxPlansBar,
+            width: w,
+          ),
+          const SizedBox(height: 4),
+          createdPlansText,
+        ],
+      ),
+    );
+
+    Widget secondColumn = SizedBox(
+      width: w,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _buildSquareIcon(),
+          const SizedBox(height: 8),
+          _buildProgressWithText(
+            currentValue: _maxParticipantsInOnePlan,
+            maxValue: maxMaxPartsBar,
+            width: w,
+          ),
+          const SizedBox(height: 4),
+          maxPartsText,
+        ],
+      ),
+    );
+
+    Widget thirdColumn = SizedBox(
+      width: w,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _buildPentagonIcon(),
+          const SizedBox(height: 8),
+          _buildProgressWithText(
+            currentValue: _totalParticipantsUntilNow,
+            maxValue: maxTotalPartsBar,
+            width: w,
+          ),
+          const SizedBox(height: 4),
+          totalPartsText,
+        ],
+      ),
+    );
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
       children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            Expanded(child: Center(child: _buildTriangleIcon())),
-            Expanded(child: Center(child: _buildSquareIcon())),
-            Expanded(child: Center(child: _buildPentagonIcon())),
-          ],
-        ),
-        const SizedBox(height: 10),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            Expanded(
-              child: Center(
-                child: _buildProgressWithText(
-                  currentValue: _totalCreatedPlans,
-                  maxValue: maxPlansBar,
-                  width: w,
-                ),
-              ),
-            ),
-            Expanded(
-              child: Center(
-                child: _buildProgressWithText(
-                  currentValue: _maxParticipantsInOnePlan,
-                  maxValue: maxMaxPartsBar,
-                  width: w,
-                ),
-              ),
-            ),
-            Expanded(
-              child: Center(
-                child: _buildProgressWithText(
-                  currentValue: _totalParticipantsUntilNow,
-                  maxValue: maxTotalPartsBar,
-                  width: w,
-                ),
-              ),
-            ),
-          ],
-        ),
-        const SizedBox(height: 1),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            Expanded(
-              child: Column(
-                children: const [
-                  Text(
-                    "Planes creados",
-                    style: TextStyle(color: Colors.white, fontSize: 10),
-                    textAlign: TextAlign.center,
-                  ),
-                ],
-              ),
-            ),
-            Expanded(
-              child: Column(
-                children: const [
-                  Text(
-                    "Máx. participantes",
-                    style: TextStyle(color: Colors.white, fontSize: 10),
-                    textAlign: TextAlign.center,
-                  ),
-                  Text(
-                    "en un plan",
-                    style: TextStyle(color: Colors.white, fontSize: 10),
-                    textAlign: TextAlign.center,
-                  ),
-                ],
-              ),
-            ),
-            Expanded(
-              child: Column(
-                children: const [
-                  Text(
-                    "Total de participantes",
-                    style: TextStyle(color: Colors.white, fontSize: 10),
-                    textAlign: TextAlign.center,
-                  ),
-                  Text(
-                    "reunidos hasta ahora",
-                    style: TextStyle(color: Colors.white, fontSize: 10),
-                    textAlign: TextAlign.center,
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
+        firstColumn,
+        secondColumn,
+        thirdColumn,
       ],
     );
   }
@@ -563,10 +571,12 @@ class _PrivilegeLevelDetailsState extends State<PrivilegeLevelDetails> {
             ),
           ),
         ),
-        const SizedBox(width: 6),
-        Text(
-          "$maxValue",
-          style: const TextStyle(color: Colors.white, fontSize: 10),
+        Padding(
+          padding: const EdgeInsets.only(left: 2),
+          child: Text(
+            "$maxValue",
+            style: const TextStyle(color: Colors.white, fontSize: 10),
+          ),
         ),
       ],
     );


### PR DESCRIPTION
## Summary
- elimina la separación grande del valor máximo
- reorganiza la fila de indicadores usando columnas de ancho fijo

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685554f548a883329871a4507c91dd42