### PR TITLE
Fix check-in confirmation

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -16,7 +16,13 @@ service cloud.firestore {
       allow update, delete: if request.auth.uid == resource.data.createdBy
         || ((request.auth.uid in resource.data.invitedUsers
             || request.auth.uid in resource.data.participants)
-            && request.resource.data.diff(resource.data).changedKeys().hasOnly(['participants', 'invitedUsers', 'removedParticipants', 'commentsCount']));
+            && request.resource.data.diff(resource.data).changedKeys().hasOnly([
+              'participants',
+              'invitedUsers',
+              'removedParticipants',
+              'commentsCount',
+              'checkedInUsers'
+            ]));
     }
 
     match /notifications/{id} {


### PR DESCRIPTION
## Summary
- allow updates to `checkedInUsers` in firestore rules so participants can confirm attendance

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68556c9b89a883329e8e9f98ac57b2d5