### PR TITLE
Actualizar mensaje de planes suscritos vacíos

### DIFF
--- a/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
@@ -303,7 +303,7 @@ class SubscribedPlansScreen extends StatelessWidget {
         if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
           return const Center(
             child: Text(
-              'No tienes planes suscritos aún.',
+              'No te has unido a ningún plan aún...',
               style: TextStyle(color: Colors.white),
             ),
           );
@@ -324,7 +324,7 @@ class SubscribedPlansScreen extends StatelessWidget {
             if (plans.isEmpty) {
               return const Center(
                 child: Text(
-                  'No tienes planes suscritos aún.',
+                  'No te has unido a ningún plan aún...',
                   style: TextStyle(color: Colors.white),
                 ),
               );


### PR DESCRIPTION
## Summary
- mostrar el texto **"No te has unido a ningún plan aún..."** cuando el usuario no tiene planes suscritos

## Testing
- `flutter test` *(falla: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec475734c833298baecf71dec43b3