### PR TITLE
Fix localization reference in permission dialog

### DIFF
--- a/app_src/lib/explore_screen/main_screen/explore_screen_filter.dart
+++ b/app_src/lib/explore_screen/main_screen/explore_screen_filter.dart
@@ -164,6 +164,7 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
   }
 
   Future<void> _requestLocationPermission() async {
+    final t = AppLocalizations.of(context);
     PermissionStatus status = await Permission.location.request();
 
     if (status.isGranted) {


### PR DESCRIPTION
## Summary
- use `AppLocalizations.of(context)` in `_requestLocationPermission`

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed199b0c4833282e42f20eef9f38d