### PR TITLE
Add localization for participants modal

### DIFF
--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -1165,10 +1165,10 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                   padding: const EdgeInsets.all(16),
                   child: Row(
                     children: [
-                      const Expanded(
+                      Expanded(
                         child: Text(
-                          "Participantes",
-                          style: TextStyle(
+                          AppLocalizations.of(context).participantsTitle,
+                          style: const TextStyle(
                             color: Colors.white,
                             fontSize: 18,
                             fontWeight: FontWeight.bold,
@@ -1220,9 +1220,9 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                                   color: Colors.white,
                                   borderRadius: BorderRadius.circular(30),
                                 ),
-                                child: const Text(
-                                  'ASISTE',
-                                  style: TextStyle(
+                                child: Text(
+                                  AppLocalizations.of(context).attends,
+                                  style: const TextStyle(
                                     color: AppColors.planColor,
                                     fontWeight: FontWeight.bold,
                                   ),

--- a/app_src/lib/explore_screen/plans_managing/plan_card.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_card.dart
@@ -862,10 +862,10 @@ class PlanCardState extends State<PlanCard> {
                   padding: const EdgeInsets.all(16),
                   child: Row(
                     children: [
-                      const Expanded(
+                      Expanded(
                         child: Text(
-                          "Participantes",
-                          style: TextStyle(
+                          AppLocalizations.of(context).participantsTitle,
+                          style: const TextStyle(
                             color: Colors.white,
                             fontSize: 18,
                             fontWeight: FontWeight.bold,
@@ -921,9 +921,9 @@ class PlanCardState extends State<PlanCard> {
                                   color: Colors.white,
                                   borderRadius: BorderRadius.circular(30),
                                 ),
-                                child: const Text(
-                                  'ASISTE',
-                                  style: TextStyle(
+                                child: Text(
+                                  AppLocalizations.of(context).attends,
+                                  style: const TextStyle(
                                     color: AppColors.blue,
                                     fontWeight: FontWeight.bold,
                                   ),

--- a/app_src/lib/l10n/app_localizations.dart
+++ b/app_src/lib/l10n/app_localizations.dart
@@ -143,6 +143,8 @@ class AppLocalizations {
       'join_requested': 'Unión solicitada',
       'full_capacity': 'Cupo completo',
       'participants': 'participantes',
+      'participants_title': 'Participantes',
+      'attends': 'ASISTE',
       'join_now': 'Únete ahora',
       'plan_chat': 'Chat del Plan',
       'location_unavailable': 'Ubicación no disponible',
@@ -317,6 +319,8 @@ class AppLocalizations {
       'join_requested': 'Join requested',
       'full_capacity': 'Full capacity',
       'participants': 'participants',
+      'participants_title': 'Participants',
+      'attends': 'ATTENDS',
       'join_now': 'Join now',
       'plan_chat': 'Plan Chat',
       'location_unavailable': 'Location unavailable',
@@ -497,6 +501,8 @@ class AppLocalizations {
   String get joinRequested => _t('join_requested');
   String get fullCapacity => _t('full_capacity');
   String get participants => _t('participants');
+  String get participantsTitle => _t('participants_title');
+  String get attends => _t('attends');
   String get joinNow => _t('join_now');
   String get planChat => _t('plan_chat');
   String get locationUnavailable => _t('location_unavailable');


### PR DESCRIPTION
## Summary
- localize participants list labels and statuses
- add 'participants_title' and 'attends' strings to English and Spanish translations

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ffcc9a4dc8332afe547ab437a314c