### PR TITLE
Ajustes de SafeArea y calendario

### DIFF
--- a/app_src/lib/explore_screen/chats/chat_screen.dart
+++ b/app_src/lib/explore_screen/chats/chat_screen.dart
@@ -1585,45 +1585,46 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
       context: context,
       backgroundColor: Colors.transparent,
       builder: (BuildContext ctx) {
-        return Container(
-          padding: const EdgeInsets.all(16),
-          decoration: const BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.only(
-              topLeft: Radius.circular(20),
-              topRight: Radius.circular(20),
+        return SafeArea(
+          child: Container(
+            padding: const EdgeInsets.all(16),
+            decoration: const BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.only(
+                topLeft: Radius.circular(20),
+                topRight: Radius.circular(20),
+              ),
             ),
-          ),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            children: [
-              _buildFloatingOption(
-                svgPath: 'assets/icono-ubicacion.svg',
-                label: 'Ubicación',
-                onTap: () async {
-                  Navigator.pop(ctx);
-                  await _handleSendLocationWithPicker();
-                },
-              ),
-              _buildFloatingOption(
-                svgPath: 'assets/plan-sin-fondo.png',
-                label: 'Plan',
-                onTap: () {
-                  Navigator.pop(ctx);
-                  _showPlanSelection();
-                },
-              ),
-              _buildFloatingOption(
-                svgPath: 'assets/icono-imagen.svg',
-                label: 'Foto',
-                onTap: () {
-                  Navigator.pop(ctx);
-                  _handleSelectImage();
-                },
-              ),
-            ],
-          ),
-        );
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                _buildFloatingOption(
+                  svgPath: 'assets/icono-ubicacion.svg',
+                  label: 'Ubicación',
+                  onTap: () async {
+                    Navigator.pop(ctx);
+                    await _handleSendLocationWithPicker();
+                  },
+                ),
+                _buildFloatingOption(
+                  svgPath: 'assets/plan-sin-fondo.png',
+                  label: 'Plan',
+                  onTap: () {
+                    Navigator.pop(ctx);
+                    _showPlanSelection();
+                  },
+                ),
+                _buildFloatingOption(
+                  svgPath: 'assets/icono-imagen.svg',
+                  label: 'Foto',
+                  onTap: () {
+                    Navigator.pop(ctx);
+                    _handleSelectImage();
+                  },
+                ),
+              ],
+            ),
+          );
       },
     );
   }

--- a/app_src/lib/explore_screen/profile/memories_calendar.dart
+++ b/app_src/lib/explore_screen/profile/memories_calendar.dart
@@ -501,7 +501,6 @@ class _MemoriesCalendarState extends State<MemoriesCalendar> {
     return Center(
       child: Container(
         width: side,
-        height: side * 1.3,
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(20),
           gradient: const LinearGradient(
@@ -515,6 +514,7 @@ class _MemoriesCalendarState extends State<MemoriesCalendar> {
           ),
         ),
         child: Column(
+          mainAxisSize: MainAxisSize.min,
           children: [
             const Padding(
               padding: EdgeInsets.all(8.0),
@@ -532,19 +532,13 @@ class _MemoriesCalendarState extends State<MemoriesCalendar> {
               padding: const EdgeInsets.symmetric(horizontal: 6),
               child: _buildDaysOfWeekRow(),
             ),
-            Expanded(
-              child: Container(
-                margin: const EdgeInsets.all(6),
-                decoration: BoxDecoration(
-                  color: Colors.white,
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                child: Column(
-                  children: [
-                    _buildCalendarDays(),
-                  ],
-                ),
+            Container(
+              margin: const EdgeInsets.all(6),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(12),
               ),
+              child: _buildCalendarDays(),
             ),
           ],
         ),

--- a/app_src/lib/explore_screen/profile/profile_screen.dart
+++ b/app_src/lib/explore_screen/profile/profile_screen.dart
@@ -607,9 +607,15 @@ class ProfileScreenState extends State<ProfileScreen> {
 
     return Scaffold(
       backgroundColor: Colors.white,
-      body: SingleChildScrollView(
-        child: Column(
-          children: [
+      body: SafeArea(
+        bottom: true,
+        top: false,
+        child: SingleChildScrollView(
+          padding: EdgeInsets.only(
+            bottom: MediaQuery.of(context).padding.bottom,
+          ),
+          child: Column(
+            children: [
             SizedBox(
               height: 380, // 300 portada + 80 avatar
               child: Stack(

--- a/app_src/lib/explore_screen/users_managing/user_info_check.dart
+++ b/app_src/lib/explore_screen/users_managing/user_info_check.dart
@@ -249,10 +249,16 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
 
     return Scaffold(
       backgroundColor: Colors.white,
-      body: SingleChildScrollView(
-        child: Column(
-          children: [
-            _buildHeader(name),
+      body: SafeArea(
+        bottom: true,
+        top: false,
+        child: SingleChildScrollView(
+          padding: EdgeInsets.only(
+            bottom: MediaQuery.of(context).padding.bottom,
+          ),
+          child: Column(
+            children: [
+              _buildHeader(name),
             const SizedBox(height: 30),
             _buildPrivilegeButton(),
             _buildBioAndStats(),


### PR DESCRIPTION
## Summary
- aplicar `SafeArea` en `UserInfoCheck` y `ProfileScreen`
- ajustar `MemoriesCalendar` para usar altura dinámica
- envolver la hoja modal de `ChatScreen` con `SafeArea`

## Testing
- `flutter analyze` *(falló: comando no encontrado)*
- `flutter test` *(falló: comando no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_686ee2ac0c908332bde5749993a77000