### PR TITLE
Remove orientation restriction for UCropActivity

### DIFF
--- a/app_src/android/app/src/main/AndroidManifest.xml
+++ b/app_src/android/app/src/main/AndroidManifest.xml
@@ -43,7 +43,6 @@
         <!-- uCrop -->
         <activity
             android:name="com.yalantis.ucrop.UCropActivity"
-            android:screenOrientation="portrait"
             android:theme="@style/Ucrop.CropTheme"/>
 
         <!-- ─────── FCM componentes ─────── -->


### PR DESCRIPTION
## Summary
- remove `android:screenOrientation="portrait"` from `UCropActivity`

## Testing
- `flutter test` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c2fc10dcc833299413ac2e0c12aaa