### PR TITLE
Remove interest chip UI

### DIFF
--- a/app_src/lib/start/registration/user_registration_screen.dart
+++ b/app_src/lib/start/registration/user_registration_screen.dart
@@ -27,7 +27,6 @@ import 'auth_service.dart';
 import 'local_registration_service.dart';
 import '../../services/fcm_token_service.dart';
 import 'register_screen.dart';
-import '../../utils/plans_list.dart';
 
 class UserRegistrationScreen extends StatefulWidget {
   const UserRegistrationScreen({
@@ -84,9 +83,6 @@ class _UserRegistrationScreenState extends State<UserRegistrationScreen> {
   bool _isSaving = false;
 
 
-  List<String> _selectedInterests = [];
-  String? _customInterest;
-  final TextEditingController _interestController = TextEditingController();
 
   int _calculateAge(DateTime date) {
     final now = DateTime.now();
@@ -149,54 +145,6 @@ class _UserRegistrationScreenState extends State<UserRegistrationScreen> {
     }
   }
 
-  void _toggleInterest(String name, {bool isCustom = false}) {
-    setState(() {
-      if (_selectedInterests.contains(name)) {
-        _selectedInterests.remove(name);
-        if (isCustom) _customInterest = null;
-      } else {
-        if (_selectedInterests.length >= 3) return;
-        _selectedInterests.add(name);
-        if (isCustom) _customInterest = name;
-      }
-    });
-  }
-
-  void _addCustomInterest() {
-    final text = _interestController.text.trim();
-    if (text.isEmpty) return;
-    if (_selectedInterests.length >= 3 && _customInterest == null) return;
-    setState(() {
-      if (_customInterest != null) {
-        _selectedInterests.remove(_customInterest);
-      }
-      _customInterest = text;
-      _selectedInterests.remove(text);
-      _selectedInterests.insert(0, text);
-      _interestController.clear();
-    });
-  }
-
-  Widget _buildInterestChip(String name, bool isCustom) {
-    final selected = _selectedInterests.contains(name);
-    return InkWell(
-      onTap: () => _toggleInterest(name, isCustom: isCustom),
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-        decoration: BoxDecoration(
-          color: selected ? MyColors.AppColors.planColor : MyColors.AppColors.lightLilac,
-          borderRadius: BorderRadius.circular(20),
-          border: Border.all(color: MyColors.AppColors.greyBorder),
-        ),
-        child: Text(
-          name,
-          style: TextStyle(
-            color: selected ? Colors.white : Colors.black,
-          ),
-        ),
-      ),
-    );
-  }
 
   @override
   void initState() {
@@ -212,7 +160,6 @@ class _UserRegistrationScreenState extends State<UserRegistrationScreen> {
     _usernameDebounce?.cancel();
     _usernameController.dispose();
     _cityController.dispose();
-    _interestController.dispose();
     super.dispose();
   }
 
@@ -409,7 +356,7 @@ class _UserRegistrationScreenState extends State<UserRegistrationScreen> {
         'deletedChats': [],
         'dateCreatedData': FieldValue.serverTimestamp(),
 
-        'interests': _selectedInterests,
+        'interests': [],
 
         // NUEVOS CAMPOS DE PRESENCIA:
         'online': true,
@@ -838,18 +785,6 @@ class _UserRegistrationScreenState extends State<UserRegistrationScreen> {
 
                   // Foto de perfil
                   _buildProfilePhotoPicker(),
-                  const SizedBox(height: 20),
-
-                  // Lista de intereses disponibles
-                  Wrap(
-                    spacing: 6,
-                    runSpacing: 6,
-                    children: [
-                      if (_customInterest != null)
-                        _buildInterestChip(_customInterest!, true),
-                      ...plans.map((p) => _buildInterestChip(p['name'], false)).toList(),
-                    ],
-                  ),
                   const SizedBox(height: 20),
 
                   Row(


### PR DESCRIPTION
## Summary
- remove interest chip widgets in registration screen
- drop unused interest-related logic and import

## Testing
- `dart format lib/start/registration/user_registration_screen.dart` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5761a8248332806168b1c4cbe06a