### PR TITLE
Fix NDK version for 16 KB page alignment

### DIFF
--- a/app_src/android/app/build.gradle
+++ b/app_src/android/app/build.gradle
@@ -17,6 +17,7 @@ if (keystorePropsFile.exists()) {
 android {
     namespace "com.company.plan"
     compileSdk flutter.compileSdkVersion    // 34
+    ndkVersion "26.2.11394342"  // Android NDK r26 para alineación de 16 KB
 
     defaultConfig {
         applicationId "com.company.plan"


### PR DESCRIPTION
## Summary
- use NDK r26 for Android build to align native libs to 16 KB pages

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c2dd15d248332976ffbb1294ecc17