### PR TITLE
Add check-in start notifications

### DIFF
--- a/app_src/lib/explore_screen/main_screen/notification_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/notification_screen.dart
@@ -865,6 +865,20 @@ class _NotificationScreenState extends State<NotificationScreen> {
                                       _handleDeleteNotification(doc),
                                 ),
                               );
+                            case 'plan_checkin_started':
+                              return ListTile(
+                                leading: leadingAvatar,
+                                title: Text(
+                                  'El organizador del plan $planType ha iniciado el Check-in. Confirma tu asistencia.',
+                                ),
+                                subtitle: buildSubtitle('Plan: $planType'),
+                                isThreeLine: true,
+                                onTap: () => _showPlanDetails(context, planId),
+                                trailing: IconButton(
+                                  icon: const Icon(Icons.delete, color: Colors.red),
+                                  onPressed: () => _handleDeleteNotification(doc),
+                                ),
+                              );
                             case 'welcome':
                               final String message = data['message'] ??
                                   '¡Bienvenido a Plan!';

--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -1719,52 +1719,64 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
           if (!isParticipant) {
             return const SizedBox.shrink();
           }
-          if (checkInActive) {
-            return Padding(
-              padding: const EdgeInsets.symmetric(vertical: 12),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  SizedBox(
-                    width: textW,
-                    child: Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Icon(Icons.info_outline, color: Colors.grey[300], size: 16),
-                        const SizedBox(width: 6),
-                        Expanded(
-                          child: Text(
-                            'Para confirmar tu asistencia, pulsa «Confirmar asistencia» y utiliza la cámara para escanear el código QR o introduce el código de seis dígitos facilitado por el organizador.',
-                            style: TextStyle(color: Colors.grey[300], fontSize: 12),
-                          ),
+          return Padding(
+            padding: const EdgeInsets.symmetric(vertical: 12),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                SizedBox(
+                  width: textW,
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Icon(Icons.info_outline, color: Colors.grey[300], size: 16),
+                      const SizedBox(width: 6),
+                      Expanded(
+                        child: Text(
+                          'Para confirmar tu asistencia, pulsa «Confirmar asistencia» y utiliza la cámara para escanear el código QR o introduce el código de seis dígitos facilitado por el organizador.',
+                          style: TextStyle(color: Colors.grey[300], fontSize: 12),
                         ),
-                      ],
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-                  SizedBox(
-                    width: btnW,
-                    child: ElevatedButton(
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: Colors.orangeAccent,
                       ),
-                      onPressed: () {
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 8),
+                SizedBox(
+                  width: btnW,
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.orangeAccent,
+                    ),
+                    onPressed: () {
+                      if (checkInActive) {
                         Navigator.push(
                           context,
                           MaterialPageRoute(
                             builder: (_) => CheckInParticipantScreen(planId: plan.id),
                           ),
                         );
-                      },
-                      child: const Text("Confirmar asistencia"),
-                    ),
+                      } else {
+                        showDialog(
+                          context: context,
+                          builder: (_) => AlertDialog(
+                            title: const Text('Check-in no iniciado'),
+                            content: const Text('El organizador del plan aún no ha iniciado el Check-in. Se te notificará una vez que se haya iniciado.'),
+                            actions: [
+                              TextButton(
+                                onPressed: () => Navigator.pop(context),
+                                child: const Text('OK'),
+                              ),
+                            ],
+                          ),
+                        );
+                      }
+                    },
+                    child: const Text("Confirmar asistencia"),
                   ),
-                ],
-              ),
-            );
-          } else {
-            return const SizedBox.shrink();
-          }
+                ),
+              ],
+            ),
+          );
         }
       },
     );


### PR DESCRIPTION
## Summary
- send push notifications when check-in is activated
- support `plan_checkin_started` notifications in the app
- keep "Confirmar asistencia" always visible and show notice if check-in isn't active

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_685afbc5bb18833296579ad4efc5d99b