### PR TITLE
Muestra planes en lista de seguidores

### DIFF
--- a/app_src/lib/explore_screen/follow/following_screen.dart
+++ b/app_src/lib/explore_screen/follow/following_screen.dart
@@ -4,7 +4,10 @@ import 'package:firebase_auth/firebase_auth.dart';
 // Eliminamos import innecesario de campanas:
 // import 'package:flutter_svg/flutter_svg.dart';
 
+import '../../models/plan_model.dart';
+import '../plans_managing/frosted_plan_dialog_state.dart' as new_frosted;
 import '../users_managing/user_info_check.dart';
+import '../../main/colors.dart';
 
 /// Pantalla de seguidores/seguidos.
 /// Se muestra como un modal a pantalla casi completa (deja libre el 10 % superior)
@@ -67,6 +70,29 @@ class _FollowingScreenState extends State<FollowingScreen> {
 
   bool _loading = true;
 
+  Future<_PlanInfo?> _getNextPlanInfo(String userId) async {
+    try {
+      final snap = await FirebaseFirestore.instance
+          .collection('plans')
+          .where('createdBy', isEqualTo: userId)
+          .where('start_timestamp', isGreaterThan: Timestamp.fromDate(DateTime.now()))
+          .orderBy('start_timestamp')
+          .get();
+
+      if (snap.docs.isEmpty) return null;
+
+      final first = snap.docs.first;
+      final pData = first.data() as Map<String, dynamic>;
+      return _PlanInfo(
+        id: first.id,
+        name: pData['type'] ?? '',
+        additional: snap.docs.length - 1,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
   @override
   void initState() {
     super.initState();
@@ -104,19 +130,24 @@ class _FollowingScreenState extends State<FollowingScreen> {
             .collection('users')
             .doc(relatedUid)
             .get();
-        if (uDoc.exists && uDoc.data() != null) {
-          final data = uDoc.data()!;
-          items.add(
-            _UserItem(
-              uid: relatedUid,
-              name: data['name'] ?? 'Usuario',
-              age: (data['age']?.toString() ?? '').isNotEmpty
-                  ? data['age'].toString()
-                  : null,
-              photoUrl: data['photoUrl'] ?? '',
-            ),
-          );
-        }
+        if (!uDoc.exists || uDoc.data() == null) continue;
+
+        final data = uDoc.data()!;
+        final planInfo = await _getNextPlanInfo(relatedUid);
+
+        items.add(
+          _UserItem(
+            uid: relatedUid,
+            name: data['name'] ?? 'Usuario',
+            age: (data['age']?.toString() ?? '').isNotEmpty
+                ? data['age'].toString()
+                : null,
+            photoUrl: data['photoUrl'] ?? '',
+            upcomingPlanId: planInfo?.id,
+            upcomingPlanName: planInfo?.name,
+            additionalPlans: planInfo?.additional ?? 0,
+          ),
+        );
       }
 
       setState(() {
@@ -231,7 +262,29 @@ class _FollowingScreenState extends State<FollowingScreen> {
                           ),
                           title: Text(u.name),
                           subtitle: u.age != null ? Text('${u.age} años') : null,
-                          trailing: null,
+                          trailing: u.upcomingPlanId != null
+                              ? InkWell(
+                                  onTap: () => _onPlanTap(u.upcomingPlanId!),
+                                  child: Container(
+                                    padding: const EdgeInsets.symmetric(
+                                        horizontal: 8, vertical: 4),
+                                    decoration: BoxDecoration(
+                                      borderRadius: BorderRadius.circular(20),
+                                      border:
+                                          Border.all(color: AppColors.planColor),
+                                    ),
+                                    child: Text(
+                                      u.additionalPlans > 0
+                                          ? '${u.upcomingPlanName} +${u.additionalPlans}'
+                                          : u.upcomingPlanName!,
+                                      style: const TextStyle(
+                                        color: AppColors.planColor,
+                                        fontSize: 12,
+                                      ),
+                                    ),
+                                  ),
+                                )
+                              : null,
                           onTap: () {
                             // 1) Cerramos primero el modal
                             Navigator.of(context).pop();
@@ -251,6 +304,46 @@ class _FollowingScreenState extends State<FollowingScreen> {
         ),
       ],
     );
+  }
+
+  Future<void> _onPlanTap(String planId) async {
+    final doc = await FirebaseFirestore.instance
+        .collection('plans')
+        .doc(planId)
+        .get();
+    if (!doc.exists || doc.data() == null) return;
+    final plan = PlanModel.fromMap({'id': doc.id, ...doc.data()!});
+
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => new_frosted.FrostedPlanDialog(
+          plan: plan,
+          fetchParticipants: _fetchAllPlanParticipants,
+        ),
+      ),
+    );
+  }
+
+  Future<List<Map<String, dynamic>>> _fetchAllPlanParticipants(
+      PlanModel plan) async {
+    final List<Map<String, dynamic>> res = [];
+    final uids = plan.participants ?? [];
+    for (final uid in uids) {
+      final uDoc =
+          await FirebaseFirestore.instance.collection('users').doc(uid).get();
+      if (uDoc.exists) {
+        final d = uDoc.data()!;
+        res.add({
+          'uid': uid,
+          'name': d['name'] ?? 'Usuario',
+          'age': d['age']?.toString() ?? '',
+          'photoUrl': d['photoUrl'] ?? '',
+          'isCreator': uid == plan.createdBy,
+        });
+      }
+    }
+    return res;
   }
 }
 
@@ -302,11 +395,25 @@ class _UserItem {
   final String name;
   final String? age;
   final String photoUrl;
+  final String? upcomingPlanId;
+  final String? upcomingPlanName;
+  final int additionalPlans;
 
   _UserItem({
     required this.uid,
     required this.name,
     required this.age,
     required this.photoUrl,
+    this.upcomingPlanId,
+    this.upcomingPlanName,
+    this.additionalPlans = 0,
   });
+}
+
+class _PlanInfo {
+  final String id;
+  final String name;
+  final int additional;
+
+  _PlanInfo({required this.id, required this.name, required this.additional});
 }


### PR DESCRIPTION
## Resumen
- extrae consulta de planes en `FollowingScreen`
- muestra nombre de próximo plan y cantidad adicional al listar seguidores/seguidos

## Testing
- `dart` y `flutter` no están disponibles, por lo que no se pudieron ejecutar los análisis.

------
https://chatgpt.com/codex/tasks/task_e_68641e6eeec88332bb3754ff2b8805d7