### PR TITLE
Add English localization for settings screens

### DIFF
--- a/app_src/lib/explore_screen/menu_side_bar/settings/account.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/settings/account.dart
@@ -11,9 +11,10 @@ class AccountScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context);
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Cuenta'),
+        title: Text(t.account),
       ),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 20.0),
@@ -32,7 +33,7 @@ class AccountScreen extends StatelessWidget {
                       width: 24,
                       height: 24,
                     ),
-                    title: const Text('Editar perfil'),
+                    title: Text(t.editProfile),
                     trailing: const Icon(Icons.chevron_right),
                     onTap: () {
                       Navigator.push(
@@ -48,7 +49,7 @@ class AccountScreen extends StatelessWidget {
                       width: 24,
                       height: 24,
                     ),
-                    title: const Text('Cambiar la contraseña de tu cuenta'),
+                    title: Text(t.changeAccountPassword),
                     trailing: const Icon(Icons.chevron_right),
                     onTap: () {
                       Navigator.push(
@@ -65,27 +66,27 @@ class AccountScreen extends StatelessWidget {
                       height: 24,
                       color: Colors.red,
                     ),
-                    title: const Text(
-                      'Eliminar mi perfil',
-                      style: TextStyle(color: Colors.red),
+                    title: Text(
+                      t.deleteProfile,
+                      style: const TextStyle(color: Colors.red),
                     ),
                     onTap: () {
                       showDialog(
                         context: context,
                         builder: (ctx) => AlertDialog(
-                          title: const Text('Confirmar eliminación'),
-                          content: const Text('¿Estás seguro de que quieres eliminar tu perfil?'),
+                          title: Text(t.deleteConfirmation),
+                          content: Text(t.deleteQuestion),
                           actions: [
                             TextButton(
                               onPressed: () => Navigator.of(ctx).pop(),
-                              child: const Text('Cancelar'),
+                              child: Text(t.cancel),
                             ),
                             TextButton(
                               onPressed: () async {
                                 Navigator.of(ctx).pop();
                                 await _deleteAccount(context);
                               },
-                              child: const Text('Aceptar'),
+                              child: Text(t.accept),
                             ),
                           ],
                         ),
@@ -164,11 +165,11 @@ Future<void> _deleteAccount(BuildContext context) async {
         context: context,
         barrierDismissible: false,
         builder: (ctx) => AlertDialog(
-          content: const Text('Tu cuenta se ha eliminado correctamente.'),
+          content: Text(t.deleteSuccess),
           actions: [
             TextButton(
               onPressed: () => Navigator.of(ctx).pop(),
-              child: const Text('Aceptar'),
+              child: Text(t.accept),
             ),
           ],
         ),
@@ -238,24 +239,23 @@ class _ReauthDialogState extends State<_ReauthDialog> {
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context);
     return AlertDialog(
-      title: const Text('Reautenticación requerida'),
+      title: Text(t.reauthRequired),
       content: SingleChildScrollView(
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const Text(
-                'Por cuestiones de seguridad debes introducir tus credenciales de inicio de sesión para eliminar tu cuenta definitivamente'),
+            Text(t.reauthExplanation),
             const SizedBox(height: 16),
             TextField(
               controller: _emailCtrl,
-              decoration: const InputDecoration(
-                  labelText: 'Correo electrónico o teléfono'),
+              decoration: InputDecoration(labelText: t.emailOrPhone),
             ),
             TextField(
               controller: _passCtrl,
               obscureText: true,
-              decoration: const InputDecoration(labelText: 'Contraseña'),
+              decoration: InputDecoration(labelText: t.password),
             ),
           ],
         ),
@@ -263,7 +263,7 @@ class _ReauthDialogState extends State<_ReauthDialog> {
       actions: [
         TextButton(
           onPressed: () => Navigator.of(context).pop(false),
-          child: const Text('Cancelar'),
+          child: Text(t.cancel),
         ),
         TextButton(
           onPressed: () async {
@@ -281,19 +281,18 @@ class _ReauthDialogState extends State<_ReauthDialog> {
               await showDialog(
                 context: context,
                 builder: (_) => AlertDialog(
-                  content: const Text(
-                      'No ha sido posible autenticarte. Credenciales incorrectas.'),
+                  content: Text(t.reauthFailed),
                   actions: [
                     TextButton(
                       onPressed: () => Navigator.of(context).pop(),
-                      child: const Text('Aceptar'),
+                      child: Text(t.accept),
                     ),
                   ],
                 ),
               );
             }
           },
-          child: const Text('Continuar con la eliminación'),
+          child: Text(t.continueDelete),
         ),
       ],
     );
@@ -343,7 +342,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
     final age = int.tryParse(_ageController.text.trim());
     if (name.isEmpty || username.isEmpty || age == null) {
       ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Campos inválidos')));
+          .showSnackBar(SnackBar(content: Text(t.invalidFields)));
       return;
     }
 
@@ -360,7 +359,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
       });
       if (mounted) {
         ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Perfil actualizado')));
+            .showSnackBar(SnackBar(content: Text(t.profileUpdated)));
         Navigator.of(context).pop();
       }
     } catch (e) {
@@ -382,30 +381,30 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
     }
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Editar perfil')),
+      appBar: AppBar(title: Text(t.editProfile)),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
           children: [
             TextField(
               controller: _nameController,
-              decoration: const InputDecoration(labelText: 'Nombre'),
+              decoration: InputDecoration(labelText: t.name),
             ),
             TextField(
               controller: _usernameController,
-              decoration: const InputDecoration(labelText: 'Nombre de usuario'),
+              decoration: InputDecoration(labelText: t.username),
             ),
             TextField(
               controller: _ageController,
               keyboardType: TextInputType.number,
-              decoration: const InputDecoration(labelText: 'Edad'),
+              decoration: InputDecoration(labelText: t.age),
             ),
             const SizedBox(height: 20),
             SizedBox(
               width: double.infinity,
               child: ElevatedButton(
                 onPressed: _saving ? null : _save,
-                child: const Text('Guardar'),
+                child: Text(t.save),
               ),
             ),
           ],
@@ -446,7 +445,7 @@ class _ChangePasswordScreenState extends State<ChangePasswordScreen> {
     final confirm = _confirmController.text;
     if (current.isEmpty || newPwd.isEmpty || newPwd != confirm) {
       ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Revisa los campos')));
+          .showSnackBar(SnackBar(content: Text(t.checkFields)));
       return;
     }
 
@@ -458,7 +457,7 @@ class _ChangePasswordScreenState extends State<ChangePasswordScreen> {
       await user.updatePassword(newPwd);
       if (mounted) {
         ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Contraseña actualizada')));
+            .showSnackBar(SnackBar(content: Text(t.passwordUpdated)));
         Navigator.of(context).pop();
       }
     } on FirebaseAuthException catch (e) {
@@ -473,8 +472,9 @@ class _ChangePasswordScreenState extends State<ChangePasswordScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context);
     return Scaffold(
-      appBar: AppBar(title: const Text('Cambiar contraseña')),
+      appBar: AppBar(title: Text(t.changePassword)),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
@@ -482,26 +482,24 @@ class _ChangePasswordScreenState extends State<ChangePasswordScreen> {
             TextField(
               controller: _currentController,
               obscureText: true,
-              decoration:
-                  const InputDecoration(labelText: 'Contraseña actual'),
+              decoration: InputDecoration(labelText: t.currentPassword),
             ),
             TextField(
               controller: _newController,
               obscureText: true,
-              decoration: const InputDecoration(labelText: 'Nueva contraseña'),
+              decoration: InputDecoration(labelText: t.newPassword),
             ),
             TextField(
               controller: _confirmController,
               obscureText: true,
-              decoration:
-                  const InputDecoration(labelText: 'Confirmar contraseña'),
+              decoration: InputDecoration(labelText: t.confirmPassword),
             ),
             const SizedBox(height: 20),
             SizedBox(
               width: double.infinity,
               child: ElevatedButton(
                 onPressed: _saving ? null : _change,
-                child: const Text('Actualizar'),
+                child: Text(t.update),
               ),
             ),
           ],

--- a/app_src/lib/explore_screen/menu_side_bar/settings/general_notifications.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/settings/general_notifications.dart
@@ -47,9 +47,10 @@ class _GeneralNotificationsScreenState extends State<GeneralNotificationsScreen>
       );
     }
 
+    final t = AppLocalizations.of(context);
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Notificaciones'),
+        title: Text(t.notifications),
         leading: BackButton(onPressed: () => Navigator.of(context).pop()),
       ),
       backgroundColor: Colors.grey.shade200,
@@ -58,9 +59,9 @@ class _GeneralNotificationsScreenState extends State<GeneralNotificationsScreen>
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Text(
-              'Activa o desactiva las notificaciones globales de Plan.',
-              style: TextStyle(fontSize: 12, color: Colors.black54),
+            Text(
+              t.notificationsDesc,
+              style: const TextStyle(fontSize: 12, color: Colors.black54),
             ),
             const SizedBox(height: 8),
             Material(
@@ -70,10 +71,10 @@ class _GeneralNotificationsScreenState extends State<GeneralNotificationsScreen>
                 padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
                 child: Row(
                   children: [
-                    const Expanded(
-                      child: Text('Habilitar notificaciones', style: TextStyle(fontSize: 16)),
+                    Expanded(
+                      child: Text(t.enableNotifications, style: const TextStyle(fontSize: 16)),
                     ),
-                    Text(_enabled ? 'Habilitado' : 'Deshabilitado',
+                    Text(_enabled ? t.enabled : t.disabled,
                         style: const TextStyle(fontSize: 14, color: Colors.black54)),
                     const SizedBox(width: 8),
                     Switch(
@@ -90,13 +91,12 @@ class _GeneralNotificationsScreenState extends State<GeneralNotificationsScreen>
             ),
             const SizedBox(height: 32),
             // Espacio reservado para notificaciones de chat
-            const Text(
-              'Chat (pendiente de implementación)',
-              style: TextStyle(fontSize: 12, fontStyle: FontStyle.italic, color: Colors.black45),
+            Text(
+              t.chatPending,
+              style: const TextStyle(fontSize: 12, fontStyle: FontStyle.italic, color: Colors.black45),
             ),
           ],
         ),
       ),
     );
-  }
-}
+  }}

--- a/app_src/lib/explore_screen/menu_side_bar/settings/help_center.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/settings/help_center.dart
@@ -10,8 +10,9 @@ class HelpCenterScreen extends StatefulWidget {
 }
 
 class _HelpCenterScreenState extends State<HelpCenterScreen> {
-  /// Lista de preguntas y respuestas que se muestran en la pantalla.
-  final List<Map<String, String>> _faqs = [
+  /// Preguntas frecuentes por idioma.
+  final Map<String, List<Map<String, String>>> _faqsByLang = {
+    'es': [
     {
       'q': '¿Cómo creo un nuevo plan?',
       'a': '1. Toca el botón “+” para abrir el formulario de creación de plan.\n'
@@ -87,20 +88,99 @@ class _HelpCenterScreenState extends State<HelpCenterScreen> {
           '• Dashboard avanzado con exportación CSV y reportes mensuales.\n'
           '• Atención al cliente en tiempo real y acceso anticipado a funcionalidades beta.'
     },
-  ];
+    ],
+    'en': [
+      {
+        'q': 'How do I create a new plan?',
+        'a': '1. Tap the “+” button to open the plan creation form.\n'
+            '2. Select or type the plan type in the selector.\n'
+            '3. Add up to 3 images or 1 video by tapping “Multimedia content” and choose from gallery or camera (video max 15s).\n'
+            '4. Tap “Plan date and time” to choose dates and times; check “All day” or “Include end date” if you want.\n'
+            '5. Select the meeting point on the map to set the location.\n'
+            '6. Adjust the age restriction with the slider and set the maximum participants.\n'
+            '7. Write a brief description of the plan.\n'
+            '8. Choose the visibility (Public, Private or Only my followers).\n'
+            '9. Finally tap “Finish Plan” and your plan will be published. You can see it in “My plans” and share it with friends.'
+      },
+      {
+        'q': 'How do I search for plans near me?',
+        'a': '1. Open the Explore section by tapping the house icon in the bottom bar.\n'
+            '2. The list of users is sorted by proximity using your location and the computeDistance function.\n'
+            '3. Adjust filters: tap the funnel icon to filter by age or distance.\n'
+            '4. If you prefer a map, tap the map icon in the bottom bar to see markers of users with public plans.\n'
+            '5. Tap a marker or a profile in the list to see their plans (PlanCard) and join.'
+      },
+      {
+        'q': 'How do I invite someone to a plan?',
+        'a': '1. On the profile of a user without plans, tap the “Invite to a Plan” button.\n'
+            '2. Choose “Existing” to select one of your active plans or “New” to create a private plan.\n'
+            '3. If you select Existing, choose a plan from the list and confirm the invitation in the dialog.\n'
+            '4. If you select New, complete the quick private plan form (type, date, location and description) and finish.\n'
+            '5. Upon confirming, a notification is sent to the invited user and you will see a success message.'
+      },
+      {
+        'q': 'What is a private plan?',
+        'a': 'A private plan is only visible to you and the people you share it with. Nobody else can see it or join.'
+      },
+      {
+        'q': 'How does the map work?',
+        'a': 'The map shows all public plans you can interact with and join if you want. '
+            'You can see the location of plans on the map and tap the markers to see more details about each plan. '
+            'You can also filter plans according to your interests and preferences. '
+            'You can zoom in, zoom out and move the map to see plans all over the world.'
+      },
+      {
+        'q': 'How do privilege levels work?',
+        'a': 'Levels define advantages and additional tools according to your activity in the app:\n'
+            '\n'
+            '**Basic**\n'
+            '• Create 1 active plan at a time.\n'
+            '• Join public plans without limit.\n'
+            '• Basic chat inside the plan.\n'
+            '• Support via FAQ and email.\n'
+            '\n'
+            '**Premium**\n'
+            '• Everything above plus more features to enhance your experience:\n'
+            '• Create up to 3 active plans at a time and recurring plans (e.g. every Friday).\n'
+            '• Add up to 10 photos + 1 long video (30 s) to promote your plans.\n'
+            '• Co-organizers: assign 1 person to help you manage the plan.\n'
+            '• Custom push notifications (choose when reminders are sent).\n'
+            '\n'
+            '**Golden**\n'
+            '• Create events with price (in-app ticketing); the app charges the standard fee.\n'
+            '• Combine your account as normal user and event/plan organizer company.\n'
+            '• Create unlimited active plans at the same time.\n'
+            '• Configure participant admission based on their privilege level (e.g. only Golden/VIP users can join).\n'
+            '• Boost your plan once per week to appear first in the list and with a golden pin on the map.\n'
+            '• Analytics: see who visited your plans, confirmation rate and interest heatmap.\n'
+            '• Customer support via chat with response in less than 24 hours.\n'
+            '\n'
+            '**VIP**\n'
+            '• All previous benefits without limits plus top priority in the discovery algorithm.\n'
+            '• Verified badge and unique short URL to share plans.\n'
+            '• Possibility to sponsor plans (your logo visible on the Explore cover).\n'
+            '• Multiple co-organizers and custom roles (moderator, photographer, etc.).\n'
+            '• Advanced dashboard with CSV export and monthly reports.\n'
+            '• Real-time customer support and early access to beta features.'
+      },
+    ],
+  };
 
   String _search = '';
 
   @override
   Widget build(BuildContext context) {
-    final filtered = _faqs.where((item) {
+    final locale = Localizations.localeOf(context).languageCode;
+    final faqs = _faqsByLang[locale] ?? _faqsByLang['es']!;
+    final filtered = faqs.where((item) {
       final text = (item['q']! + ' ' + item['a']!).toLowerCase();
       return text.contains(_search.toLowerCase());
     }).toList();
 
+    final t = AppLocalizations.of(context);
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Centro de ayuda'),
+        title: Text(t.helpCenter),
         leading: BackButton(onPressed: () => Navigator.of(context).pop()),
       ),
       backgroundColor: Colors.grey.shade200,
@@ -117,15 +197,15 @@ class _HelpCenterScreenState extends State<HelpCenterScreen> {
               ),
             ),
             const SizedBox(height: 12),
-            const Text(
-              '¿En qué te puedo ayudar?',
-              style: TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+            Text(
+              t.howHelp,
+              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
             ),
             const SizedBox(height: 8),
             // Buscador
             TextField(
               decoration: InputDecoration(
-                hintText: 'Buscar en preguntas...',
+                hintText: t.searchQuestionsHint,
                 prefixIcon: const Icon(Icons.search),
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(8),
@@ -136,9 +216,9 @@ class _HelpCenterScreenState extends State<HelpCenterScreen> {
               onChanged: (value) => setState(() => _search = value),
             ),
             const SizedBox(height: 16),
-            const Text(
-              'Preguntas más frecuentes',
-              style: TextStyle(
+            Text(
+              t.frequentQuestions,
+              style: const TextStyle(
                 fontSize: 14,
                 fontWeight: FontWeight.w600,
                 color: Colors.black54,

--- a/app_src/lib/explore_screen/menu_side_bar/settings/privacy.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/settings/privacy.dart
@@ -72,9 +72,10 @@ class _PrivacyScreenState extends State<PrivacyScreen> {
         body: Center(child: CircularProgressIndicator()),
       );
     }
+    final t = AppLocalizations.of(context);
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Privacidad'),
+        title: Text(t.privacy),
         leading: BackButton(onPressed: () => Navigator.of(context).pop()),
       ),
       backgroundColor: Colors.grey.shade200,
@@ -83,9 +84,9 @@ class _PrivacyScreenState extends State<PrivacyScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Text(
-              'Controla quién puede ver tu perfil.',
-              style: TextStyle(
+            Text(
+              t.controlProfileVisibility,
+              style: const TextStyle(
                 fontSize: 12,
                 color: Colors.black54,
               ),
@@ -101,12 +102,12 @@ class _PrivacyScreenState extends State<PrivacyScreen> {
                   children: [
                     Expanded(
                       child: Text(
-                        'Visibilidad',
+                        t.visibility,
                         style: const TextStyle(fontSize: 16),
                       ),
                     ),
                     Text(
-                      _isVisibilityPublic ? 'Público' : 'Privado',
+                      _isVisibilityPublic ? t.public : t.private,
                       style: const TextStyle(
                         fontSize: 14,
                         color: Colors.black54,
@@ -129,9 +130,9 @@ class _PrivacyScreenState extends State<PrivacyScreen> {
               ),
             ),
             const SizedBox(height: 24),
-            const Text(
-              'Permite que otros vean si estás en línea o tu última conexión.',
-              style: TextStyle(
+            Text(
+              t.activityPrivacyDesc,
+              style: const TextStyle(
                 fontSize: 12,
                 color: Colors.black54,
               ),
@@ -147,12 +148,12 @@ class _PrivacyScreenState extends State<PrivacyScreen> {
                   children: [
                     Expanded(
                       child: Text(
-                        'Estado de actividad',
+                        t.activityStatus,
                         style: const TextStyle(fontSize: 16),
                       ),
                     ),
                     Text(
-                      _isActivityPublic ? 'Público' : 'Privado',
+                      _isActivityPublic ? t.public : t.private,
                       style: const TextStyle(
                         fontSize: 14,
                         color: Colors.black54,

--- a/app_src/lib/l10n/app_localizations.dart
+++ b/app_src/lib/l10n/app_localizations.dart
@@ -19,6 +19,47 @@ class AppLocalizations {
       'report_failures': 'Reportar fallos de la aplicación',
       'send': 'Enviar',
       'search': 'Buscar',
+      'edit_profile': 'Editar perfil',
+      'change_account_password': 'Cambiar la contraseña de tu cuenta',
+      'delete_profile': 'Eliminar mi perfil',
+      'delete_confirmation': 'Confirmar eliminación',
+      'delete_question': '¿Estás seguro de que quieres eliminar tu perfil?',
+      'cancel': 'Cancelar',
+      'accept': 'Aceptar',
+      'delete_success': 'Tu cuenta se ha eliminado correctamente.',
+      'reauth_required': 'Reautenticación requerida',
+      'reauth_explanation': 'Por cuestiones de seguridad debes introducir tus credenciales de inicio de sesión para eliminar tu cuenta definitivamente',
+      'reauth_failed': 'No ha sido posible autenticarte. Credenciales incorrectas.',
+      'email_or_phone': 'Correo electrónico o teléfono',
+      'password': 'Contraseña',
+      'continue_delete': 'Continuar con la eliminación',
+      'name': 'Nombre',
+      'username': 'Nombre de usuario',
+      'age': 'Edad',
+      'save': 'Guardar',
+      'change_password': 'Cambiar contraseña',
+      'current_password': 'Contraseña actual',
+      'new_password': 'Nueva contraseña',
+      'confirm_password': 'Confirmar contraseña',
+      'update': 'Actualizar',
+      'invalid_fields': 'Campos inválidos',
+      'profile_updated': 'Perfil actualizado',
+      'check_fields': 'Revisa los campos',
+      'password_updated': 'Contraseña actualizada',
+      'visibility': 'Visibilidad',
+      'public': 'Público',
+      'private': 'Privado',
+      'control_profile_visibility': 'Controla quién puede ver tu perfil.',
+      'activity_privacy_desc': 'Permite que otros vean si estás en línea o tu última conexión.',
+      'activity_status': 'Estado de actividad',
+      'notifications_desc': 'Activa o desactiva las notificaciones globales de Plan.',
+      'enable_notifications': 'Habilitar notificaciones',
+      'enabled': 'Habilitado',
+      'disabled': 'Deshabilitado',
+      'chat_pending': 'Chat (pendiente de implementación)',
+      'how_help': '¿En qué te puedo ayudar?',
+      'search_questions_hint': 'Buscar en preguntas...',
+      'frequent_questions': 'Preguntas más frecuentes',
     },
     'en': {
       'settings': 'Settings',
@@ -34,6 +75,47 @@ class AppLocalizations {
       'report_failures': 'Report app failures',
       'send': 'Send',
       'search': 'Search',
+      'edit_profile': 'Edit profile',
+      'change_account_password': 'Change your account password',
+      'delete_profile': 'Delete my profile',
+      'delete_confirmation': 'Confirm deletion',
+      'delete_question': 'Are you sure you want to delete your profile?',
+      'cancel': 'Cancel',
+      'accept': 'Accept',
+      'delete_success': 'Your account has been deleted successfully.',
+      'reauth_required': 'Reauthentication required',
+      'reauth_explanation': 'For security reasons you must enter your login credentials to permanently delete your account',
+      'reauth_failed': 'Unable to authenticate. Wrong credentials.',
+      'email_or_phone': 'Email or phone',
+      'password': 'Password',
+      'continue_delete': 'Continue with deletion',
+      'name': 'Name',
+      'username': 'Username',
+      'age': 'Age',
+      'save': 'Save',
+      'change_password': 'Change password',
+      'current_password': 'Current password',
+      'new_password': 'New password',
+      'confirm_password': 'Confirm password',
+      'update': 'Update',
+      'invalid_fields': 'Invalid fields',
+      'profile_updated': 'Profile updated',
+      'check_fields': 'Check the fields',
+      'password_updated': 'Password updated',
+      'visibility': 'Visibility',
+      'public': 'Public',
+      'private': 'Private',
+      'control_profile_visibility': 'Control who can see your profile.',
+      'activity_privacy_desc': "Allow others to see if you're online or your last connection.",
+      'activity_status': 'Activity status',
+      'notifications_desc': 'Enable or disable Plan global notifications.',
+      'enable_notifications': 'Enable notifications',
+      'enabled': 'Enabled',
+      'disabled': 'Disabled',
+      'chat_pending': 'Chat (pending implementation)',
+      'how_help': 'How can I help you?',
+      'search_questions_hint': 'Search in questions...',
+      'frequent_questions': 'Frequently asked questions',
     },
   };
 
@@ -56,6 +138,47 @@ class AppLocalizations {
   String get reportFailures => _t('report_failures');
   String get send => _t('send');
   String get search => _t('search');
+  String get editProfile => _t('edit_profile');
+  String get changeAccountPassword => _t('change_account_password');
+  String get deleteProfile => _t('delete_profile');
+  String get deleteConfirmation => _t('delete_confirmation');
+  String get deleteQuestion => _t('delete_question');
+  String get cancel => _t('cancel');
+  String get accept => _t('accept');
+  String get deleteSuccess => _t('delete_success');
+  String get reauthRequired => _t('reauth_required');
+  String get reauthExplanation => _t('reauth_explanation');
+  String get reauthFailed => _t('reauth_failed');
+  String get emailOrPhone => _t('email_or_phone');
+  String get password => _t('password');
+  String get continueDelete => _t('continue_delete');
+  String get name => _t('name');
+  String get username => _t('username');
+  String get age => _t('age');
+  String get save => _t('save');
+  String get changePassword => _t('change_password');
+  String get currentPassword => _t('current_password');
+  String get newPassword => _t('new_password');
+  String get confirmPassword => _t('confirm_password');
+  String get update => _t('update');
+  String get invalidFields => _t('invalid_fields');
+  String get profileUpdated => _t('profile_updated');
+  String get checkFields => _t('check_fields');
+  String get passwordUpdated => _t('password_updated');
+  String get visibility => _t('visibility');
+  String get public => _t('public');
+  String get private => _t('private');
+  String get controlProfileVisibility => _t('control_profile_visibility');
+  String get activityPrivacyDesc => _t('activity_privacy_desc');
+  String get activityStatus => _t('activity_status');
+  String get notificationsDesc => _t('notifications_desc');
+  String get enableNotifications => _t('enable_notifications');
+  String get enabled => _t('enabled');
+  String get disabled => _t('disabled');
+  String get chatPending => _t('chat_pending');
+  String get howHelp => _t('how_help');
+  String get searchQuestionsHint => _t('search_questions_hint');
+  String get frequentQuestions => _t('frequent_questions');
 
   static const LocalizationsDelegate<AppLocalizations> delegate =
       _AppLocalizationsDelegate();


### PR DESCRIPTION
## Summary
- enable language switching for account, privacy, notifications, and help center screens
- translate UI strings via `AppLocalizations`
- add extensive translation data and getters

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e971a97608332b7ac0a3857f31ab6