### PR TITLE
Update location when app opens

### DIFF
--- a/app_src/lib/explore_screen/menu_side_bar/close_session_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/close_session_screen.dart
@@ -5,6 +5,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 
 import '../../start/welcome_screen.dart';
 import '../users_managing/presence_service.dart';
+import '../../services/location_update_service.dart';
 
 class CloseSessionScreen extends StatefulWidget {
   const CloseSessionScreen({super.key});
@@ -36,6 +37,7 @@ class _CloseSessionScreenState extends State<CloseSessionScreen> {
         }
 
         PresenceService.dispose(); // sin await
+        LocationUpdateService.dispose();
         await FirebaseAuth.instance.signOut();
       }
 

--- a/app_src/lib/explore_screen/profile/profile_screen.dart
+++ b/app_src/lib/explore_screen/profile/profile_screen.dart
@@ -18,6 +18,7 @@ import '../future_plans/future_plans.dart';
 // Manejo de imágenes
 import 'user_images_managing.dart';
 import '../users_managing/presence_service.dart';
+import '../../services/location_update_service.dart';
 
 import 'package:firebase_messaging/firebase_messaging.dart';
 
@@ -673,6 +674,7 @@ class ProfileScreenState extends State<ProfileScreen> {
                   }
 
                   PresenceService.dispose();
+                  LocationUpdateService.dispose();
                   await FirebaseAuth.instance.signOut();
 
                   if (!mounted) return;

--- a/app_src/lib/main.dart
+++ b/app_src/lib/main.dart
@@ -23,6 +23,7 @@ import 'firebase_options.dart';
 import 'services/notification_service.dart';
 import 'services/fcm_token_service.dart';
 import 'explore_screen/users_managing/presence_service.dart';
+import 'services/location_update_service.dart';
 import 'explore_screen/chats/chats_screen.dart';
 import 'explore_screen/main_screen/explore_screen.dart';
 import 'start/welcome_screen.dart';
@@ -73,11 +74,12 @@ Future<void> main() async {
   );
   FirebaseMessaging.onMessage.listen(NotificationService.instance.show);
 
-  // 6 ▸ Presencia + token si hay sesión persistente
+  // 6 ▸ Presencia, ubicación y token si hay sesión persistente
   final user = FirebaseAuth.instance.currentUser;
   if (user != null) {
     PresenceService.dispose();
     await PresenceService.init(user);
+    await LocationUpdateService.init(user);
     await FcmTokenService.register(user);
   }
 
@@ -104,6 +106,7 @@ Future<void> signOutAndRemoveToken() async {
   }
   // Stop presence updates for the current user before signing out.
   PresenceService.dispose();
+  LocationUpdateService.dispose();
   await FirebaseAuth.instance.signOut();
 }
 

--- a/app_src/lib/services/location_update_service.dart
+++ b/app_src/lib/services/location_update_service.dart
@@ -1,0 +1,63 @@
+import 'dart:async';
+import 'package:flutter/widgets.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:geolocator/geolocator.dart';
+
+/// Servicio que actualiza la ubicación del usuario cuando la app
+/// entra en primer plano. Mantiene la última posición al salir.
+class LocationUpdateService with WidgetsBindingObserver {
+  LocationUpdateService._(this._uid);
+
+  static LocationUpdateService? _instance;
+  final String _uid;
+
+  /// Inicializa el servicio para el usuario autenticado.
+  static Future<void> init(User user) async {
+    if (_instance != null && _instance!._uid == user.uid) {
+      return;
+    }
+    _instance?._dispose();
+    _instance = LocationUpdateService._(user.uid);
+    await _instance!._start();
+  }
+
+  /// Limpia el observer. Llamar al cerrar sesión.
+  static void dispose() => _instance?._dispose();
+
+  Future<void> _start() async {
+    WidgetsBinding.instance.addObserver(this);
+    await _updateLocation();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _updateLocation();
+    }
+  }
+
+  Future<void> _updateLocation() async {
+    bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    if (!serviceEnabled) return;
+    LocationPermission permission = await Geolocator.checkPermission();
+    if (permission == LocationPermission.denied) {
+      permission = await Geolocator.requestPermission();
+    }
+    if (permission == LocationPermission.denied ||
+        permission == LocationPermission.deniedForever) {
+      return;
+    }
+    final position = await Geolocator.getCurrentPosition(
+      desiredAccuracy: LocationAccuracy.high,
+    );
+    await FirebaseFirestore.instance.doc('users/$_uid').update({
+      'latitude': position.latitude,
+      'longitude': position.longitude,
+    });
+  }
+
+  void _dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+  }
+}

