### PR TITLE
Fix translation for failure hint

### DIFF
--- a/app_src/lib/explore_screen/menu_side_bar/settings/settings_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/settings/settings_screen.dart
@@ -294,11 +294,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
                       child: TextField(
                         controller: _failureController,
                         maxLines: 5,
-                        decoration: const InputDecoration(
-                          hintText: 'Describe aquí el fallo...',
+                        decoration: InputDecoration(
+                          hintText:
+                              AppLocalizations.of(context).describeFailureHint,
                           border: InputBorder.none,
                           contentPadding:
-                              EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+                              const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
                         ),
                       ),
                     ),

--- a/app_src/lib/l10n/app_localizations.dart
+++ b/app_src/lib/l10n/app_localizations.dart
@@ -60,6 +60,7 @@ class AppLocalizations {
       'how_help': '¿En qué te puedo ayudar?',
       'search_questions_hint': 'Buscar en preguntas...',
       'frequent_questions': 'Preguntas más frecuentes',
+      'describe_failure_hint': 'Describe aquí el fallo...',
     },
     'en': {
       'settings': 'Settings',
@@ -116,6 +117,7 @@ class AppLocalizations {
       'how_help': 'How can I help you?',
       'search_questions_hint': 'Search in questions...',
       'frequent_questions': 'Frequently asked questions',
+      'describe_failure_hint': 'Describe the issue here...',
     },
   };
 
@@ -179,6 +181,7 @@ class AppLocalizations {
   String get howHelp => _t('how_help');
   String get searchQuestionsHint => _t('search_questions_hint');
   String get frequentQuestions => _t('frequent_questions');
+  String get describeFailureHint => _t('describe_failure_hint');
 
   static const LocalizationsDelegate<AppLocalizations> delegate =
       _AppLocalizationsDelegate();


### PR DESCRIPTION
## Summary
- add missing translation for 'Describe aquí el fallo...'
- use localized text in `settings_screen.dart`

## Testing
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ea1c64ecc8332927d680cc85b12a3