### PR TITLE
Localización de planes en inglés

### DIFF
--- a/app_src/lib/explore_screen/main_screen/explore_screen_filter.dart
+++ b/app_src/lib/explore_screen/main_screen/explore_screen_filter.dart
@@ -283,9 +283,14 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
   @override
   Widget build(BuildContext context) {
     final t = AppLocalizations.of(context);
+    final String lang = AppLocalizations.of(context).locale.languageCode;
     final List<Map<String, dynamic>> planSugeridos = planBusqueda.isNotEmpty
         ? plans.where((plan) {
-            final nombre = plan['name'].toString().toLowerCase();
+            final nombre = (lang == 'en'
+                    ? (plan['name_en'] ?? plan['name'])
+                    : plan['name'])
+                .toString()
+                .toLowerCase();
             return nombre.contains(planBusqueda.toLowerCase());
           }).toList()
         : [];
@@ -411,7 +416,11 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
                           ),
                         ),
                         ...plans.map((plan) {
-                        final String name = plan['name'];
+                        final String lang =
+                            AppLocalizations.of(context).locale.languageCode;
+                        final String name = lang == 'en'
+                            ? (plan['name_en'] ?? plan['name'])
+                            : plan['name'];
                         final bool selected = _selectedPlans.contains(name);
                         return InkWell(
                           onTap: () {
@@ -490,10 +499,14 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
                         child: Column(
                           mainAxisSize: MainAxisSize.min,
                           children: planSugeridos.map((plan) {
+                            final String lang =
+                                AppLocalizations.of(context).locale.languageCode;
+                            final String name = lang == 'en'
+                                ? (plan['name_en'] ?? plan['name'])
+                                : plan['name'];
                             return GestureDetector(
                               onTap: () {
                                 setState(() {
-                                  final name = plan['name'];
                                   if (_selectedPlans.contains(name)) {
                                     _selectedPlans.remove(name);
                                   } else {
@@ -507,7 +520,7 @@ class _ExploreScreenFilterDialogState extends State<ExploreScreenFilterDialog>
                                 padding: const EdgeInsets.symmetric(
                                     horizontal: 16, vertical: 12),
                                 child: Text(
-                                  plan['name'],
+                                  name,
                                   style: const TextStyle(
                                     color: Colors.black,
                                     fontFamily: 'Inter-Regular',

--- a/app_src/lib/explore_screen/special_plans/invite_users_to_plan_screen.dart
+++ b/app_src/lib/explore_screen/special_plans/invite_users_to_plan_screen.dart
@@ -711,7 +711,11 @@ class _NewPlanInviteContentState extends State<_NewPlanInviteContent> {
                     spacing: 6,
                     runSpacing: 6,
                     children: plans.map((plan) {
-                      final String name = plan['name'];
+                      final String lang =
+                          AppLocalizations.of(context).locale.languageCode;
+                      final String name = lang == 'en'
+                          ? (plan['name_en'] ?? plan['name'])
+                          : plan['name'];
                       final bool selected = _selectedPlan == name;
                       return InkWell(
                         onTap: () {

--- a/app_src/lib/plan_creation/new_plan_creation_screen.dart
+++ b/app_src/lib/plan_creation/new_plan_creation_screen.dart
@@ -314,7 +314,11 @@ class __NewPlanPopupContentState extends State<_NewPlanPopupContent> {
                     spacing: 6,
                     runSpacing: 6,
                     children: plans.map((plan) {
-                      final String name = plan['name'];
+                      final String lang =
+                          AppLocalizations.of(context).locale.languageCode;
+                      final String name = lang == 'en'
+                          ? (plan['name_en'] ?? plan['name'])
+                          : plan['name'];
                       final bool selected = _selectedPlan == name;
                       return InkWell(
                         onTap: () {

--- a/app_src/lib/utils/plans_list.dart
+++ b/app_src/lib/utils/plans_list.dart
@@ -1,17 +1,69 @@
 // plans_list.dart
 
 final List<Map<String, dynamic>> plans = [
-  {'icon': 'assets/icono-cafe.svg', 'name': 'Tomar algo'},
-  {'icon': 'assets/icono-juegos.svg', 'name': 'Videojuegos'},
-  {'icon': 'assets/icono-fiesta.svg', 'name': 'Fiesta'},
-  {'icon': 'assets/icono-deporte.svg', 'name': 'Padel'},
-  {'icon': 'assets/icono-deporte.svg', 'name': 'Running'},
-  {'icon': 'assets/icono-deporte.svg', 'name': 'Ciclismo'},
-  {'icon': 'assets/icono-deporte.svg', 'name': 'Fútbol'},
-  {'icon': 'assets/icono-excursion.svg', 'name': 'Senderismo'},
-  {'icon': 'assets/icono-excursion.svg', 'name': 'Excursión'},
-  {'icon': 'assets/icono-tour-cultural.svg', 'name': 'Actividades culturales'},
-  {'icon': 'assets/icono-concierto-musica.svg', 'name': 'Concierto'},
-  {'icon': 'assets/icono-viaje.svg', 'name': 'Viaje'},
-  {'icon': 'assets/icono-yoga.svg', 'name': 'Yoga'},
+  {
+    'icon': 'assets/icono-cafe.svg',
+    'name': 'Tomar algo',
+    'name_en': 'Have a drink'
+  },
+  {
+    'icon': 'assets/icono-juegos.svg',
+    'name': 'Videojuegos',
+    'name_en': 'Video games'
+  },
+  {
+    'icon': 'assets/icono-fiesta.svg',
+    'name': 'Fiesta',
+    'name_en': 'Party'
+  },
+  {
+    'icon': 'assets/icono-deporte.svg',
+    'name': 'Padel',
+    'name_en': 'Padel'
+  },
+  {
+    'icon': 'assets/icono-deporte.svg',
+    'name': 'Running',
+    'name_en': 'Running'
+  },
+  {
+    'icon': 'assets/icono-deporte.svg',
+    'name': 'Ciclismo',
+    'name_en': 'Cycling'
+  },
+  {
+    'icon': 'assets/icono-deporte.svg',
+    'name': 'Fútbol',
+    'name_en': 'Soccer'
+  },
+  {
+    'icon': 'assets/icono-excursion.svg',
+    'name': 'Senderismo',
+    'name_en': 'Hiking'
+  },
+  {
+    'icon': 'assets/icono-excursion.svg',
+    'name': 'Excursión',
+    'name_en': 'Excursion'
+  },
+  {
+    'icon': 'assets/icono-tour-cultural.svg',
+    'name': 'Actividades culturales',
+    'name_en': 'Cultural activities'
+  },
+  {
+    'icon': 'assets/icono-concierto-musica.svg',
+    'name': 'Concierto',
+    'name_en': 'Concert'
+  },
+  {
+    'icon': 'assets/icono-viaje.svg',
+    'name': 'Viaje',
+    'name_en': 'Travel'
+  },
+  {
+    'icon': 'assets/icono-yoga.svg',
+    'name': 'Yoga',
+    'name_en': 'Yoga'
+  },
 ];


### PR DESCRIPTION
## Summary
- add English translations in plans_list
- mostrar las opciones de planes en el idioma seleccionado en:
  - nuevo plan
  - invitaciones a plan
  - filtro de planes

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ede936ea883328757644e3574b16f