### PR TITLE
Fix Kotlin build error

### DIFF
--- a/app_src/android/app/src/main/kotlin/com/company/plan/MainActivity.kt
+++ b/app_src/android/app/src/main/kotlin/com/company/plan/MainActivity.kt
@@ -1,12 +1,12 @@
 package com.company.plan
 
 import android.os.Bundle
-import androidx.activity.enableEdgeToEdge
+import androidx.core.view.WindowCompat
 import io.flutter.embedding.android.FlutterActivity
 
 class MainActivity: FlutterActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
-        enableEdgeToEdge()
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         super.onCreate(savedInstanceState)
     }
 }


### PR DESCRIPTION
## Summary
- avoid using ComponentActivity-only method in FlutterActivity

## Testing
- `gradle -p app_src/android assembleDebug` *(fails: /workspace/Plan/app_src/android/local.properties not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c352d565883328823826c16778719