### PR TITLE
Filtrar creador en listas de participantes

### DIFF
--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -943,13 +943,15 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
   }
 
   Widget _buildParticipantsCorner(List<Map<String, dynamic>> participants) {
-    final count = participants.length;
+    final filtered =
+        participants.where((p) => p['uid'] != widget.plan.createdBy).toList();
+    final count = filtered.length;
     if (count == 0) {
       return const SizedBox.shrink();
     }
 
     if (count == 1) {
-      final p = participants[0];
+      final p = filtered[0];
       final pic = p['photoUrl'] ?? '';
       String name = p['name'] ?? 'Usuario';
       final age = p['age']?.toString() ?? '';
@@ -962,7 +964,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
 
       return GestureDetector(
         onTap: () async {
-          await _showParticipantsModal(participants);
+          await _showParticipantsModal(filtered);
           if (mounted) setState(() {});
         },
         child: Container(
@@ -992,8 +994,8 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
         ),
       );
     } else {
-      final p1 = participants[0];
-      final p2 = participants[1];
+      final p1 = filtered[0];
+      final p2 = filtered[1];
       final pic1 = p1['photoUrl'] ?? '';
       final pic2 = p2['photoUrl'] ?? '';
 
@@ -1007,7 +1009,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
 
       return GestureDetector(
         onTap: () async {
-          await _showParticipantsModal(participants);
+          await _showParticipantsModal(filtered);
           if (mounted) setState(() {});
         },
         child: SizedBox(
@@ -1479,7 +1481,9 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                   ),
                 );
               }
-              final allParts = snapshot.data ?? [];
+              final allParts = (snapshot.data ?? [])
+                  .where((p) => p['uid'] != plan.createdBy)
+                  .toList();
 
               return SingleChildScrollView(
                 physics: const BouncingScrollPhysics(),
@@ -1515,8 +1519,10 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
     if (plan.special_plan == 1) {
       return const SizedBox.shrink();
     }
+    final filtered =
+        participants.where((p) => p['uid'] != widget.plan.createdBy).toList();
     final bool isParticipant =
-        participants.any((p) => p['uid'] == _currentUser?.uid);
+        filtered.any((p) => p['uid'] == _currentUser?.uid);
 
     return StreamBuilder<DocumentSnapshot>(
       stream: FirebaseFirestore.instance

--- a/app_src/lib/explore_screen/plans_managing/plan_card.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_card.dart
@@ -689,12 +689,14 @@ class PlanCardState extends State<PlanCard> {
   // Participantes en la esquina
   // ─────────────────────────────────────────────────────────────
   Widget _buildParticipantsCorner() {
-    if (_participants.isEmpty) return const SizedBox.shrink();
-    final count = _participants.length;
+    final participants =
+        _participants.where((p) => p['uid'] != widget.plan.createdBy).toList();
+    if (participants.isEmpty) return const SizedBox.shrink();
+    final count = participants.length;
 
     // Solo 1
     if (count == 1) {
-      final p = _participants[0];
+      final p = participants[0];
       final pic = p['photoUrl'] ?? '';
       String name = p['name'] ?? 'Usuario';
       final age = p['age']?.toString() ?? '';
@@ -704,7 +706,7 @@ class PlanCardState extends State<PlanCard> {
       displayText = _truncate(displayText, maxChars);
 
       return GestureDetector(
-        onTap: () => _showParticipantsModal(_participants),
+        onTap: () => _showParticipantsModal(participants),
         child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
           decoration: BoxDecoration(
@@ -734,8 +736,8 @@ class PlanCardState extends State<PlanCard> {
     }
     // Si hay 2 o más
     else {
-      final p1 = _participants[0];
-      final p2 = _participants[1];
+      final p1 = participants[0];
+      final p2 = participants[1];
       final pic1 = p1['photoUrl'] ?? '';
       final pic2 = p2['photoUrl'] ?? '';
 
@@ -749,7 +751,7 @@ class PlanCardState extends State<PlanCard> {
           : (avatarSize + overlapOffset);
 
       return GestureDetector(
-        onTap: () => _showParticipantsModal(_participants),
+        onTap: () => _showParticipantsModal(participants),
         child: SizedBox(
           width: containerWidth,
           height: avatarSize,
@@ -1152,7 +1154,9 @@ class PlanCardState extends State<PlanCard> {
             ),
           );
         }
-        _participants = snap.data ?? [];
+        _participants = (snap.data ?? [])
+            .where((p) => p['uid'] != plan.createdBy)
+            .toList();
         final totalP = _participants.length;
         final maxP = plan.maxParticipants ?? 0;
         final bool isFull = (maxP > 0 && totalP >= maxP);


### PR DESCRIPTION
## Summary
- no incluir al creador en las listas de participantes de `PlanCard` y `FrostedPlanDialog`
- ajustar conteo y modal de participantes

## Testing
- `dart` y `flutter` no están disponibles en el entorno, por lo que no se pudieron ejecutar pruebas

------
https://chatgpt.com/codex/tasks/task_e_68556805e7dc8332871d325c30b3365f