### PR TITLE
Fix user marker interaction on map

### DIFF
--- a/app_src/lib/explore_screen/map/plans_in_map_screen.dart
+++ b/app_src/lib/explore_screen/map/plans_in_map_screen.dart
@@ -10,6 +10,7 @@ import '../../main/colors.dart';
 import '../plans_managing/frosted_plan_dialog_state.dart';
 import '../../models/plan_model.dart';
 
+import '../users_managing/user_info_check.dart';
 class _MarkerData {
   final BitmapDescriptor icon;
   final Offset anchor;
@@ -244,7 +245,7 @@ class PlansInMapScreen {
           position: pos,
           icon: iconData.icon,
           anchor: iconData.anchor,
-          onTap: () {},
+          onTap: () => UserInfoCheck.open(context, uid),
         ),
       );
     }


### PR DESCRIPTION
## Summary
- allow tapping user markers on map to open profile

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685675175f7c8332b84c3b3886fc11f3