### PR TITLE
Fix missing localization references

### DIFF
--- a/app_src/lib/explore_screen/menu_side_bar/settings/account.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/settings/account.dart
@@ -5,6 +5,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import '../../../start/welcome_screen.dart';
+import '../../../l10n/app_localizations.dart';
 
 class AccountScreen extends StatelessWidget {
   const AccountScreen({super.key});
@@ -106,6 +107,8 @@ class AccountScreen extends StatelessWidget {
 Future<void> _deleteAccount(BuildContext context) async {
   final user = FirebaseAuth.instance.currentUser;
   if (user == null) return;
+
+  final t = AppLocalizations.of(context);
 
   showDialog(
     context: context,
@@ -337,6 +340,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
   }
 
   Future<void> _save() async {
+    final t = AppLocalizations.of(context);
     final name = _nameController.text.trim();
     final username = _usernameController.text.trim();
     final age = int.tryParse(_ageController.text.trim());
@@ -374,6 +378,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context);
     if (_loading) {
       return const Scaffold(
         body: Center(child: CircularProgressIndicator()),
@@ -436,6 +441,7 @@ class _ChangePasswordScreenState extends State<ChangePasswordScreen> {
   bool _saving = false;
 
   Future<void> _change() async {
+    final t = AppLocalizations.of(context);
     final user = FirebaseAuth.instance.currentUser;
     final email = user?.email;
     if (user == null || email == null) return;

--- a/app_src/lib/explore_screen/menu_side_bar/settings/general_notifications.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/settings/general_notifications.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../../../services/notification_service.dart';
+import '../../../l10n/app_localizations.dart';
 
 class GeneralNotificationsScreen extends StatefulWidget {
   const GeneralNotificationsScreen({Key? key}) : super(key: key);

--- a/app_src/lib/explore_screen/menu_side_bar/settings/help_center.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/settings/help_center.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import '../../../l10n/app_localizations.dart';
 
 /// Pantalla de Centro de Ayuda con buscador y preguntas frecuentes.
 class HelpCenterScreen extends StatefulWidget {

--- a/app_src/lib/explore_screen/menu_side_bar/settings/privacy.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/settings/privacy.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import '../../../l10n/app_localizations.dart';
 
 class PrivacyScreen extends StatefulWidget {
   const PrivacyScreen({Key? key}) : super(key: key);


### PR DESCRIPTION
## Summary
- add `app_localizations` imports to settings screens
- access localization context in methods that lacked it

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e9bb12e6c83329756340f2b40e198