### PR TITLE
Translate search bar hint

### DIFF
--- a/app_src/lib/explore_screen/map/map_screen.dart
+++ b/app_src/lib/explore_screen/map/map_screen.dart
@@ -12,6 +12,7 @@ import 'package:http/http.dart' as http;
 import '../../main/keys.dart';
 import 'plans_in_map_screen.dart';
 import '../main_screen/explore_screen_filter.dart';
+import '../../l10n/app_localizations.dart';
 
 class MapScreen extends StatefulWidget {
   const MapScreen({Key? key}) : super(key: key);
@@ -288,7 +289,8 @@ class MapScreenState extends State<MapScreen> {
                           focusNode: _searchFocusNode,
                           style: const TextStyle(color: Colors.black),
                           decoration: InputDecoration(
-                            hintText: 'Buscar dirección o planes...',
+                            hintText: AppLocalizations.of(context)
+                                .searchAddressPlansHint,
                             hintStyle: const TextStyle(color: Colors.grey),
                             prefixIcon:
                                 const Icon(Icons.search, color: Colors.grey),

--- a/app_src/lib/l10n/app_localizations.dart
+++ b/app_src/lib/l10n/app_localizations.dart
@@ -80,6 +80,7 @@ class AppLocalizations {
       'only_followed': 'Solo de personas que sigo',
       'or_separator': '- o -',
       'search_by_name_hint': 'Busca por nombre...',
+      'search_address_plans_hint': 'Buscar dirección o planes...',
       'search_region': '¿En qué región buscas planes?',
       'region_hint': 'Ciudad, país...',
       'current_location': 'Tu ubicación actual',
@@ -163,6 +164,7 @@ class AppLocalizations {
       'only_followed': 'Only from people I follow',
       'or_separator': '- or -',
       'search_by_name_hint': 'Search by name...',
+      'search_address_plans_hint': 'Search address or plans...',
       'search_region': 'In which region are you looking for plans?',
       'region_hint': 'City, country...',
       'current_location': 'Your current location',
@@ -252,6 +254,7 @@ class AppLocalizations {
   String get onlyFollowed => _t('only_followed');
   String get orSeparator => _t('or_separator');
   String get searchByNameHint => _t('search_by_name_hint');
+  String get searchAddressPlansHint => _t('search_address_plans_hint');
   String get searchRegion => _t('search_region');
   String get regionHint => _t('region_hint');
   String get currentLocation => _t('current_location');


### PR DESCRIPTION
## Summary
- localize the map search hint
- reference the localization in map_screen

## Testing
- `flutter test app_src/test/widget_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed31ec2208332928a5cf7bc6eaa37