### PR TITLE
Fix map user visibility

### DIFF
--- a/app_src/lib/explore_screen/map/plans_in_map_screen.dart
+++ b/app_src/lib/explore_screen/map/plans_in_map_screen.dart
@@ -72,6 +72,7 @@ class PlansInMapScreen {
       final type = data['type'] as String?;
       final uid = data['createdBy'] as String?;
       if (lat == null || lng == null || type == null || uid == null) continue;
+      if (lat == 0.0 || lng == 0.0) continue;
       if (onlyFollowed && !followedUids.contains(uid)) {
         continue;
       }
@@ -236,6 +237,7 @@ class PlansInMapScreen {
       final lat = data['latitude']?.toDouble();
       final lng = data['longitude']?.toDouble();
       if (lat == null || lng == null) continue;
+      if (lat == 0.0 || lng == 0.0) continue;
       final photoUrl = data['photoUrl'] as String? ?? '';
       final pos = LatLng(lat, lng);
       final _MarkerData iconData = await _buildNoPlanMarker(photoUrl);


### PR DESCRIPTION
## Summary
- don't show plan or user markers with lat/long at zero

## Testing
- `flutter analyze` *(fails: command not found)*
- `npm test` *(fails: missing script and offline)*

------
https://chatgpt.com/codex/tasks/task_e_685dac0e043c83329d1ee33955a095cb