### PR TITLE
Fix logout screen initialization

### DIFF
--- a/app_src/lib/explore_screen/menu_side_bar/close_session_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/close_session_screen.dart
@@ -19,7 +19,7 @@ class _CloseSessionScreenState extends State<CloseSessionScreen> {
   @override
   void initState() {
     super.initState();
-    _logout();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _logout());
   }
 
   Future<void> _logout() async {


### PR DESCRIPTION
## Summary
- avoid calling `_logout` before the widget tree is ready by using a post-frame callback

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ecb8c6478833288a4b6d93d88ead0