### PR TITLE
Remove chat placeholder

### DIFF
--- a/app_src/lib/explore_screen/menu_side_bar/settings/general_notifications.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/settings/general_notifications.dart
@@ -91,13 +91,7 @@ class _GeneralNotificationsScreenState extends State<GeneralNotificationsScreen>
               ),
             ),
             const SizedBox(height: 32),
-            // Espacio reservado para notificaciones de chat
-            Text(
-              t.chatPending,
-              style: const TextStyle(fontSize: 12, fontStyle: FontStyle.italic, color: Colors.black45),
-            ),
           ],
         ),
       ),
-    );
-  }}
+    );  }}

--- a/app_src/lib/l10n/app_localizations.dart
+++ b/app_src/lib/l10n/app_localizations.dart
@@ -56,7 +56,6 @@ class AppLocalizations {
       'enable_notifications': 'Habilitar notificaciones',
       'enabled': 'Habilitado',
       'disabled': 'Deshabilitado',
-      'chat_pending': 'Chat (pendiente de implementación)',
       'how_help': '¿En qué te puedo ayudar?',
       'search_questions_hint': 'Buscar en preguntas...',
       'frequent_questions': 'Preguntas más frecuentes',
@@ -112,7 +111,6 @@ class AppLocalizations {
       'enable_notifications': 'Enable notifications',
       'enabled': 'Enabled',
       'disabled': 'Disabled',
-      'chat_pending': 'Chat (pending implementation)',
       'how_help': 'How can I help you?',
       'search_questions_hint': 'Search in questions...',
       'frequent_questions': 'Frequently asked questions',
@@ -175,7 +173,6 @@ class AppLocalizations {
   String get enableNotifications => _t('enable_notifications');
   String get enabled => _t('enabled');
   String get disabled => _t('disabled');
-  String get chatPending => _t('chat_pending');
   String get howHelp => _t('how_help');
   String get searchQuestionsHint => _t('search_questions_hint');
   String get frequentQuestions => _t('frequent_questions');


### PR DESCRIPTION
## Summary
- remove chat pending text from general notifications screen
- drop unused `chat_pending` localization entries

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ea12960bc8332996331ce65dd9468