### PR TITLE
Mensajes y creación de planes desde pantallas vacías

### DIFF
--- a/app_src/lib/explore_screen/menu_side_bar/favourites_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/favourites_screen.dart
@@ -9,6 +9,62 @@ import '../../models/plan_model.dart';
 import '../../main/colors.dart';
 import '../../l10n/app_localizations.dart';
 import '../main_screen/explore_screen.dart';
+import '../../plan_creation/new_plan_creation_screen.dart';
+
+class _ExploreScreenWithNewPlan extends StatefulWidget {
+  const _ExploreScreenWithNewPlan();
+
+  @override
+  State<_ExploreScreenWithNewPlan> createState() => _ExploreScreenWithNewPlanState();
+}
+
+class _ExploreScreenWithNewPlanState extends State<_ExploreScreenWithNewPlan> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      NewPlanCreationScreen.showPopup(context);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const ExploreScreen();
+  }
+
+  Widget _buildEmptyState(BuildContext context, String message) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Text(
+          message,
+          style: const TextStyle(color: Colors.white),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 12),
+        GestureDetector(
+          onTap: () {
+            Navigator.pushReplacement(
+              context,
+              MaterialPageRoute(
+                builder: (_) => const _ExploreScreenWithNewPlan(),
+              ),
+            );
+          },
+          child: Container(
+            width: 40,
+            height: 40,
+            decoration: const BoxDecoration(
+              color: Colors.grey,
+              shape: BoxShape.circle,
+            ),
+            child: const Icon(Icons.add, color: Colors.white),
+          ),
+        ),
+      ],
+    );
+  }
+}
 
 class FavouritesScreen extends StatelessWidget {
   const FavouritesScreen({Key? key}) : super(key: key);
@@ -82,23 +138,15 @@ class FavouritesScreen extends StatelessWidget {
             return const Center(child: CircularProgressIndicator());
           }
           if (!snapshot.hasData || !snapshot.data!.exists) {
-            return const Center(
-              child: Text(
-                'No tienes planes favoritos aún.',
-                style: TextStyle(color: Colors.white),
-              ),
-            );
+            return _buildEmptyState(
+                context, 'No tienes planes favoritos aún...');
           }
 
           final data = snapshot.data!.data() as Map<String, dynamic>;
           final favouritePlanIds = List<String>.from(data['favourites'] ?? []);
           if (favouritePlanIds.isEmpty) {
-            return const Center(
-              child: Text(
-                'No tienes planes favoritos aún.',
-                style: TextStyle(color: Colors.white),
-              ),
-            );
+            return _buildEmptyState(
+                context, 'No tienes planes favoritos aún...');
           }
 
           return FutureBuilder<List<PlanModel>>(
@@ -108,12 +156,8 @@ class FavouritesScreen extends StatelessWidget {
                 return const Center(child: CircularProgressIndicator());
               }
               if (!planSnapshot.hasData || planSnapshot.data!.isEmpty) {
-                return const Center(
-                  child: Text(
-                    'No tienes planes favoritos aún.',
-                    style: TextStyle(color: Colors.white),
-                  ),
-                );
+                return _buildEmptyState(
+                    context, 'No tienes planes favoritos aún...');
               }
 
               final plans = planSnapshot.data!;

--- a/app_src/lib/explore_screen/menu_side_bar/my_plans_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/my_plans_screen.dart
@@ -16,6 +16,28 @@ import '../plans_managing/frosted_plan_dialog_state.dart' as new_frosted;
 
 import '../main_screen/explore_screen.dart';
 
+class _ExploreScreenWithNewPlan extends StatefulWidget {
+  const _ExploreScreenWithNewPlan();
+
+  @override
+  State<_ExploreScreenWithNewPlan> createState() => _ExploreScreenWithNewPlanState();
+}
+
+class _ExploreScreenWithNewPlanState extends State<_ExploreScreenWithNewPlan> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      NewPlanCreationScreen.showPopup(context);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const ExploreScreen();
+  }
+}
+
 
 class MyPlansScreen extends StatelessWidget {
   const MyPlansScreen({Key? key}) : super(key: key);
@@ -94,12 +116,7 @@ class MyPlansScreen extends StatelessWidget {
             return const Center(child: CircularProgressIndicator());
           }
           if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
-            return const Center(
-              child: Text(
-                'No tienes planes aún.',
-                style: TextStyle(color: Colors.white),
-              ),
-            );
+            return _buildEmptyState(context, 'No tienes planes creados aún...');
           }
 
           final plans = snapshot.data!.docs.map((doc) {
@@ -341,6 +358,39 @@ Widget _buildPlanTile(BuildContext context, PlanModel plan) {
           ],
         );
       },
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context, String message) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Text(
+          message,
+          style: const TextStyle(color: Colors.white),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 12),
+        GestureDetector(
+          onTap: () {
+            Navigator.pushReplacement(
+              context,
+              MaterialPageRoute(
+                builder: (_) => const _ExploreScreenWithNewPlan(),
+              ),
+            );
+          },
+          child: Container(
+            width: 40,
+            height: 40,
+            decoration: const BoxDecoration(
+              color: Colors.grey,
+              shape: BoxShape.circle,
+            ),
+            child: const Icon(Icons.add, color: Colors.white),
+          ),
+        ),
+      ],
     );
   }
 

