### PR TITLE
Add English translations for explore filter

### DIFF
--- a/app_src/lib/explore_screen/main_screen/explore_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/explore_screen.dart
@@ -8,6 +8,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 import 'explore_screen_filter.dart';
+import '../../l10n/app_localizations.dart';
 import 'explore_app_bar.dart';
 import '../users_grid/users_grid.dart';
 import '../menu_side_bar/menu_side_bar_screen.dart';
@@ -190,6 +191,7 @@ class ExploreScreenState extends State<ExploreScreen> {
   }
 
   Widget _buildSearchContainer() {
+    final t = AppLocalizations.of(context);
     return Padding(
       padding: const EdgeInsets.only(left: 15, right: 15, top: 0, bottom: 10),
       child: Container(
@@ -239,10 +241,10 @@ class ExploreScreenState extends State<ExploreScreen> {
                             _showSearchResults = value.isNotEmpty;
                           });
                         },
-                        decoration: const InputDecoration(
-                          hintText: 'Buscar...',
+                        decoration: InputDecoration(
+                          hintText: '${t.search}...',
                           border: InputBorder.none,
-                          contentPadding: EdgeInsets.symmetric(horizontal: 8),
+                          contentPadding: const EdgeInsets.symmetric(horizontal: 8),
                         ),
                       ),
                     ),

--- a/app_src/lib/explore_screen/main_screen/explore_screen_filter.dart
+++ b/app_src/lib/explore_screen/main_screen/explore_screen_filter.dart
@@ -10,6 +10,7 @@ import 'package:geocoding/geocoding.dart';
 import '../../main/colors.dart'; // Define AppColors
 import '../../main/keys.dart'; // Contiene las claves APIKeys.androidApiKey y APIKeys.iosApiKey
 import '../../utils/plans_list.dart'; // Lista de planes
