### PR TITLE
Fix like behavior and user sorting

### DIFF
--- a/app_src/lib/explore_screen/main_screen/explore_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/explore_screen.dart
@@ -383,16 +383,16 @@ class ExploreScreenState extends State<ExploreScreen> {
     validUsers.sort((a, b) {
       final dataA = a.data() as Map<String, dynamic>;
       final dataB = b.data() as Map<String, dynamic>;
-      final double latA =
-          double.tryParse(dataA['latitude']?.toString() ?? '') ?? 0;
-      final double lngA =
-          double.tryParse(dataA['longitude']?.toString() ?? '') ?? 0;
-      final double latB =
-          double.tryParse(dataB['latitude']?.toString() ?? '') ?? 0;
-      final double lngB =
-          double.tryParse(dataB['longitude']?.toString() ?? '') ?? 0;
-      final distanceA = computeDistance(referenceLat, referenceLng, latA, lngA);
-      final distanceB = computeDistance(referenceLat, referenceLng, latB, lngB);
+      final double? latA = double.tryParse(dataA['latitude']?.toString() ?? '');
+      final double? lngA = double.tryParse(dataA['longitude']?.toString() ?? '');
+      final double? latB = double.tryParse(dataB['latitude']?.toString() ?? '');
+      final double? lngB = double.tryParse(dataB['longitude']?.toString() ?? '');
+      final distanceA = (latA != null && lngA != null)
+          ? computeDistance(referenceLat, referenceLng, latA, lngA)
+          : double.infinity;
+      final distanceB = (latB != null && lngB != null)
+          ? computeDistance(referenceLat, referenceLng, latB, lngB)
+          : double.infinity;
       return distanceA.compareTo(distanceB);
     });
 

--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -1690,22 +1690,25 @@ extension LikeLogic on _FrostedPlanDialogState {
     final userRef =
         FirebaseFirestore.instance.collection('users').doc(user.uid);
 
+    final bool newLiked = !_liked;
+    setState(() {
+      _liked = newLiked;
+      _likeCount = math.max(0, _likeCount + (newLiked ? 1 : -1));
+    });
+
     await FirebaseFirestore.instance.runTransaction((transaction) async {
       final snap = await transaction.get(planRef);
       if (!snap.exists) return;
       int currentLikes = snap.data()?['likes'] ?? 0;
-      if (!_liked) {
+      if (newLiked) {
         currentLikes++;
       } else {
         currentLikes = currentLikes > 0 ? currentLikes - 1 : 0;
       }
       transaction.update(planRef, {'likes': currentLikes});
-      setState(() {
-        _likeCount = currentLikes;
-      });
     });
 
-    if (!_liked) {
+    if (newLiked) {
       await userRef.update({
         'favourites': FieldValue.arrayUnion([widget.plan.id])
       });
@@ -1714,9 +1717,6 @@ extension LikeLogic on _FrostedPlanDialogState {
         'favourites': FieldValue.arrayRemove([widget.plan.id])
       });
     }
-    setState(() {
-      _liked = !_liked;
-    });
   }
 }
 


### PR DESCRIPTION
## Summary
- update like toggle logic so the heart instantly changes state and favorite list updates
- handle null coordinates when sorting users by distance

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859748b2a808332ae41959408481aba