--- a/app_src/lib/start/login/login_screen.dart
+++ b/app_src/lib/start/login/login_screen.dart
@@ -15,6 +15,7 @@ import '../../utils/auth_error_utils.dart';
 import '../../explore_screen/main_screen/explore_screen.dart';
 import '../../main/colors.dart';
 import '../../explore_screen/users_managing/presence_service.dart';
+import '../../services/location_update_service.dart';
 import 'recover_password.dart';
 import '../registration/register_screen.dart';
 import '../welcome_screen.dart';
@@ -105,6 +106,7 @@ class _LoginScreenState extends State<LoginScreen> {
 
       if (!await _userDocExists(user.uid)) {
         await _auth.signOut();
+        LocationUpdateService.dispose();
         if (mounted) _showNoProfileDialog();
         return;
       }
@@ -160,6 +162,7 @@ class _LoginScreenState extends State<LoginScreen> {
 
       if (!await _userDocExists(user.uid)) {
         await _auth.signOut();
+        LocationUpdateService.dispose();
         if (!mounted) return;
         final create = await _showGoogleNoProfileDialog();
         if (create == true && mounted) {

--- a/app_src/lib/start/login/recover_password.dart
+++ b/app_src/lib/start/login/recover_password.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:http/http.dart' as http;
 import '../../utils/auth_error_utils.dart';
+import '../../services/location_update_service.dart';
 
 class RecoverPasswordScreen extends StatefulWidget {
   const RecoverPasswordScreen({Key? key}) : super(key: key);
@@ -130,6 +131,7 @@ class _RecoverPasswordScreenState extends State<RecoverPasswordScreen> {
                 final userCred = await _auth.signInWithCredential(cred);
                 await userCred.user!.updatePassword(pwd);
                 await _auth.signOut();
+                LocationUpdateService.dispose();
                 Navigator.of(context).pop();
                 _showSnack('Contraseña actualizada');
                 Navigator.of(context).pop();

--- a/app_src/lib/start/registration/register_screen.dart
+++ b/app_src/lib/start/registration/register_screen.dart
@@ -13,6 +13,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import '../login/login_screen.dart';
 import '../welcome_screen.dart';
 import '../../utils/auth_error_utils.dart';
+import '../../services/location_update_service.dart';
 import 'package:flutter/gestures.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -180,6 +181,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
             return;
           }
           await FirebaseAuth.instance.signOut();
+          LocationUpdateService.dispose();
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(
               content: Text(

--- a/app_src/lib/start/welcome_screen.dart
+++ b/app_src/lib/start/welcome_screen.dart
@@ -12,6 +12,7 @@ import 'registration/user_registration_screen.dart';
 import 'registration/verification_provider.dart';
 import 'registration/email_verification_screen.dart';
 import '../../explore_screen/users_managing/presence_service.dart';
+import '../services/location_update_service.dart';
 
 class WelcomeScreen extends StatefulWidget {
   const WelcomeScreen({Key? key}) : super(key: key);
@@ -133,6 +134,7 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
         // Todo OK → ir a ExploreScreen
         if (mounted) {
           await PresenceService.init(user);
+          await LocationUpdateService.init(user);
           Navigator.pushReplacement(
             context,
             MaterialPageRoute(builder: (_) => const ExploreScreen()),


### PR DESCRIPTION
## Summary
- create a service for updating Firestore location on app resume
- initialise LocationUpdateService in main and welcome flows
- dispose service when logging out
- update logout screens to call the service

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68597a8327ac8332ba925d4e819a988a