### PR TITLE
Enable username login with public query

### DIFF
--- a/app_src/functions/src/index.ts
+++ b/app_src/functions/src/index.ts
@@ -316,7 +316,7 @@ export const getEmailByUsername = functions
     const db = getFirestore();
     const snap = await db
       .collection("users")
-      .where("user_name_lowercase", "==", username.toLowerCase())
+      .where("user_name", "==", username)
       .limit(1)
       .get();
 

--- a/app_src/lib/start/login/login_screen.dart
+++ b/app_src/lib/start/login/login_screen.dart
@@ -114,7 +114,7 @@ class _LoginScreenState extends State<LoginScreen> {
           // Fallback: buscar directamente en Firestore por el nombre de usuario
           final snap = await FirebaseFirestore.instance
               .collection('users')
-              .where('user_name_lowercase', isEqualTo: input.toLowerCase())
+              .where('user_name', isEqualTo: input)
               .limit(1)
               .get();
           if (snap.docs.isNotEmpty) {

--- a/firestore.rules
+++ b/firestore.rules
@@ -3,7 +3,9 @@ service cloud.firestore {
   match /databases/{database}/documents {
 
     match /users/{uid} {
-      allow list, read: if request.auth != null;
+      // Permitir consultas públicas por nombre de usuario.
+      allow list: if true;
+      allow get: if request.auth != null;
       allow create, update, delete: if request.auth.uid == uid;
       match /{sub=**} {
         allow read: if request.auth != null;


### PR DESCRIPTION
## Summary
- allow unauthenticated queries on `users` collection
- look up user email by `user_name` instead of lowercase field
- adjust Cloud Function to query `user_name`

## Testing
- `npm run build` *(failed: Cannot find module 'firebase-admin/app')*
- `npm run lint` *(failed: ESLint couldn't find a configuration file)*
- `flutter analyze` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857fec721548332bbddad422cc94ba6