### PR TITLE
Habilitar vista de borde a borde en Android

### DIFF
--- a/app_src/android/app/build.gradle
+++ b/app_src/android/app/build.gradle
@@ -16,13 +16,13 @@ if (keystorePropsFile.exists()) {
 
 android {
     namespace "com.company.plan"
-    compileSdk flutter.compileSdkVersion    // 34
+    compileSdk 35
     ndkVersion "26.2.11394342"  // Android NDK r26 para alineación de 16 KB
 
     defaultConfig {
         applicationId "com.company.plan"
         minSdk 23
-        targetSdk flutter.targetSdkVersion
+        targetSdk 35
         versionCode flutter.versionCode
         versionName flutter.versionName
     }

--- a/app_src/android/app/src/main/kotlin/com/company/plan/MainActivity.kt
+++ b/app_src/android/app/src/main/kotlin/com/company/plan/MainActivity.kt
@@ -1,5 +1,12 @@
 package com.company.plan
 
+import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import io.flutter.embedding.android.FlutterActivity
 
-class MainActivity: FlutterActivity()
+class MainActivity: FlutterActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
+        super.onCreate(savedInstanceState)
+    }
+}


### PR DESCRIPTION
## Resumen
- compilar y orientarse al SDK 35
- habilitar borde a borde en `MainActivity` usando `enableEdgeToEdge`

## Testing
- `flutter test` *(falló: comando no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_685c3301c0cc8332884db991a3544db8