### PR TITLE
Add missing English translations

### DIFF
--- a/app_src/lib/explore_screen/menu_side_bar/favourites_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/favourites_screen.dart
@@ -82,10 +82,10 @@ class FavouritesScreen extends StatelessWidget {
             return const Center(child: CircularProgressIndicator());
           }
           if (!snapshot.hasData || !snapshot.data!.exists) {
-            return const Center(
+            return Center(
               child: Text(
-                'No tienes planes favoritos aún.',
-                style: TextStyle(color: Colors.white),
+                t.noFavouritePlansYet,
+                style: const TextStyle(color: Colors.white),
               ),
             );
           }
@@ -93,10 +93,10 @@ class FavouritesScreen extends StatelessWidget {
           final data = snapshot.data!.data() as Map<String, dynamic>;
           final favouritePlanIds = List<String>.from(data['favourites'] ?? []);
           if (favouritePlanIds.isEmpty) {
-            return const Center(
+            return Center(
               child: Text(
-                'No tienes planes favoritos aún.',
-                style: TextStyle(color: Colors.white),
+                t.noFavouritePlansYet,
+                style: const TextStyle(color: Colors.white),
               ),
             );
           }
@@ -108,10 +108,10 @@ class FavouritesScreen extends StatelessWidget {
                 return const Center(child: CircularProgressIndicator());
               }
               if (!planSnapshot.hasData || planSnapshot.data!.isEmpty) {
-                return const Center(
+                return Center(
                   child: Text(
-                    'No tienes planes favoritos aún.',
-                    style: TextStyle(color: Colors.white),
+                    t.noFavouritePlansYet,
+                    style: const TextStyle(color: Colors.white),
                   ),
                 );
               }

--- a/app_src/lib/explore_screen/menu_side_bar/my_plans_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/my_plans_screen.dart
@@ -94,10 +94,10 @@ class MyPlansScreen extends StatelessWidget {
             return const Center(child: CircularProgressIndicator());
           }
           if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
-            return const Center(
+            return Center(
               child: Text(
-                'No tienes planes aún.',
-                style: TextStyle(color: Colors.white),
+                t.noPlansYet,
+                style: const TextStyle(color: Colors.white),
               ),
             );
           }

--- a/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
@@ -301,10 +301,10 @@ class SubscribedPlansScreen extends StatelessWidget {
           return const Center(child: CircularProgressIndicator());
         }
         if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
-          return const Center(
+          return Center(
             child: Text(
-              'No te has unido a ningún plan aún...',
-              style: TextStyle(color: Colors.white),
+              t.noJoinedPlansYet,
+              style: const TextStyle(color: Colors.white),
             ),
           );
         }
@@ -322,10 +322,10 @@ class SubscribedPlansScreen extends StatelessWidget {
             }
             final plans = planSnapshot.data!;
             if (plans.isEmpty) {
-              return const Center(
+              return Center(
                 child: Text(
-                  'No te has unido a ningún plan aún...',
-                  style: TextStyle(color: Colors.white),
+                  t.noJoinedPlansYet,
+                  style: const TextStyle(color: Colors.white),
                 ),
               );
             }

--- a/app_src/lib/l10n/app_localizations.dart
+++ b/app_src/lib/l10n/app_localizations.dart
@@ -65,6 +65,9 @@ class AppLocalizations {
       'search_questions_hint': 'Buscar en preguntas...',
       'frequent_questions': 'Preguntas más frecuentes',
       'describe_failure_hint': 'Describe aquí el fallo...',
+      'no_plans_yet': 'No tienes planes aún.',
+      'no_joined_plans_yet': 'No te has unido a ningún plan aún...',
+      'no_favourite_plans_yet': 'No tienes planes favoritos aún.',
     },
     'en': {
       'settings': 'Settings',
@@ -126,6 +129,9 @@ class AppLocalizations {
       'search_questions_hint': 'Search in questions...',
       'frequent_questions': 'Frequently asked questions',
       'describe_failure_hint': 'Describe the issue here...',
+      'no_plans_yet': "You don't have any plans yet.",
+      'no_joined_plans_yet': "You haven't joined any plan yet...",
+      'no_favourite_plans_yet': "You don't have any favourite plans yet.",
     },
   };
 
@@ -194,6 +200,9 @@ class AppLocalizations {
   String get searchQuestionsHint => _t('search_questions_hint');
   String get frequentQuestions => _t('frequent_questions');
   String get describeFailureHint => _t('describe_failure_hint');
+  String get noPlansYet => _t('no_plans_yet');
+  String get noJoinedPlansYet => _t('no_joined_plans_yet');
+  String get noFavouritePlansYet => _t('no_favourite_plans_yet');
 
   static const LocalizationsDelegate<AppLocalizations> delegate =
       _AppLocalizationsDelegate();


### PR DESCRIPTION
## Summary
- extend localization strings for messages shown when there are no plans
- wire up translations in my plans, favourites and subscribed plans screens

## Testing
- `dart format` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec8aff11083328272fbbae121d38d