### PR TITLE
Implementar bloqueo de imágenes explícitas

### DIFF
--- a/app_src/functions/package.json
+++ b/app_src/functions/package.json
@@ -16,7 +16,8 @@
   "main": "lib/index.js",
   "dependencies": {
     "firebase-admin": "^12.6.0",
-    "firebase-functions": "^6.0.1"
+    "firebase-functions": "^6.0.1",
+    "@google-cloud/vision": "^3.4.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.62.0",

--- a/app_src/lib/explore_screen/chats/chat_screen.dart
+++ b/app_src/lib/explore_screen/chats/chat_screen.dart
@@ -13,6 +13,7 @@ import 'package:geolocator/geolocator.dart'; // Si lo usas
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
+import '../profile/user_images_managing.dart';
 
 import '../../main/colors.dart';
 import '../../models/plan_model.dart';
@@ -1799,6 +1800,10 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
 
   Future<void> _uploadAndSendImage(XFile imageFile) async {
     try {
+      if (await UserImagesManaging.checkExplicit(File(imageFile.path))) {
+        await UserImagesManaging.showExplicitDialog(context);
+        return;
+      }
       final storageRef = FirebaseStorage.instance
           .ref()
           .child('chat_images')

--- a/app_src/lib/explore_screen/profile/plan_memories_screen.dart
+++ b/app_src/lib/explore_screen/profile/plan_memories_screen.dart
@@ -6,6 +6,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:image_picker/image_picker.dart';
+import 'user_images_managing.dart';
 
 import '../plans_managing/plan_card.dart';
 import '../../models/plan_model.dart';
@@ -168,6 +169,10 @@ class _PlanMemoriesScreenState extends State<PlanMemoriesScreen> {
   /// Subir la imagen al Storage y guardar su URL en Firestore
   Future<void> _uploadMemory(File file) async {
     try {
+      if (await UserImagesManaging.checkExplicit(file)) {
+        await UserImagesManaging.showExplicitDialog(context);
+        return;
+      }
       final ref = FirebaseStorage.instance
           .ref()
           .child('plan_memories')

--- a/app_src/lib/start/registration/user_registration_screen.dart
+++ b/app_src/lib/start/registration/user_registration_screen.dart
@@ -13,6 +13,7 @@ import 'package:geolocator/geolocator.dart';
 import 'package:intl/intl.dart';
 // Importación para "reverse geocoding"
 import 'package:geocoding/geocoding.dart' show placemarkFromCoordinates, Placemark;
+import '../../explore_screen/profile/user_images_managing.dart';
 
 // Importa tus colores desde tu archivo principal (ajusta el import si lo requieres)
 import 'package:dating_app/main/colors.dart' as MyColors;
@@ -244,6 +245,10 @@ class _UserRegistrationScreenState extends State<UserRegistrationScreen> {
   /// Sube un archivo a Firebase Storage y devuelve la URL
   Future<String?> _uploadFileToFirebase(File file, String fileName) async {
     try {
+      if (await UserImagesManaging.checkExplicit(file)) {
+        await UserImagesManaging.showExplicitDialog(context);
+        return null;
+      }
       final ref = FirebaseStorage.instance.ref().child(fileName);
       await ref.putFile(file);
       return await ref.getDownloadURL();


### PR DESCRIPTION
## Summary
- añadir dependencia `@google-cloud/vision` y nueva función `detectExplicitContent` en Cloud Functions
- verificar imágenes en Flutter y web antes de subirlas
- mostrar aviso con enlace a condiciones de uso cuando la imagen es explícita
- impedir carga de contenido explícito en chats, recuerdos de planes y registro de usuarios

## Testing
- `flutter analyze` *(falló: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857d609838c833291a46241707b96c5