--- a/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
@@ -14,6 +14,62 @@ import '../plans_managing/frosted_plan_dialog_state.dart' as new_frosted;
 import '../plans_managing/plan_card.dart';
 
 import '../main_screen/explore_screen.dart';
+import '../../plan_creation/new_plan_creation_screen.dart';
+
+class _ExploreScreenWithNewPlan extends StatefulWidget {
+  const _ExploreScreenWithNewPlan();
+
+  @override
+  State<_ExploreScreenWithNewPlan> createState() => _ExploreScreenWithNewPlanState();
+}
+
+class _ExploreScreenWithNewPlanState extends State<_ExploreScreenWithNewPlan> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      NewPlanCreationScreen.showPopup(context);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const ExploreScreen();
+  }
+
+  Widget _buildEmptyState(BuildContext context, String message) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Text(
+          message,
+          style: const TextStyle(color: Colors.white),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 12),
+        GestureDetector(
+          onTap: () {
+            Navigator.pushReplacement(
+              context,
+              MaterialPageRoute(
+                builder: (_) => const _ExploreScreenWithNewPlan(),
+              ),
+            );
+          },
+          child: Container(
+            width: 40,
+            height: 40,
+            decoration: const BoxDecoration(
+              color: Colors.grey,
+              shape: BoxShape.circle,
+            ),
+            child: const Icon(Icons.add, color: Colors.white),
+          ),
+        ),
+      ],
+    );
+  }
+}
 
 class SubscribedPlansScreen extends StatelessWidget {
   final String userId;
@@ -301,12 +357,8 @@ class SubscribedPlansScreen extends StatelessWidget {
           return const Center(child: CircularProgressIndicator());
         }
         if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
-          return const Center(
-            child: Text(
-              'No tienes planes suscritos aún.',
-              style: TextStyle(color: Colors.white),
-            ),
-          );
+          return _buildEmptyState(
+              context, 'No te has unido a ningún plan aún...');
         }
         final planIds = snapshot.data!.docs
             .map((doc) => (doc.data() as Map<String, dynamic>)['id'] as String?)
@@ -322,12 +374,8 @@ class SubscribedPlansScreen extends StatelessWidget {
             }
             final plans = planSnapshot.data!;
             if (plans.isEmpty) {
-              return const Center(
-                child: Text(
-                  'No tienes planes suscritos aún.',
-                  style: TextStyle(color: Colors.white),
-                ),
-              );
+              return _buildEmptyState(
+                  context, 'No te has unido a ningún plan aún...');
             }
 
             return ListView.builder(


### PR DESCRIPTION
## Resumen
- mensaje informativo en pantallas de planes cuando no hay tarjetas
- botón `+` que abre la creación de planes y regresa a `ExploreScreen`

## Testing
- `flutter analyze` *(falla: comando no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_686ebd7f33e48332b16dbe089973de67