### PR TITLE
Add localization for chat and plan details

### DIFF
--- a/app_src/lib/explore_screen/chats/chat_screen.dart
+++ b/app_src/lib/explore_screen/chats/chat_screen.dart
@@ -400,9 +400,10 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
       builder: (BuildContext ctx) {
         return StatefulBuilder(
           builder: (context, setDialogState) {
+            final t = AppLocalizations.of(context);
             // Cambiamos el texto según si está bloqueado o no.
             final blockText =
-                _isPartnerBlocked ? 'Desbloquear perfil' : 'Bloquear perfil';
+                _isPartnerBlocked ? t.unblockProfile : t.blockProfile;
 
             return Material(
               color: Colors.transparent,
@@ -461,8 +462,8 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
                                       const SizedBox(width: 8),
                                       Text(
                                         _notificationsEnabled
-                                            ? 'Deshabilitar notificaciones'
-                                            : 'Habilitar notificaciones',
+                                            ? t.disableNotifications
+                                            : t.enableNotifications,
                                         style: const TextStyle(
                                           color: Colors.white,
                                         ),
@@ -490,9 +491,9 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
                                         color: Colors.white,
                                       ),
                                       const SizedBox(width: 8),
-                                      const Text(
-                                        'Reportar perfil',
-                                        style: TextStyle(color: Colors.white),
+                                      Text(
+                                        t.reportProfile,
+                                        style: const TextStyle(color: Colors.white),
                                       ),
                                     ],
                                   ),

--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -282,7 +282,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                     children: [
                       Expanded(
                         child: Text(
-                          "ID del Plan: ${plan.id}",
+                      "${AppLocalizations.of(context).planIdLabel}: ${plan.id}",
                           style: const TextStyle(
                             color: Color.fromARGB(255, 212, 211, 211),
                             fontWeight: FontWeight.bold,
@@ -311,7 +311,8 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                   const SizedBox(height: 12),
                   if (plan.special_plan != 1)
                     Text(
-                      "Restricción de edad: ${plan.minAge} - ${plan.maxAge} años",
+                      AppLocalizations.of(context)
+                          .ageRestrictionRange(plan.minAge, plan.maxAge),
                       style: const TextStyle(
                         color: Color.fromARGB(255, 212, 211, 211),
                         fontWeight: FontWeight.bold,
@@ -331,7 +332,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                       const SizedBox(width: 6),
                       Expanded(
                         child: Text(
-                          "Fecha de inicio: ${plan.formattedDate(plan.startTimestamp)}",
+                          "${AppLocalizations.of(context).startDate}: ${plan.formattedDate(plan.startTimestamp)}",
                           style: const TextStyle(
                             color: Color.fromARGB(255, 219, 218, 218),
                             fontSize: 15,
@@ -350,7 +351,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                           const SizedBox(width: 21),
                           Expanded(
                             child: Text(
-                              "Finaliza: ${plan.formattedDate(plan.finishTimestamp)}",
+                              "${AppLocalizations.of(context).endsAt}: ${plan.formattedDate(plan.finishTimestamp)}",
                               style: const TextStyle(
                                 color: Color.fromARGB(255, 219, 218, 218),
                                 fontSize: 15,
@@ -650,9 +651,9 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
             borderRadius: BorderRadius.circular(30),
           ),
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-          child: const Text(
-            "Cupo completo",
-            style: TextStyle(
+          child: Text(
+            AppLocalizations.of(context).fullCapacity,
+            style: const TextStyle(
               color: Colors.redAccent,
               fontWeight: FontWeight.bold,
             ),

--- a/app_src/lib/l10n/app_localizations.dart
+++ b/app_src/lib/l10n/app_localizations.dart
@@ -171,6 +171,13 @@ class AppLocalizations {
       'manual_entry': 'Si no puedes escanear el código QR,\ningrésalo manualmente:',
       'error_loading_messages': 'Error al cargar mensajes',
       'no_messages_yet': 'No hay mensajes todavía',
+      'disable_notifications': 'Deshabilitar notificaciones',
+      'report_profile': 'Reportar perfil',
+      'block_profile': 'Bloquear perfil',
+      'unblock_profile': 'Desbloquear perfil',
+      'plan_id_label': 'ID del Plan',
+      'age_restriction_label': 'Restricción de edad',
+      'ends_at_label': 'Finaliza',
     },
     'en': {
       'settings': 'Settings',
@@ -338,6 +345,13 @@ class AppLocalizations {
       'manual_entry': "If you can't scan the QR code,\nenter it manually:",
       'error_loading_messages': 'Error loading messages',
       'no_messages_yet': 'No messages yet',
+      'disable_notifications': 'Disable notifications',
+      'report_profile': 'Report profile',
+      'block_profile': 'Block profile',
+      'unblock_profile': 'Unblock profile',
+      'plan_id_label': 'Plan ID',
+      'age_restriction_label': 'Age restriction',
+      'ends_at_label': 'Ends',
     },
   };
 
@@ -508,11 +522,24 @@ class AppLocalizations {
   String get manualEntry => _t('manual_entry');
   String get errorLoadingMessages => _t('error_loading_messages');
   String get noMessagesYet => _t('no_messages_yet');
+  String get disableNotifications => _t('disable_notifications');
+  String get reportProfile => _t('report_profile');
+  String get blockProfile => _t('block_profile');
+  String get unblockProfile => _t('unblock_profile');
+  String get planIdLabel => _t('plan_id_label');
+  String get ageRestrictionLabel => _t('age_restriction_label');
+  String get endsAt => _t('ends_at_label');
 
   String planAgeRange(int start, int end) {
     return locale.languageCode == 'en'
         ? 'Participants from $start to $end years old'
         : 'Participan edades de $start a $end años';
+  }
+
+  String ageRestrictionRange(int start, int end) {
+    return locale.languageCode == 'en'
+        ? 'Age restriction: $start - $end years'
+        : 'Restricción de edad: $start - $end años';
   }
 
   static const LocalizationsDelegate<AppLocalizations> delegate =


### PR DESCRIPTION
## Summary
- enable translations for chat action menu
- localize plan dialog details and state labels
- introduce new localization strings and helper methods

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ff7520270833289ac7c2d5637777b