### PR TITLE
Fix age range interpolation and localize plan picker

### DIFF
--- a/app_src/lib/explore_screen/special_plans/invite_users_to_plan_screen.dart
+++ b/app_src/lib/explore_screen/special_plans/invite_users_to_plan_screen.dart
@@ -15,6 +15,7 @@ import '../../plan_creation/meeting_location_screen.dart';
 import '../../plan_creation/new_plan_creation_screen.dart';
 import '../../../main/colors.dart';
 import 'invite_existing_plan_screen.dart';
+import '../../l10n/app_localizations.dart';
 
 /// ***************************************************************************
 /// CONSTANTES DE ANCHOS Y ALTOS FIJOS (SIN MEDIAQUERY)
@@ -618,7 +619,9 @@ class _NewPlanInviteContentState extends State<_NewPlanInviteContent> {
                 children: [
                   Expanded(
                     child: Text(
-                      _customPlan ?? _selectedPlan ?? "Elige un plan",
+                      _customPlan ??
+                          _selectedPlan ??
+                          AppLocalizations.of(context).chooseAPlan,
                       style: const TextStyle(
                         color: Colors.white,
                         fontFamily: 'Inter-Regular',
@@ -745,9 +748,9 @@ class _NewPlanInviteContentState extends State<_NewPlanInviteContent> {
                     }).toList(),
                   ),
                   const SizedBox(height: 10),
-                  const Text(
-                    '- o -',
-                    style: TextStyle(
+                  Text(
+                    AppLocalizations.of(context).orSeparator,
+                    style: const TextStyle(
                       color: Colors.white,
                       fontWeight: FontWeight.bold,
                       decoration: TextDecoration.none,
@@ -769,7 +772,7 @@ class _NewPlanInviteContentState extends State<_NewPlanInviteContent> {
                       fontFamily: 'Inter-Regular',
                     ),
                     decoration: InputDecoration(
-                      hintText: 'Escribe tu plan...',
+                      hintText: AppLocalizations.of(context).writePlanHint,
                       hintStyle: const TextStyle(
                         color: Colors.white70,
                         decoration: TextDecoration.none,

--- a/app_src/lib/l10n/app_localizations.dart
+++ b/app_src/lib/l10n/app_localizations.dart
@@ -104,6 +104,7 @@ class AppLocalizations {
       'edit_plan_title': 'Edita tu plan como desees',
       'share_plan_title': '¡Hazle saber a la gente el plan que deseas compartir!',
       'choose_a_plan': 'Elige un plan',
+      'write_plan_hint': 'Escribe tu plan...',
       'age_restriction': 'Restricción de edad para el plan',
       'max_participants': 'Máximo número de participantes',
       'enter_number': 'Ingresa un número...',
@@ -230,6 +231,7 @@ class AppLocalizations {
       'edit_plan_title': 'Edit your plan as you wish',
       'share_plan_title': 'Let people know the plan you want to share!',
       'choose_a_plan': 'Choose a plan',
+      'write_plan_hint': 'Type your plan...',
       'age_restriction': 'Age restriction for the plan',
       'max_participants': 'Maximum number of participants',
       'enter_number': 'Enter a number...',
@@ -362,6 +364,7 @@ class AppLocalizations {
   String get editPlanTitle => _t('edit_plan_title');
   String get sharePlanTitle => _t('share_plan_title');
   String get chooseAPlan => _t('choose_a_plan');
+  String get writePlanHint => _t('write_plan_hint');
   String get ageRestriction => _t('age_restriction');
   String get maxParticipants => _t('max_participants');
   String get enterNumber => _t('enter_number');
@@ -391,8 +394,8 @@ class AppLocalizations {
 
   String planAgeRange(int start, int end) {
     return locale.languageCode == 'en'
-        ? 'Participants from \$start to \$end years old'
-        : 'Participan edades de \$start a \$end años';
+        ? 'Participants from $start to $end years old'
+        : 'Participan edades de $start a $end años';
   }
 
   static const LocalizationsDelegate<AppLocalizations> delegate =

--- a/app_src/lib/plan_creation/new_plan_creation_screen.dart
+++ b/app_src/lib/plan_creation/new_plan_creation_screen.dart
@@ -350,9 +350,9 @@ class __NewPlanPopupContentState extends State<_NewPlanPopupContent> {
                     }).toList(),
                   ),
                   const SizedBox(height: 10),
-                  const Text(
-                    '- o -',
-                    style: TextStyle(
+                  Text(
+                    AppLocalizations.of(context).orSeparator,
+                    style: const TextStyle(
                       color: Colors.white,
                       fontWeight: FontWeight.bold,
                       decoration: TextDecoration.none,
@@ -374,7 +374,7 @@ class __NewPlanPopupContentState extends State<_NewPlanPopupContent> {
                       fontFamily: 'Inter-Regular',
                     ),
                     decoration: InputDecoration(
-                      hintText: 'Escribe tu plan...',
+                      hintText: AppLocalizations.of(context).writePlanHint,
                       hintStyle: const TextStyle(
                         color: Colors.white70,
                         decoration: TextDecoration.none,


### PR DESCRIPTION
## Summary
- ensure `planAgeRange` interpolates numbers in both languages
- translate "Write your plan" placeholder and or-separator
- localize plan picker text in invite screen as well

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eda70666c8332a9d2267fb1105434