### PR TITLE
Fix email lookup when user doc lacks email field

### DIFF
--- a/app_src/lib/start/login/login_screen.dart
+++ b/app_src/lib/start/login/login_screen.dart
@@ -118,7 +118,8 @@ class _LoginScreenState extends State<LoginScreen> {
               .limit(1)
               .get();
           if (snap.docs.isNotEmpty) {
-            emailToUse = snap.docs.first.get('email') ?? '';
+            emailToUse =
+                snap.docs.first.data()['email']?.toString() ?? '';
           }
         }
 


### PR DESCRIPTION
## Summary
- avoid `get('email')` on Firestore docs that may not contain the field

## Testing
- `bash` *(failed: `flutter` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68580427fd2c8332871774c845033997