### PR TITLE
Translate UI strings to English

### DIFF
--- a/app_src/lib/explore_screen/chats/chat_screen.dart
+++ b/app_src/lib/explore_screen/chats/chat_screen.dart
@@ -15,6 +15,8 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import '../profile/user_images_managing.dart';
 
+import '../../l10n/app_localizations.dart';
+
 import '../../main/colors.dart';
 import '../../models/plan_model.dart';
 import '../plans_managing/frosted_plan_dialog_state.dart';
@@ -1548,8 +1550,8 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
               ),
               child: TextField(
                 controller: _messageController,
-                decoration: const InputDecoration(
-                  hintText: "Escribe un mensaje...",
+                decoration: InputDecoration(
+                  hintText: AppLocalizations.of(context).writeMessage,
                   border: InputBorder.none,
                   isCollapsed: true,
                 ),
@@ -1600,7 +1602,7 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
               children: [
                 _buildFloatingOption(
                   svgPath: 'assets/icono-ubicacion.svg',
-                  label: 'Ubicación',
+                  label: AppLocalizations.of(context).shareLocation,
                   onTap: () async {
                     Navigator.pop(ctx);
                     await _handleSendLocationWithPicker();
@@ -1608,7 +1610,7 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
                 ),
                 _buildFloatingOption(
                   svgPath: 'assets/plan-sin-fondo.png',
-                  label: 'Plan',
+                  label: AppLocalizations.of(context).sharePlan,
                   onTap: () {
                     Navigator.pop(ctx);
                     _showPlanSelection();
@@ -1616,7 +1618,7 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
                 ),
                 _buildFloatingOption(
                   svgPath: 'assets/icono-imagen.svg',
-                  label: 'Foto',
+                  label: AppLocalizations.of(context).sharePhoto,
                   onTap: () {
                     Navigator.pop(ctx);
                     _handleSelectImage();

--- a/app_src/lib/explore_screen/plans_managing/attendance_managing.dart
+++ b/app_src/lib/explore_screen/plans_managing/attendance_managing.dart
@@ -5,6 +5,7 @@ import 'dart:math';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import '../../l10n/app_localizations.dart';
 // Para generar QR
 import 'package:qr_flutter/qr_flutter.dart';
 // Para escanear QR
@@ -177,16 +178,16 @@ class _CheckInCreatorScreenState extends State<CheckInCreatorScreen> {
           }
           final data = snapshot.data!.data() as Map<String, dynamic>?;
           if (data == null) {
-            return const Center(child: Text("Plan no existe"));
+            return Center(child: Text(AppLocalizations.of(context).planNotExists));
           }
 
           final code = data['checkInCode'] ?? '';
           final isActive = data['checkInActive'] ?? false;
           if (!isActive) {
-            return const Center(
+            return Center(
               child: Text(
-                "El check-in no está activo.\nPresiona atrás para iniciar.",
-                style: TextStyle(color: Colors.white),
+                AppLocalizations.of(context).checkinNotActive,
+                style: const TextStyle(color: Colors.white),
               ),
             );
           }
@@ -211,9 +212,9 @@ class _CheckInCreatorScreenState extends State<CheckInCreatorScreen> {
                           size: 200.0,
                           backgroundColor: Colors.white,
                         )
-                      : const Text(
-                          "Generando código...",
-                          style: TextStyle(color: Colors.white),
+                      : Text(
+                          AppLocalizations.of(context).generatingCode,
+                          style: const TextStyle(color: Colors.white),
                         ),
                 ),
               ),
@@ -243,7 +244,7 @@ class _CheckInCreatorScreenState extends State<CheckInCreatorScreen> {
                     await AttendanceManaging.finalizeCheckIn(widget.planId);
                     Navigator.pop(context);
                   },
-                  child: const Text("Finalizar Check-in"),
+                  child: Text(AppLocalizations.of(context).endCheckin),
                 ),
               ),
             ],
@@ -306,7 +307,7 @@ class _CheckInParticipantScreenState extends State<CheckInParticipantScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text("Confirmar asistencia"),
+        title: Text(AppLocalizations.of(context).confirmAttendance),
         backgroundColor: Colors.black87,
       ),
       backgroundColor: Colors.black87,
@@ -330,9 +331,9 @@ class _CheckInParticipantScreenState extends State<CheckInParticipantScreen> {
               ),
               child: Column(
                 children: [
-                  const Text(
-                    "Si no puedes escanear el código QR,\ningrésalo manualmente:",
-                    style: TextStyle(color: Colors.white),
+                  Text(
+                    AppLocalizations.of(context).manualEntry,
+                    style: const TextStyle(color: Colors.white),
                   ),
                   const SizedBox(height: 16),
                   TextField(
@@ -341,7 +342,7 @@ class _CheckInParticipantScreenState extends State<CheckInParticipantScreen> {
                     decoration: InputDecoration(
                       fillColor: Colors.white10,
                       filled: true,
-                      hintText: "Código alfanumérico",
+                      hintText: AppLocalizations.of(context).alphanumericCode,
                       hintStyle: const TextStyle(color: Colors.white54),
                       border: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(12),
@@ -360,7 +361,7 @@ class _CheckInParticipantScreenState extends State<CheckInParticipantScreen> {
                   const SizedBox(height: 12),
                   ElevatedButton(
                     onPressed: _onSubmitManualCode,
-                    child: const Text("Validar código"),
+                    child: Text(AppLocalizations.of(context).validateCode),
                   ),
                 ],
               ),
@@ -399,7 +400,7 @@ class _CheckInParticipantScreenState extends State<CheckInParticipantScreen> {
     final isValid = await AttendanceManaging.validateCode(widget.planId, code);
     if (!isValid) {
       setState(() {
-        _errorMsg = "El código es incorrecto o el check-in no está activo.";
+        _errorMsg = AppLocalizations.of(context).invalidCode;
         _scannedOk = false;
       });
       return;
@@ -409,7 +410,7 @@ class _CheckInParticipantScreenState extends State<CheckInParticipantScreen> {
     final uid = FirebaseAuth.instance.currentUser?.uid ?? '';
     if (uid.isEmpty) {
       setState(() {
-        _errorMsg = "No se encontró un usuario logueado.";
+        _errorMsg = AppLocalizations.of(context).noLoggedUser;
         _scannedOk = false;
       });
       return;
@@ -484,7 +485,7 @@ class CheckInActionArea extends StatelessWidget {
           // 2A) No está activo => botón "Iniciar"
           if (!checkInActive) {
             return _buildButton(
-              label: "Iniciar Check-in",
+              label: AppLocalizations.of(context).startCheckin,
               color: Colors.green,
               onTap: () async {
                 await AttendanceManaging.startCheckIn(planId);
@@ -505,7 +506,7 @@ class CheckInActionArea extends StatelessWidget {
             return Column(
               children: [
                 _buildButton(
-                  label: "Ver Check-in (QR)",
+                  label: AppLocalizations.of(context).viewCheckin,
                   color: Colors.blueAccent,
                   onTap: () {
                     Navigator.push(
@@ -518,7 +519,7 @@ class CheckInActionArea extends StatelessWidget {
                 ),
                 const SizedBox(height: 8),
                 _buildButton(
-                  label: "Finalizar Check-in",
+                  label: AppLocalizations.of(context).endCheckin,
                   color: Colors.redAccent,
                   onTap: () async {
                     await AttendanceManaging.finalizeCheckIn(planId);
@@ -537,7 +538,7 @@ class CheckInActionArea extends StatelessWidget {
           } else {
             // Botón "Confirmar asistencia"
             return _buildButton(
-              label: "Confirmar asistencia",
+              label: AppLocalizations.of(context).confirmAttendance,
               color: Colors.orangeAccent,
               onTap: () {
                 Navigator.push(

--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:share_plus/share_plus.dart';
+import '../../l10n/app_localizations.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 
 import '../../models/plan_model.dart';
@@ -171,9 +172,10 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                         color: Colors.white,
                       ),
                       const SizedBox(width: 8),
-                      const Text(
-                        "Ubicación",
-                        style: TextStyle(color: Colors.white, fontSize: 14),
+                      Text(
+                        AppLocalizations.of(context).meetingLocation,
+                        style:
+                            const TextStyle(color: Colors.white, fontSize: 14),
                         textAlign: TextAlign.center,
                       ),
                     ],
@@ -215,11 +217,11 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                       ),
                     )
                   else
-                    const Padding(
-                      padding: EdgeInsets.all(8.0),
+                    Padding(
+                      padding: const EdgeInsets.all(8.0),
                       child: Text(
-                        "Ubicación no disponible",
-                        style: TextStyle(
+                        AppLocalizations.of(context).locationUnavailable,
+                        style: const TextStyle(
                           color: Color.fromARGB(255, 151, 121, 215),
                           fontWeight: FontWeight.bold,
                         ),
@@ -265,10 +267,11 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                         color: Colors.white,
                       ),
                       const SizedBox(width: 8),
-                      const Flexible(
+                      Flexible(
                         child: Text(
-                          "Información adicional",
-                          style: TextStyle(color: Colors.white, fontSize: 14),
+                          AppLocalizations.of(context).additionalInfo,
+                          style:
+                              const TextStyle(color: Colors.white, fontSize: 14),
                           textAlign: TextAlign.center,
                         ),
                       ),
@@ -296,8 +299,9 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                         onPressed: () {
                           Clipboard.setData(ClipboardData(text: plan.id));
                           ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(
-                              content: Text('ID copiado al portapapeles'),
+                            SnackBar(
+                              content:
+                                  Text(AppLocalizations.of(context).planIdCopied),
                             ),
                           );
                         },
@@ -711,9 +715,9 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                 color: Colors.white,
               ),
               const SizedBox(width: 6),
-              const Text(
-                "Únete ahora",
-                style: TextStyle(color: Colors.white, fontSize: 14),
+              Text(
+                AppLocalizations.of(context).joinNow,
+                style: const TextStyle(color: Colors.white, fontSize: 14),
               ),
             ],
           ),
@@ -731,11 +735,11 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
           child: Row(
             children: [
               const SizedBox(width: 48),
-              const Expanded(
+              Expanded(
                 child: Text(
-                  "Chat del Plan",
+                  AppLocalizations.of(context).planChat,
                   textAlign: TextAlign.center,
-                  style: TextStyle(
+                  style: const TextStyle(
                     color: AppColors.planColor,
                     fontSize: 18,
                     fontWeight: FontWeight.bold,
@@ -1615,9 +1619,9 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                 Icon(Icons.check_circle, color: Colors.greenAccent, size: 32),
                 SizedBox(height: 8),
                 Text(
-                  "Tu asistencia se ha confirmado con éxito.\n¡Disfruta del evento!",
+                  AppLocalizations.of(context).attendanceConfirmed,
                   textAlign: TextAlign.center,
-                  style: TextStyle(color: Colors.white),
+                  style: const TextStyle(color: Colors.white),
                 ),
               ],
             ),
@@ -1643,8 +1647,9 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                         const SizedBox(width: 6),
                         Expanded(
                           child: Text(
-                            'Inicia el registro de asistencia para que los participantes escaneen el código QR o introduzcan el código de seis dígitos y confirmen su presencia en tu plan. Con cada check-in tu nivel de privilegio aumentará, lo que te permitirá aprovechar al máximo la app y, por ejemplo, crear planes de pago. Para ver tu progreso, abre tu perfil y toca la INSIGNIA situada justo debajo de tu nombre.',
-                            style: TextStyle(color: Colors.grey[300], fontSize: 12),
+                            AppLocalizations.of(context).checkinInstructionsCreator,
+                            style:
+                                TextStyle(color: Colors.grey[300], fontSize: 12),
                           ),
                         ),
                       ],
@@ -1668,7 +1673,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                           ),
                         );
                       },
-                      child: const Text("Iniciar Check-in"),
+                      child: Text(AppLocalizations.of(context).startCheckin),
                     ),
                   ),
                 ],
@@ -1694,7 +1699,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                           ),
                         );
                       },
-                      child: const Text("Ver Check-in (QR)"),
+                      child: Text(AppLocalizations.of(context).viewCheckin),
                     ),
                   ),
                   const SizedBox(height: 6),
@@ -1708,7 +1713,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                       onPressed: () async {
                         await AttendanceManaging.finalizeCheckIn(plan.id);
                       },
-                      child: const Text("Finalizar Check-in"),
+                      child: Text(AppLocalizations.of(context).endCheckin),
                     ),
                   ),
                 ],
@@ -1733,8 +1738,9 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                       const SizedBox(width: 6),
                       Expanded(
                         child: Text(
-                          'Para confirmar tu asistencia, pulsa «Confirmar asistencia» y utiliza la cámara para escanear el código QR o introduce el código de seis dígitos facilitado por el organizador.',
-                          style: TextStyle(color: Colors.grey[300], fontSize: 12),
+                          AppLocalizations.of(context).checkinInstructionsParticipant,
+                          style:
+                              TextStyle(color: Colors.grey[300], fontSize: 12),
                         ),
                       ),
                     ],
@@ -1759,8 +1765,8 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                         showDialog(
                           context: context,
                           builder: (_) => AlertDialog(
-                            title: const Text('Check-in no iniciado'),
-                            content: const Text('El organizador del plan aún no ha iniciado el Check-in. Se te notificará una vez que se haya iniciado.'),
+                            title: Text(AppLocalizations.of(context).checkinNotStartedTitle),
+                            content: Text(AppLocalizations.of(context).checkinNotStartedMsg),
                             actions: [
                               TextButton(
                                 onPressed: () => Navigator.pop(context),
@@ -1771,7 +1777,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                         );
                       }
                     },
-                    child: const Text("Confirmar asistencia"),
+                    child: Text(AppLocalizations.of(context).confirmAttendance),
                   ),
                 ),
               ],

--- a/app_src/lib/explore_screen/plans_managing/plan_card.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_card.dart
@@ -337,10 +337,10 @@ class PlanCardState extends State<PlanCard> {
             child: Row(
               children: [
                 const SizedBox(width: 48),
-                const Text(
-                  "Chat del Plan",
+                Text(
+                  AppLocalizations.of(context).planChat,
                   textAlign: TextAlign.center,
-                  style: TextStyle(
+                  style: const TextStyle(
                     color: AppColors.planColor,
                     fontSize: 18,
                     fontWeight: FontWeight.bold,
@@ -366,9 +366,9 @@ class PlanCardState extends State<PlanCard> {
                 .snapshots(),
             builder: (ctx, snap) {
               if (snap.hasError) {
-                return const Center(
-                  child: Text('Error al cargar mensajes',
-                      style: TextStyle(color: Colors.black)),
+                return Center(
+                  child: Text(AppLocalizations.of(context).errorLoadingMessages,
+                      style: const TextStyle(color: Colors.black)),
                 );
               }
               if (snap.connectionState == ConnectionState.waiting) {
@@ -376,9 +376,9 @@ class PlanCardState extends State<PlanCard> {
               }
               final docs = snap.data?.docs ?? [];
               if (docs.isEmpty) {
-                return const Center(
-                  child: Text('No hay mensajes todavía',
-                      style: TextStyle(color: Colors.black)),
+                return Center(
+                  child: Text(AppLocalizations.of(context).noMessagesYet,
+                      style: const TextStyle(color: Colors.black)),
                 );
               }
               return ListView(
@@ -400,7 +400,7 @@ class PlanCardState extends State<PlanCard> {
                 child: TextField(
                   controller: _chatController,
                   decoration: InputDecoration(
-                    hintText: "Escribe un mensaje...",
+                    hintText: AppLocalizations.of(context).writeMessage,
                     filled: true,
                     fillColor: const ui.Color.fromARGB(
                         255, 177, 177, 177), // dark gray background
@@ -1006,8 +1006,8 @@ class PlanCardState extends State<PlanCard> {
           child: Container(
             color: Colors.black.withOpacity(0.2),
             padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
-            child: const Text(
-              "Cupo completo",
+            child: Text(
+              AppLocalizations.of(context).fullCapacity,
               style: TextStyle(
                 color: Colors.redAccent,
                 fontWeight: FontWeight.bold,
@@ -1022,13 +1022,13 @@ class PlanCardState extends State<PlanCard> {
       String buttonText;
       switch (_joinState) {
         case JoinState.none:
-          buttonText = 'Unirse';
+          buttonText = AppLocalizations.of(context).join;
           break;
         case JoinState.requested:
-          buttonText = 'Unión solicitada';
+          buttonText = AppLocalizations.of(context).joinRequested;
           break;
         case JoinState.rejoin:
-          buttonText = 'Unirse';
+          buttonText = AppLocalizations.of(context).join;
           break;
       }
 
@@ -1336,8 +1336,8 @@ class PlanCardState extends State<PlanCard> {
                       alignment: Alignment.centerRight,
                       child: Text(
                         maxP > 0
-                            ? '$totalP/$maxP participantes'
-                            : '$totalP participantes',
+                            ? '$totalP/$maxP ${AppLocalizations.of(context).participants}'
+                            : '$totalP ${AppLocalizations.of(context).participants}',
                         style: TextStyle(
                           color: (isFull && maxP > 0)
                               ? Colors.redAccent

--- a/app_src/lib/explore_screen/users_grid/users_grid.dart
+++ b/app_src/lib/explore_screen/users_grid/users_grid.dart
@@ -8,6 +8,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import '../../models/plan_model.dart';
 import '../../main/colors.dart';
 import '../plans_managing/firebase_services.dart';
+import '../l10n/app_localizations.dart';
 import 'users_grid_helpers.dart';
 import '../plans_managing/plan_card.dart';
 import '../special_plans/invite_users_to_plan_screen.dart';
@@ -392,9 +393,9 @@ class _UsersGridState extends State<UsersGrid> {
                             padding: const EdgeInsets.all(8),
                             color: const Color.fromARGB(255, 84, 78, 78)
                                 .withOpacity(0.3),
-                            child: const Text(
-                              'Este usuario no ha creado planes aún...',
-                              style: TextStyle(color: Colors.white),
+                            child: Text(
+                              AppLocalizations.of(context).userNoPlans,
+                              style: const TextStyle(color: Colors.white),
                               textAlign: TextAlign.center,
                             ),
                           ),
@@ -432,7 +433,7 @@ class _UsersGridState extends State<UsersGrid> {
         _buildActionButton(
           context: context,
           iconPath: 'assets/agregar-usuario.svg',
-          label: 'Invítale a un Plan',
+          label: AppLocalizations.of(context).inviteToPlan,
           onTap: () => _handleInvite(context, userId),
         ),
         const SizedBox(width: 16),

--- a/app_src/lib/explore_screen/users_managing/user_activity_status.dart
+++ b/app_src/lib/explore_screen/users_managing/user_activity_status.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:firebase_database/firebase_database.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../l10n/app_localizations.dart';
 
 // Widget que muestra la actividad de un usuario usando Realtime Database.
 class UserActivityStatus extends StatefulWidget {
@@ -95,19 +96,28 @@ class _UserActivityStatusState extends State<UserActivityStatus> {
     });
   }
 
-  /// Retorna un string estilo "Hace 5 minuto/s", etc.
-  String _formatLastActive(DateTime? dt) {
-    if (dt == null) return "Desconectado";
+  /// Retorna un string estilo "Hace 5 minuto/s" o "5 minutes ago" según idioma.
+  String _formatLastActive(BuildContext context, DateTime? dt) {
+    final t = AppLocalizations.of(context);
+    if (dt == null) return t.offline;
     final diff = DateTime.now().difference(dt);
 
     if (diff.inMinutes < 1) {
-      return "Hace unos segundos";
+      return t.locale.languageCode == 'en'
+          ? 'A few seconds ago'
+          : 'Hace unos segundos';
     } else if (diff.inMinutes < 60) {
-      return "Hace ${diff.inMinutes} minutos";
+      return t.locale.languageCode == 'en'
+          ? '${diff.inMinutes} minutes ago'
+          : 'Hace ${diff.inMinutes} minutos';
     } else if (diff.inHours < 24) {
-      return "Hace ${diff.inHours} horas";
+      return t.locale.languageCode == 'en'
+          ? '${diff.inHours} hours ago'
+          : 'Hace ${diff.inHours} horas';
     } else {
-      return "Hace ${diff.inDays} días";
+      return t.locale.languageCode == 'en'
+          ? '${diff.inDays} days ago'
+          : 'Hace ${diff.inDays} días';
     }
   }
 
@@ -121,15 +131,15 @@ class _UserActivityStatusState extends State<UserActivityStatus> {
         children: [
           _buildDot(color: Colors.green),
           const SizedBox(width: 4),
-          const Text(
-            "En línea",
-            style: TextStyle(color: Colors.white, fontSize: 12),
+          Text(
+            AppLocalizations.of(context).online,
+            style: const TextStyle(color: Colors.white, fontSize: 12),
           ),
         ],
       );
     } else {
       // Usuario desconectado
-      final info = _formatLastActive(_lastSeen);
+      final info = _formatLastActive(context, _lastSeen);
       return Row(
         mainAxisSize: MainAxisSize.min,
         children: [

--- a/app_src/lib/l10n/app_localizations.dart
+++ b/app_src/lib/l10n/app_localizations.dart
@@ -131,6 +131,46 @@ class AppLocalizations {
       'must_select_start': 'Debes elegir la fecha y hora de inicio.',
       'end_after_start_error': 'La fecha final debe ser posterior a la fecha/hora de inicio.',
       'until': 'Hasta',
+      'online': 'En línea',
+      'offline': 'Desconectado',
+      'write_message': 'Escribe un mensaje...',
+      'share_location': 'Ubicación',
+      'share_plan': 'Plan',
+      'share_photo': 'Foto',
+      'user_no_plans': 'Este usuario no ha creado planes aún...',
+      'invite_to_plan': 'Invítale a un Plan',
+      'join': 'Unirse',
+      'join_requested': 'Unión solicitada',
+      'full_capacity': 'Cupo completo',
+      'participants': 'participantes',
+      'join_now': 'Únete ahora',
+      'plan_chat': 'Chat del Plan',
+      'location_unavailable': 'Ubicación no disponible',
+      'additional_info': 'Información adicional',
+      'plan_id_copied': 'ID copiado al portapapeles',
+      'start_checkin': 'Iniciar Check-in',
+      'view_checkin': 'Ver Check-in (QR)',
+      'end_checkin': 'Finalizar Check-in',
+      'checkin_instructions_creator':
+          'Inicia el registro de asistencia para que los participantes escaneen el código QR o introduzcan el código de seis dígitos y confirmen su presencia en tu plan. Con cada check-in tu nivel de privilegio aumentará, lo que te permitirá aprovechar al máximo la app y, por ejemplo, crear planes de pago. Para ver tu progreso, abre tu perfil y toca la INSIGNIA situada justo debajo de tu nombre.',
+      'checkin_instructions_participant':
+          'Para confirmar tu asistencia, pulsa «Confirmar asistencia» y utiliza la cámara para escanear el código QR o introduce el código de seis dígitos facilitado por el organizador.',
+      'checkin_not_started_title': 'Check-in no iniciado',
+      'checkin_not_started_msg':
+          'El organizador del plan aún no ha iniciado el Check-in. Se te notificará una vez que se haya iniciado.',
+      'confirm_attendance': 'Confirmar asistencia',
+      'attendance_confirmed':
+          'Tu asistencia se ha confirmado con éxito.\n¡Disfruta del evento!',
+      'checkin_not_active': 'El check-in no está activo.\nPresiona atrás para iniciar.',
+      'generating_code': 'Generando código...',
+      'alphanumeric_code': 'Código alfanumérico',
+      'validate_code': 'Validar código',
+      'invalid_code': 'El código es incorrecto o el check-in no está activo.',
+      'no_logged_user': 'No se encontró un usuario logueado.',
+      'plan_not_exists': 'Plan no existe',
+      'manual_entry': 'Si no puedes escanear el código QR,\ningrésalo manualmente:',
+      'error_loading_messages': 'Error al cargar mensajes',
+      'no_messages_yet': 'No hay mensajes todavía',
     },
     'en': {
       'settings': 'Settings',
@@ -258,6 +298,46 @@ class AppLocalizations {
       'must_select_start': 'You must choose a start date and time.',
       'end_after_start_error': 'The end date must be after the start date/time.',
       'until': 'Until',
+      'online': 'Online',
+      'offline': 'Offline',
+      'write_message': 'Write a message...',
+      'share_location': 'Location',
+      'share_plan': 'Plan',
+      'share_photo': 'Photo',
+      'user_no_plans': "This user hasn't created any plans yet...",
+      'invite_to_plan': 'Invite to a Plan',
+      'join': 'Join',
+      'join_requested': 'Join requested',
+      'full_capacity': 'Full capacity',
+      'participants': 'participants',
+      'join_now': 'Join now',
+      'plan_chat': 'Plan Chat',
+      'location_unavailable': 'Location unavailable',
+      'additional_info': 'Additional information',
+      'plan_id_copied': 'ID copied to clipboard',
+      'start_checkin': 'Start Check-in',
+      'view_checkin': 'View Check-in (QR)',
+      'end_checkin': 'End Check-in',
+      'checkin_instructions_creator':
+          'Start attendance registration so participants can scan the QR code or enter the six-digit code and confirm their presence at your plan. With each check-in your privilege level will increase, allowing you to get the most out of the app and, for example, create paid plans. To see your progress, open your profile and tap the BADGE just below your name.',
+      'checkin_instructions_participant':
+          'To confirm your attendance, tap "Confirm attendance" and use the camera to scan the QR code or enter the six-digit code provided by the organizer.',
+      'checkin_not_started_title': 'Check-in not started',
+      'checkin_not_started_msg':
+          "The organizer hasn't started Check-in yet. You'll be notified once it has started.",
+      'confirm_attendance': 'Confirm attendance',
+      'attendance_confirmed':
+          'Your attendance has been successfully confirmed.\nEnjoy the event!',
+      'checkin_not_active': 'Check-in is not active.\nPress back to start.',
+      'generating_code': 'Generating code...',
+      'alphanumeric_code': 'Alphanumeric code',
+      'validate_code': 'Validate code',
+      'invalid_code': 'The code is incorrect or check-in is not active.',
+      'no_logged_user': 'No logged user found.',
+      'plan_not_exists': 'Plan does not exist',
+      'manual_entry': "If you can't scan the QR code,\nenter it manually:",
+      'error_loading_messages': 'Error loading messages',
+      'no_messages_yet': 'No messages yet',
     },
   };
 
@@ -391,6 +471,43 @@ class AppLocalizations {
   String get mustSelectStart => _t('must_select_start');
   String get endAfterStartError => _t('end_after_start_error');
   String get until => _t('until');
+  String get online => _t('online');
+  String get offline => _t('offline');
+  String get writeMessage => _t('write_message');
+  String get shareLocation => _t('share_location');
+  String get sharePlan => _t('share_plan');
+  String get sharePhoto => _t('share_photo');
+  String get userNoPlans => _t('user_no_plans');
+  String get inviteToPlan => _t('invite_to_plan');
+  String get join => _t('join');
+  String get joinRequested => _t('join_requested');
+  String get fullCapacity => _t('full_capacity');
+  String get participants => _t('participants');
+  String get joinNow => _t('join_now');
+  String get planChat => _t('plan_chat');
+  String get locationUnavailable => _t('location_unavailable');
+  String get additionalInfo => _t('additional_info');
+  String get planIdCopied => _t('plan_id_copied');
+  String get startCheckin => _t('start_checkin');
+  String get viewCheckin => _t('view_checkin');
+  String get endCheckin => _t('end_checkin');
+  String get checkinInstructionsCreator => _t('checkin_instructions_creator');
+  String get checkinInstructionsParticipant =>
+      _t('checkin_instructions_participant');
+  String get checkinNotStartedTitle => _t('checkin_not_started_title');
+  String get checkinNotStartedMsg => _t('checkin_not_started_msg');
+  String get confirmAttendance => _t('confirm_attendance');
+  String get attendanceConfirmed => _t('attendance_confirmed');
+  String get checkinNotActive => _t('checkin_not_active');
+  String get generatingCode => _t('generating_code');
+  String get alphanumericCode => _t('alphanumeric_code');
+  String get validateCode => _t('validate_code');
+  String get invalidCode => _t('invalid_code');
+  String get noLoggedUser => _t('no_logged_user');
+  String get planNotExists => _t('plan_not_exists');
+  String get manualEntry => _t('manual_entry');
+  String get errorLoadingMessages => _t('error_loading_messages');
+  String get noMessagesYet => _t('no_messages_yet');
 
   String planAgeRange(int start, int end) {
     return locale.languageCode == 'en'


### PR DESCRIPTION
## Summary
- add extensive localization keys
- translate chat screen hints and menu options
- translate user status labels and relative time
- translate empty user grid messages
- translate plan card and frosted dialog text, including join and check-in actions
- localize attendance management prompts

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fe5580e008332b53c6323937cadff