### PR TITLE
Translate sidebar menu to English

### DIFF
--- a/app_src/lib/explore_screen/menu_side_bar/favourites_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/favourites_screen.dart
@@ -3,6 +3,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import '../../l10n/app_localizations.dart';
 
 import '../plans_managing/plan_card.dart';
 import '../../models/plan_model.dart';
@@ -181,9 +182,9 @@ class FavouritesScreen extends StatelessWidget {
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  const Text(
-                    'Planes favoritos',
-                    style: TextStyle(
+                  Text(
+                    AppLocalizations.of(context).favouritePlans,
+                    style: const TextStyle(
                       color: Colors.black,
                       fontSize: 22,
                       fontWeight: FontWeight.bold,

--- a/app_src/lib/explore_screen/menu_side_bar/menu_side_bar_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/menu_side_bar_screen.dart
@@ -6,6 +6,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:url_launcher/url_launcher.dart';
+import '../../l10n/app_localizations.dart';
 
 import 'package:dating_app/main/colors.dart';
 import 'my_plans_screen.dart';
@@ -116,7 +117,7 @@ class MainSideBarScreenState extends State<MainSideBarScreen> {
                       _buildProfileHeader(),
                       _buildMenuItemWithBadge(
                         icon: 'assets/icono-calendario.svg',
-                        title: 'Mis Planes',
+                        title: AppLocalizations.of(context).myPlans,
                         destination: const MyPlansScreen(),
                         iconColor: Colors.white,
                         textColor: Colors.white,
@@ -128,7 +129,7 @@ class MainSideBarScreenState extends State<MainSideBarScreen> {
                       ),
                       _buildMenuItemWithBadge(
                         icon: 'assets/union.svg',
-                        title: 'Planes Suscritos',
+                        title: AppLocalizations.of(context).subscribedPlans,
                         destination: SubscribedPlansScreen(
                           userId: currentUserId ?? '',
                         ),
@@ -142,7 +143,7 @@ class MainSideBarScreenState extends State<MainSideBarScreen> {
                       ),
                       _buildMenuItemWithBadge(
                         icon: 'assets/icono-corazon.svg',
-                        title: 'Favoritos',
+                        title: AppLocalizations.of(context).favourites,
                         destination: const FavouritesScreen(),
                         iconColor: Colors.white,
                         textColor: Colors.white,
@@ -154,7 +155,7 @@ class MainSideBarScreenState extends State<MainSideBarScreen> {
                       ),
                       _buildMenuItem(
                         icon: 'assets/icono-ajustes.svg',
-                        title: 'Ajustes',
+                        title: AppLocalizations.of(context).settings,
                         destination: const SettingsScreen(),
                         iconColor: Colors.white,
                         textColor: Colors.white,
@@ -162,7 +163,7 @@ class MainSideBarScreenState extends State<MainSideBarScreen> {
                       ),
                       _buildMenuItem(
                         icon: 'assets/icono-cerrar-sesion.svg',
-                        title: 'Cerrar Sesión',
+                        title: AppLocalizations.of(context).closeSession,
                         destination: const CloseSessionScreen(),
                         iconColor: Colors.red,
                         textColor: Colors.red,
@@ -205,7 +206,7 @@ class MainSideBarScreenState extends State<MainSideBarScreen> {
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       Text(
-                        'Síguenos también en:',
+                        AppLocalizations.of(context).followUs,
                         style: GoogleFonts.roboto(color: Colors.white),
                         textAlign: TextAlign.center,
                       ),

--- a/app_src/lib/explore_screen/menu_side_bar/my_plans_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/my_plans_screen.dart
@@ -5,6 +5,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:intl/intl.dart';
+import '../../l10n/app_localizations.dart';
 
 import '../../models/plan_model.dart';
 import '../../main/colors.dart';
@@ -129,9 +130,9 @@ class MyPlansScreen extends StatelessWidget {
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  const Text(
-                    'Mis planes',
-                    style: TextStyle(
+                  Text(
+                    AppLocalizations.of(context).myPlans,
+                    style: const TextStyle(
                       color: Colors.black,
                       fontSize: 22,
                       fontWeight: FontWeight.bold,

--- a/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
@@ -5,6 +5,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:share_plus/share_plus.dart';
+import '../../l10n/app_localizations.dart';
 
 import '../../models/plan_model.dart';
 import '../../main/colors.dart';
@@ -381,9 +382,9 @@ class SubscribedPlansScreen extends StatelessWidget {
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  const Text(
-                    'Planes suscritos',
-                    style: TextStyle(
+                  Text(
+                    AppLocalizations.of(context).subscribedPlans,
+                    style: const TextStyle(
                       color: Colors.black,
                       fontSize: 22,
                       fontWeight: FontWeight.bold,

--- a/app_src/lib/l10n/app_localizations.dart
+++ b/app_src/lib/l10n/app_localizations.dart
@@ -59,6 +59,12 @@ class AppLocalizations {
       'how_help': '¿En qué te puedo ayudar?',
       'search_questions_hint': 'Buscar en preguntas...',
       'frequent_questions': 'Preguntas más frecuentes',
+      'my_plans': 'Mis planes',
+      'subscribed_plans': 'Planes suscritos',
+      'favourites': 'Favoritos',
+      'favourite_plans': 'Planes favoritos',
+      'close_session': 'Cerrar sesión',
+      'follow_us': 'Síguenos también en:',
     },
     'en': {
       'settings': 'Settings',
@@ -114,6 +120,12 @@ class AppLocalizations {
       'how_help': 'How can I help you?',
       'search_questions_hint': 'Search in questions...',
       'frequent_questions': 'Frequently asked questions',
+      'my_plans': 'My plans',
+      'subscribed_plans': 'Subscribed plans',
+      'favourites': 'Favourites',
+      'favourite_plans': 'Favourite plans',
+      'close_session': 'Log out',
+      'follow_us': 'Follow us also on:',
     },
   };
 
@@ -176,6 +188,12 @@ class AppLocalizations {
   String get howHelp => _t('how_help');
   String get searchQuestionsHint => _t('search_questions_hint');
   String get frequentQuestions => _t('frequent_questions');
+  String get myPlans => _t('my_plans');
+  String get subscribedPlans => _t('subscribed_plans');
+  String get favourites => _t('favourites');
+  String get favouritePlans => _t('favourite_plans');
+  String get closeSession => _t('close_session');
+  String get followUs => _t('follow_us');
 
   static const LocalizationsDelegate<AppLocalizations> delegate =
       _AppLocalizationsDelegate();


### PR DESCRIPTION
## Summary
- localize menu strings and screen titles
- add new labels to `AppLocalizations`

## Testing
- `flutter test test/widget_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ea32545c08332a09068de55248602