+import '../../l10n/app_localizations.dart';
 
 // El diálogo acepta opcionalmente filtros iniciales para preservar el último estado.
 class ExploreScreenFilterDialog extends StatefulWidget {
@@ -177,20 +178,19 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
       showDialog(
         context: context,
         builder: (context) => AlertDialog(
-          title: const Text('Permiso de ubicación'),
-          content: const Text(
-              'El permiso de ubicación ha sido denegado permanentemente. Ve a la configuración de la app para habilitarlo.'),
+          title: Text(t.locationPermissionTitle),
+          content: Text(t.locationPermissionMessage),
           actions: [
             TextButton(
               onPressed: () => Navigator.of(context).pop(),
-              child: const Text('Cancelar'),
+              child: Text(t.cancel),
             ),
             TextButton(
               onPressed: () {
                 openAppSettings();
                 Navigator.of(context).pop();
               },
-              child: const Text('Configuración'),
+              child: Text(t.configuration),
             ),
           ],
         ),
@@ -281,6 +281,7 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context);
     final List<Map<String, dynamic>> planSugeridos = planBusqueda.isNotEmpty
         ? plans.where((plan) {
             final nombre = plan['name'].toString().toLowerCase();
@@ -318,9 +319,9 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    const Text(
-                      'Filtrar Planes',
-                      style: TextStyle(
+                    Text(
+                      t.filterPlans,
+                      style: const TextStyle(
                         fontSize: 20,
                         fontWeight: FontWeight.bold,
                         color: AppColors.planColor,
@@ -334,14 +335,14 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        const Text(
-                          '¿Qué deseas ver?',
-                          style: TextStyle(fontSize: 16, color: Colors.black),
+                        Text(
+                          t.whatToShow,
+                          style: const TextStyle(fontSize: 16, color: Colors.black),
                         ),
                         Row(
                           children: [
                             Text(
-                              _onlyPlans ? 'Solo planes' : 'Todo',
+                              _onlyPlans ? t.onlyPlans : t.everything,
                               style: const TextStyle(
                                   fontSize: 14, color: Colors.black),
                             ),
@@ -368,8 +369,8 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
                     Align(
                       alignment: Alignment.centerLeft,
                       child: Text(
-                        'Planes',
-                        style: TextStyle(
+                        t.plans,
+                        style: const TextStyle(
                           fontSize: 16,
                           color: Colors.black,
                         ),
@@ -397,7 +398,7 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
                               border: Border.all(color: AppColors.greyBorder),
                             ),
                             child: Text(
-                              'Solo de personas que sigo',
+                              t.onlyFollowed,
                               style: TextStyle(
                                 color:
                                     _onlyFollowed ? Colors.white : Colors.black,
@@ -446,9 +447,9 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
                     ],
                     ),
                     const SizedBox(height: 10),
-                    const Text(
-                      '- o -',
-                      style: TextStyle(
+                    Text(
+                      t.orSeparator,
+                      style: const TextStyle(
                         color: Colors.black,
                         fontWeight: FontWeight.bold,
                       ),
@@ -461,7 +462,7 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
                         decoration: InputDecoration(
                           filled: true,
                           fillColor: AppColors.lightLilac,
-                          hintText: 'Busca por nombre...',
+                          hintText: t.searchByNameHint,
                           hintStyle: const TextStyle(
                             color: Colors.black54,
                           ),
@@ -526,8 +527,8 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
                       Align(
                         alignment: Alignment.centerLeft,
                         child: Text(
-                          '¿En qué región buscas planes?',
-                          style: TextStyle(
+                          t.searchRegion,
+                          style: const TextStyle(
                             fontSize: 16,
                             color: Colors.black,
                           ),
@@ -547,7 +548,7 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
                           decoration: InputDecoration(
                             filled: true,
                             fillColor: AppColors.lightLilac,
-                            hintText: 'Ciudad, país...',
+                            hintText: t.regionHint,
                             hintStyle: const TextStyle(
                               color: Colors.black54,
                             ),
@@ -613,8 +614,8 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
                       const SizedBox(height: 10),
                       Center(
                         child: Text(
-                          '- o -',
-                          style: TextStyle(
+                          t.orSeparator,
+                          style: const TextStyle(
                             color: Colors.black,
                             fontWeight: FontWeight.bold,
                           ),
@@ -634,7 +635,7 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
                         ),
                         onPressed: _requestLocationPermission,
                         child: Text(
-                          'Tu ubicación actual',
+                          t.currentLocation,
                           style: TextStyle(
                             color:
                                 locationAllowed ? Colors.white : Colors.black,
@@ -651,8 +652,8 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
                   Align(
                     alignment: Alignment.centerLeft,
                     child: Text(
-                      '¿Para qué fecha buscas planes?',
-                      style: TextStyle(
+                      t.planDateQuestion,
+                      style: const TextStyle(
                         fontSize: 16,
                         color: Colors.black,
                       ),
@@ -685,7 +686,7 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
                     child: Text(
                       _selectedDate != null
                           ? '${_selectedDate!.day}/${_selectedDate!.month}/${_selectedDate!.year}'
-                          : 'Selecciona una fecha',
+                          : t.selectDate,
                       style: const TextStyle(color: Colors.white),
                     ),
                   ),
@@ -697,8 +698,8 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
                   Align(
                     alignment: Alignment.centerLeft,
                     child: Text(
-                      '¿Qué rango de edad?',
-                      style: TextStyle(
+                      t.whatAgeRange,
+                      style: const TextStyle(
                         fontSize: 16,
                           color: Colors.black,
                         ),
@@ -750,9 +751,9 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
                         ),
                       ),
                       onPressed: _limpiarFiltros,
-                      child: const Text(
-                        'Limpiar Filtro',
-                        style: TextStyle(color: Colors.white),
+                      child: Text(
+                        t.clearFilter,
+                        style: const TextStyle(color: Colors.white),
                       ),
                     ),
                     const SizedBox(height: 10),
@@ -760,9 +761,9 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
                       mainAxisAlignment: MainAxisAlignment.end,
                       children: [
                         TextButton(
-                          child: const Text(
-                            'Cancelar',
-                            style: TextStyle(color: Colors.black),
+                          child: Text(
+                            t.cancel,
+                            style: const TextStyle(color: Colors.black),
                           ),
                           onPressed: () => Navigator.of(context).pop(),
                         ),
@@ -772,9 +773,9 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
                             backgroundColor: AppColors.planColor,
                           ),
                           onPressed: _aplicarFiltros,
-                          child: const Text(
-                            'Aceptar',
-                            style: TextStyle(color: Colors.white),
+                          child: Text(
+                            t.accept,
+                            style: const TextStyle(color: Colors.white),
                           ),
                         ),
                       ],

--- a/app_src/lib/l10n/app_localizations.dart
+++ b/app_src/lib/l10n/app_localizations.dart
@@ -68,6 +68,25 @@ class AppLocalizations {
       'no_plans_yet': 'No tienes planes aún.',
       'no_joined_plans_yet': 'No te has unido a ningún plan aún...',
       'no_favourite_plans_yet': 'No tienes planes favoritos aún.',
+      'location_permission_title': 'Permiso de ubicación',
+      'location_permission_message':
+          'El permiso de ubicación ha sido denegado permanentemente. Ve a la configuración de la app para habilitarlo.',
+      'configuration': 'Configuración',
+      'filter_plans': 'Filtrar Planes',
+      'what_to_show': '¿Qué deseas ver?',
+      'only_plans': 'Solo planes',
+      'everything': 'Todo',
+      'plans': 'Planes',
+      'only_followed': 'Solo de personas que sigo',
+      'or_separator': '- o -',
+      'search_by_name_hint': 'Busca por nombre...',
+      'search_region': '¿En qué región buscas planes?',
+      'region_hint': 'Ciudad, país...',
+      'current_location': 'Tu ubicación actual',
+      'plan_date_question': '¿Para qué fecha buscas planes?',
+      'select_date': 'Selecciona una fecha',
+      'what_age_range': '¿Qué rango de edad?',
+      'clear_filter': 'Limpiar Filtro',
     },
     'en': {
       'settings': 'Settings',
@@ -132,6 +151,25 @@ class AppLocalizations {
       'no_plans_yet': "You don't have any plans yet.",
       'no_joined_plans_yet': "You haven't joined any plan yet...",
       'no_favourite_plans_yet': "You don't have any favourite plans yet.",
+      'location_permission_title': 'Location permission',
+      'location_permission_message':
+          'Location permission has been permanently denied. Go to app settings to enable it.',
+      'configuration': 'Settings',
+      'filter_plans': 'Filter Plans',
+      'what_to_show': 'What do you want to see?',
+      'only_plans': 'Only plans',
+      'everything': 'Everything',
+      'plans': 'Plans',
+      'only_followed': 'Only from people I follow',
+      'or_separator': '- or -',
+      'search_by_name_hint': 'Search by name...',
+      'search_region': 'In which region are you looking for plans?',
+      'region_hint': 'City, country...',
+      'current_location': 'Your current location',
+      'plan_date_question': 'For what date are you looking for plans?',
+      'select_date': 'Select a date',
+      'what_age_range': 'What age range?',
+      'clear_filter': 'Clear Filter',
     },
   };
 
@@ -203,6 +241,24 @@ class AppLocalizations {
   String get noPlansYet => _t('no_plans_yet');
   String get noJoinedPlansYet => _t('no_joined_plans_yet');
   String get noFavouritePlansYet => _t('no_favourite_plans_yet');
+  String get locationPermissionTitle => _t('location_permission_title');
+  String get locationPermissionMessage => _t('location_permission_message');
+  String get configuration => _t('configuration');
+  String get filterPlans => _t('filter_plans');
+  String get whatToShow => _t('what_to_show');
+  String get onlyPlans => _t('only_plans');
+  String get everything => _t('everything');
+  String get plans => _t('plans');
+  String get onlyFollowed => _t('only_followed');
+  String get orSeparator => _t('or_separator');
+  String get searchByNameHint => _t('search_by_name_hint');
+  String get searchRegion => _t('search_region');
+  String get regionHint => _t('region_hint');
+  String get currentLocation => _t('current_location');
+  String get planDateQuestion => _t('plan_date_question');
+  String get selectDate => _t('select_date');
+  String get whatAgeRange => _t('what_age_range');
+  String get clearFilter => _t('clear_filter');
 
   static const LocalizationsDelegate<AppLocalizations> delegate =
       _AppLocalizationsDelegate();


### PR DESCRIPTION
## Summary
- translate search bar and filter dialog in ExploreScreen
- add new localization strings and getters

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ece337fd08332bbc6d2b1d14b09d5