### PR TITLE
Add empty-plan messages with translations

### DIFF
--- a/app_src/lib/explore_screen/menu_side_bar/favourites_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/favourites_screen.dart
@@ -8,6 +8,7 @@ import '../plans_managing/plan_card.dart';
 import '../../models/plan_model.dart';
 import '../../main/colors.dart';
 import '../main_screen/explore_screen.dart';
+import '../../l10n/app_localizations.dart';
 
 class FavouritesScreen extends StatelessWidget {
   const FavouritesScreen({Key? key}) : super(key: key);
@@ -80,10 +81,14 @@ class FavouritesScreen extends StatelessWidget {
             return const Center(child: CircularProgressIndicator());
           }
           if (!snapshot.hasData || !snapshot.data!.exists) {
-            return const Center(
+            final t = AppLocalizations.of(context);
+            return Center(
               child: Text(
-                'No tienes planes favoritos aún.',
-                style: TextStyle(color: Colors.white),
+                t.noFavouritePlansYet,
+                style: const TextStyle(
+                  color: Colors.grey,
+                  fontStyle: FontStyle.italic,
+                ),
               ),
             );
           }
@@ -91,10 +96,14 @@ class FavouritesScreen extends StatelessWidget {
           final data = snapshot.data!.data() as Map<String, dynamic>;
           final favouritePlanIds = List<String>.from(data['favourites'] ?? []);
           if (favouritePlanIds.isEmpty) {
-            return const Center(
+            final t = AppLocalizations.of(context);
+            return Center(
               child: Text(
-                'No tienes planes favoritos aún.',
-                style: TextStyle(color: Colors.white),
+                t.noFavouritePlansYet,
+                style: const TextStyle(
+                  color: Colors.grey,
+                  fontStyle: FontStyle.italic,
+                ),
               ),
             );
           }
@@ -106,10 +115,14 @@ class FavouritesScreen extends StatelessWidget {
                 return const Center(child: CircularProgressIndicator());
               }
               if (!planSnapshot.hasData || planSnapshot.data!.isEmpty) {
-                return const Center(
+                final t = AppLocalizations.of(context);
+                return Center(
                   child: Text(
-                    'No tienes planes favoritos aún.',
-                    style: TextStyle(color: Colors.white),
+                    t.noFavouritePlansYet,
+                    style: const TextStyle(
+                      color: Colors.grey,
+                      fontStyle: FontStyle.italic,
+                    ),
                   ),
                 );
               }

--- a/app_src/lib/explore_screen/menu_side_bar/my_plans_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/my_plans_screen.dart
@@ -14,6 +14,7 @@ import '../plans_managing/plan_card.dart';
 import '../plans_managing/frosted_plan_dialog_state.dart' as new_frosted;
 
 import '../main_screen/explore_screen.dart';
+import '../../l10n/app_localizations.dart';
 
 
 class MyPlansScreen extends StatelessWidget {
@@ -92,10 +93,14 @@ class MyPlansScreen extends StatelessWidget {
             return const Center(child: CircularProgressIndicator());
           }
           if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
-            return const Center(
+            final t = AppLocalizations.of(context);
+            return Center(
               child: Text(
-                'No tienes planes aún.',
-                style: TextStyle(color: Colors.white),
+                t.noPlansCreatedYet,
+                style: const TextStyle(
+                  color: Colors.grey,
+                  fontStyle: FontStyle.italic,
+                ),
               ),
             );
           }

--- a/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
@@ -13,6 +13,7 @@ import '../plans_managing/frosted_plan_dialog_state.dart' as new_frosted;
 import '../plans_managing/plan_card.dart';
 
 import '../main_screen/explore_screen.dart';
+import '../../l10n/app_localizations.dart';
 
 class SubscribedPlansScreen extends StatelessWidget {
   final String userId;
@@ -299,10 +300,14 @@ class SubscribedPlansScreen extends StatelessWidget {
           return const Center(child: CircularProgressIndicator());
         }
         if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
-          return const Center(
+          final t = AppLocalizations.of(context);
+          return Center(
             child: Text(
-              'No tienes planes suscritos aún.',
-              style: TextStyle(color: Colors.white),
+              t.noJoinedPlansYet,
+              style: const TextStyle(
+                color: Colors.grey,
+                fontStyle: FontStyle.italic,
+              ),
             ),
           );
         }
@@ -320,10 +325,14 @@ class SubscribedPlansScreen extends StatelessWidget {
             }
             final plans = planSnapshot.data!;
             if (plans.isEmpty) {
-              return const Center(
+              final t = AppLocalizations.of(context);
+              return Center(
                 child: Text(
-                  'No tienes planes suscritos aún.',
-                  style: TextStyle(color: Colors.white),
+                  t.noJoinedPlansYet,
+                  style: const TextStyle(
+                    color: Colors.grey,
+                    fontStyle: FontStyle.italic,
+                  ),
                 ),
               );
             }

--- a/app_src/lib/l10n/app_localizations.dart
+++ b/app_src/lib/l10n/app_localizations.dart
@@ -60,6 +60,9 @@ class AppLocalizations {
       'search_questions_hint': 'Buscar en preguntas...',
       'frequent_questions': 'Preguntas más frecuentes',
       'describe_failure_hint': 'Describe aquí el fallo...',
+      'no_plans_created_yet': 'No tienes creado ningún plan aún...',
+      'no_favourite_plans_yet': 'No tienes ningún plan favorito aún...',
+      'no_joined_plans_yet': 'No te has unido a ningún plan aún...',
     },
     'en': {
       'settings': 'Settings',
@@ -116,6 +119,9 @@ class AppLocalizations {
       'search_questions_hint': 'Search in questions...',
       'frequent_questions': 'Frequently asked questions',
       'describe_failure_hint': 'Describe the issue here...',
+      'no_plans_created_yet': "You haven't created any plans yet...",
+      'no_favourite_plans_yet': "You don't have any favourite plans yet...",
+      'no_joined_plans_yet': "You haven't joined any plans yet...",
     },
   };
 
@@ -179,6 +185,9 @@ class AppLocalizations {
   String get searchQuestionsHint => _t('search_questions_hint');
   String get frequentQuestions => _t('frequent_questions');
   String get describeFailureHint => _t('describe_failure_hint');
+  String get noPlansCreatedYet => _t('no_plans_created_yet');
+  String get noFavouritePlansYet => _t('no_favourite_plans_yet');
+  String get noJoinedPlansYet => _t('no_joined_plans_yet');
 
   static const LocalizationsDelegate<AppLocalizations> delegate =
       _AppLocalizationsDelegate();


### PR DESCRIPTION
## Summary
- provide English/Spanish strings for empty plan states
- show grey italic messages in MyPlans, Favourites and Subscribed screens when no plans are present

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ea42ff9a8833280925f6b4cadf86b