### PR TITLE
Add English translations for profile and privilege levels

### DIFF
--- a/app_src/lib/explore_screen/profile/memories_calendar.dart
+++ b/app_src/lib/explore_screen/profile/memories_calendar.dart
@@ -8,6 +8,8 @@ import 'package:flutter_svg/flutter_svg.dart';
 import '../../main/colors.dart';
 import '../../models/plan_model.dart';
 import 'plan_memories_screen.dart'; // Asegúrate de importar tu pantalla de memorias
+import '../../services/language_service.dart';
+import '../../l10n/app_localizations.dart';
 
 class MemoriesCalendar extends StatefulWidget {
   final String userId;
@@ -43,7 +45,8 @@ class _MemoriesCalendarState extends State<MemoriesCalendar> {
   @override
   void initState() {
     super.initState();
-    initializeDateFormatting('es', null).then((_) {
+    final locale = LanguageService.locale.value.languageCode;
+    initializeDateFormatting(locale, null).then((_) {
       setState(() {
         _localeInitialized = true;
         _currentMonth = DateTime.now();
@@ -145,7 +148,8 @@ class _MemoriesCalendarState extends State<MemoriesCalendar> {
   void _onDayTapped(DateTime date) {
     final dateKey = DateFormat('yyyy-MM-dd').format(date);
     final dayPlans = _plansByDate[dateKey];
-    final String formattedDate = DateFormat.yMMMMd('es').format(date);
+    final locale = Localizations.localeOf(context).languageCode;
+    final String formattedDate = DateFormat.yMMMMd(locale).format(date);
 
     if (dayPlans == null || dayPlans.isEmpty) {
       // No hay planes => popup "sin memorias".
@@ -153,7 +157,7 @@ class _MemoriesCalendarState extends State<MemoriesCalendar> {
         context: context,
         builder: (_) => AlertDialog(
           title: Text(formattedDate),
-          content: const Text("No hay memorias para este día."),
+          content: Text(AppLocalizations.of(context).noMemoriesDay),
           actions: [
             TextButton(
               onPressed: () => Navigator.of(context).pop(),
@@ -212,7 +216,8 @@ class _MemoriesCalendarState extends State<MemoriesCalendar> {
 
   /// Popup para planes futuros (aún no celebrados).
   void _showUpcomingPlanPopup(DateTime date, List<PlanModel> dayPlans) {
-    final String formattedDate = DateFormat.yMMMMd('es').format(date);
+    final locale = Localizations.localeOf(context).languageCode;
+    final String formattedDate = DateFormat.yMMMMd(locale).format(date);
     showDialog(
       context: context,
       builder: (_) {
@@ -243,7 +248,8 @@ class _MemoriesCalendarState extends State<MemoriesCalendar> {
 
   /// Popup para planes caducados
   void _showExpiredPlanPopup(DateTime date, List<PlanModel> dayPlans) {
-    final String formattedDate = DateFormat.yMMMMd('es').format(date);
+    final locale = Localizations.localeOf(context).languageCode;
+    final String formattedDate = DateFormat.yMMMMd(locale).format(date);
 
     showDialog(
       context: context,
@@ -256,7 +262,7 @@ class _MemoriesCalendarState extends State<MemoriesCalendar> {
             Container(
               padding: const EdgeInsets.all(16),
               child: Text(
-                'Memorias',
+                AppLocalizations.of(context).memories,
                 style: GoogleFonts.roboto(
                   color: AppColors.white,
                   fontSize: 26,
@@ -323,7 +329,8 @@ class _MemoriesCalendarState extends State<MemoriesCalendar> {
 
   Widget _buildHeader() {
     if (!_localeInitialized) return const SizedBox.shrink();
-    final String monthYear = DateFormat.yMMMM('es').format(_currentMonth);
+    final locale = Localizations.localeOf(context).languageCode;
+    final String monthYear = DateFormat.yMMMM(locale).format(_currentMonth);
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 8),
       child: Row(
@@ -352,7 +359,14 @@ class _MemoriesCalendarState extends State<MemoriesCalendar> {
   }
 
   Widget _buildDaysOfWeekRow() {
-    final daysOfWeek = ["Lu", "Ma", "Mi", "Ju", "Vi", "Sá", "Do"];
+    final locale = Localizations.localeOf(context).languageCode;
+    final baseDate = DateTime(2020, 1, 6); // Monday
+    final daysOfWeek = List.generate(7, (i) {
+      final date = baseDate.add(Duration(days: i));
+      var abbr = DateFormat('EEE', locale).format(date);
+      if (abbr.length > 2) abbr = abbr.substring(0, 2);
+      return abbr[0].toUpperCase() + abbr.substring(1);
+    });
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceAround,
       children: daysOfWeek.map((day) {
@@ -516,11 +530,11 @@ class _MemoriesCalendarState extends State<MemoriesCalendar> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const Padding(
-              padding: EdgeInsets.all(8.0),
+            Padding(
+              padding: const EdgeInsets.all(8.0),
               child: Text(
-                "Memorias",
-                style: TextStyle(
+                AppLocalizations.of(context).memories,
+                style: const TextStyle(
                   fontSize: 22,
                   fontWeight: FontWeight.bold,
                   color: Colors.white,

--- a/app_src/lib/explore_screen/profile/plan_memories_screen.dart
+++ b/app_src/lib/explore_screen/profile/plan_memories_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:image_picker/image_picker.dart';
 import 'user_images_managing.dart';
+import '../../l10n/app_localizations.dart';
 
 import '../plans_managing/plan_card.dart';
 import '../../models/plan_model.dart';
@@ -245,10 +246,11 @@ class _PlanMemoriesScreenState extends State<PlanMemoriesScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context);
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: AppBar(
-        title: const Text("Plan y Memorias"),
+        title: Text(t.planAndMemories),
         backgroundColor: Colors.white,
         elevation: 0,
         iconTheme: const IconThemeData(color: Colors.black),
@@ -336,21 +338,22 @@ class _PlanMemoriesScreenState extends State<PlanMemoriesScreen> {
 
   /// Cabecera "Memorias" centrada
   Widget _buildMemoriesSection() {
+    final t = AppLocalizations.of(context);
     return Column(
-      children: const [
-        SizedBox(height: 12),
+      children: [
+        const SizedBox(height: 12),
         Center(
           child: Text(
-            "Memorias",
-            style: TextStyle(
+            t.memories,
+            style: const TextStyle(
               fontSize: 18,
               fontWeight: FontWeight.bold,
             ),
           ),
         ),
-        SizedBox(height: 8),
-        Divider(thickness: 1),
-        SizedBox(height: 16),
+        const SizedBox(height: 8),
+        const Divider(thickness: 1),
+        const SizedBox(height: 16),
       ],
     );
   }

--- a/app_src/lib/explore_screen/users_managing/privilege_level_details.dart
+++ b/app_src/lib/explore_screen/users_managing/privilege_level_details.dart
@@ -128,12 +128,16 @@ class _PrivilegeLevelDetailsState extends State<PrivilegeLevelDetails> {
         });
       } else {
         setState(() {
-          _privilegeInfo = "No se encontró información de privilegios.";
+          _privilegeInfo = Localizations.localeOf(context).languageCode == 'en'
+              ? 'No privilege information found.'
+              : 'No se encontró información de privilegios.';
         });
       }
     } catch (e) {
       setState(() {
-        _privilegeInfo = "Error al cargar: $e";
+        _privilegeInfo = Localizations.localeOf(context).languageCode == 'en'
+            ? 'Error loading: $e'
+            : 'Error al cargar: $e';
       });
     }
   }
@@ -442,34 +446,31 @@ class _PrivilegeLevelDetailsState extends State<PrivilegeLevelDetails> {
   void _showPrivilegeInfoPopup(String levelName) {
     String titleText;
     String contentText;
+    final isEn = Localizations.localeOf(context).languageCode == 'en';
 
     switch (levelName.toLowerCase()) {
       case 'premium':
-        titleText = "Nivel Premium";
-        contentText = "El nivel Premium es el segundo nivel. "
-            "Para pasar al siguiente nivel de Golden:\n"
-            "- Crear 50 planes.\n"
-            "- Máximo de 50 participantes en un plan.\n"
-            "- 2000 participantes en total.";
+        titleText = isEn ? 'Premium Level' : 'Nivel Premium';
+        contentText = isEn
+            ? 'The Premium level is the second. To reach Golden:\n- Create 50 plans.\n- Up to 50 participants in a plan.\n- 2000 participants in total.'
+            : 'El nivel Premium es el segundo nivel. Para pasar al siguiente nivel de Golden:\n- Crear 50 planes.\n- Máximo de 50 participantes en un plan.\n- 2000 participantes en total.';
         break;
       case 'golden':
-        titleText = "Nivel Golden";
-        contentText = "El nivel Golden es el penúltimo nivel. "
-            "Para pasar a VIP:\n"
-            "- Crear 500 planes.\n"
-            "- Alcanzar 500 participantes en un plan.\n"
-            "- 10000 participantes en total.";
+        titleText = isEn ? 'Golden Level' : 'Nivel Golden';
+        contentText = isEn
+            ? 'The Golden level is the penultimate. To reach VIP:\n- Create 500 plans.\n- Reach 500 participants in one plan.\n- 10000 participants in total.'
+            : 'El nivel Golden es el penúltimo nivel. Para pasar a VIP:\n- Crear 500 planes.\n- Alcanzar 500 participantes en un plan.\n- 10000 participantes en total.';
         break;
       case 'vip':
-        titleText = "Nivel VIP";
-        contentText = "Este es el nivel más alto, sin límites.";
+        titleText = isEn ? 'VIP Level' : 'Nivel VIP';
+        contentText =
+            isEn ? 'This is the highest level with no limits.' : 'Este es el nivel más alto, sin límites.';
         break;
       default:
-        titleText = "Nivel Básico";
-        contentText = "El nivel Básico es el más bajo. Para pasar a Premium:\n"
-            "- Crear 5 planes.\n"
-            "- Alcanzar 5 participantes en un plan.\n"
-            "- 20 participantes en total.";
+        titleText = isEn ? 'Basic Level' : 'Nivel Básico';
+        contentText = isEn
+            ? 'The Basic level is the lowest. To reach Premium:\n- Create 5 plans.\n- Reach 5 participants in one plan.\n- 20 participants in total.'
+            : 'El nivel Básico es el más bajo. Para pasar a Premium:\n- Crear 5 planes.\n- Alcanzar 5 participantes en un plan.\n- 20 participantes en total.';
         break;
     }
 

--- a/app_src/lib/explore_screen/users_managing/user_info_check.dart
+++ b/app_src/lib/explore_screen/users_managing/user_info_check.dart
@@ -14,6 +14,7 @@ import '../profile/memories_calendar.dart';
 import '../follow/following_screen.dart';
 import '../future_plans/future_plans.dart';
 import 'report_and_block_user.dart'; // Import para Reportar/Bloquear
+import '../../l10n/app_localizations.dart';
 
 class UserInfoCheck extends StatefulWidget {
   final String userId;
@@ -450,8 +451,9 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
       builder: (BuildContext ctx) {
         return StatefulBuilder(
           builder: (context, setDialogState) {
+            final t = AppLocalizations.of(context);
             final blockText =
-                _isUserBlocked ? 'Desbloquear perfil' : 'Bloquear perfil';
+                _isUserBlocked ? t.unblockProfile : t.blockProfile;
 
             return Material(
               color: Colors.transparent,
@@ -505,8 +507,8 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
                                       const SizedBox(width: 8),
                                       Text(
                                         _notificationsEnabled
-                                            ? 'Deshabilitar notificaciones'
-                                            : 'Habilitar notificaciones',
+                                            ? t.disableNotifications
+                                            : t.enableNotifications,
                                         style: const TextStyle(
                                           color: Colors.white,
                                         ),
@@ -534,9 +536,9 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
                                         color: Colors.white,
                                       ),
                                       const SizedBox(width: 8),
-                                      const Text(
-                                        'Reportar perfil',
-                                        style: TextStyle(color: Colors.white),
+                                      Text(
+                                        t.reportProfile,
+                                        style: const TextStyle(color: Colors.white),
                                       ),
                                     ],
                                   ),
@@ -671,7 +673,9 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
       case 'vip':
         return 'VIP';
       default:
-        return 'Básico';
+        return Localizations.localeOf(context).languageCode == 'en'
+            ? 'Basic'
+            : 'Básico';
     }
   }
 
@@ -724,21 +728,23 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
   }
 
   Widget _buildStatsRow(String planes, String followers, String followed) {
+    final t = AppLocalizations.of(context);
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        _buildStatItem('planes futuros', planes),
+        _buildStatItem(t.futurePlans, planes),
         const SizedBox(width: 20),
-        _buildStatItem('seguidores', followers),
+        _buildStatItem(t.followers, followers),
         const SizedBox(width: 20),
-        _buildStatItem('seguidos', followed),
+        _buildStatItem(t.following, followed),
       ],
     );
   }
 
   Widget _buildStatItem(String label, String count) {
-    final isFuture = label == 'planes futuros';
-    final isFollowers = label == 'seguidores';
+    final t = AppLocalizations.of(context);
+    final isFuture = label == t.futurePlans;
+    final isFollowers = label == t.followers;
     final iconPath = isFuture
         ? 'assets/icono-calendario.svg'
         : 'assets/icono-seguidores.svg';
@@ -860,6 +866,7 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
   // Botones principales: Invitar, Mensaje, Seguir
   //----------------------------------------------------------------------------
   Widget _buildActionButtons(String otherUserId) {
+    final t = AppLocalizations.of(context);
     return Wrap(
       alignment: WrapAlignment.center,
       spacing: 12,
@@ -867,14 +874,14 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
       children: [
         _buildActionButton(
           iconPath: 'assets/union.svg',
-          label: 'Invítale a un Plan',
+          label: t.inviteToPlan,
           onTap: (_isPrivate && !isFollowing && !_isRequestPending)
               ? _showPrivateToast
               : () => InviteUsersToPlanScreen.showPopup(context, otherUserId),
         ),
         _buildActionButton(
           iconPath: 'assets/mensaje.svg',
-          label: 'Enviar Mensaje',
+          label: t.sendMessage,
           onTap: () {
             if (_isPrivate && !isFollowing) {
               _showPrivateToast();
@@ -896,7 +903,7 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
         ),
         _buildActionButton(
           iconPath: _getFollowIcon(),
-          label: _getFollowLabel(),
+          label: _getFollowLabel(t),
           onTap: _handleFollowTap,
         ),
       ],
@@ -957,13 +964,13 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
     );
   }
 
-  String _getFollowLabel() {
+  String _getFollowLabel(AppLocalizations t) {
     if (isFollowing) {
-      return 'Siguiendo';
+      return t.followingStatus;
     } else if (_isRequestPending) {
-      return 'Solicitado';
+      return t.requested;
     } else {
-      return 'Seguir';
+      return t.follow;
     }
   }
 
@@ -1116,9 +1123,10 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
   // Toast si es privado y no puedo invitar/chatear
   //----------------------------------------------------------------------------
   void _showPrivateToast() {
+    final t = AppLocalizations.of(context);
     ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(
-        content: Text('Este usuario es privado. Debes enviar solicitud.'),
+      SnackBar(
+        content: Text(t.privateUser),
       ),
     );
   }
@@ -1132,10 +1140,10 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
         children: [
           SvgPicture.asset('assets/icono-candado.svg', width: 40, height: 40),
           const SizedBox(height: 8),
-          const Text(
-            'Este perfil es privado. Debes seguirle y ser aceptado para ver sus memorias.',
+          Text(
+            AppLocalizations.of(context).privateProfileMemories,
             textAlign: TextAlign.center,
-            style: TextStyle(color: Colors.grey, fontSize: 16),
+            style: const TextStyle(color: Colors.grey, fontSize: 16),
           ),
         ],
       );

--- a/app_src/lib/l10n/app_localizations.dart
+++ b/app_src/lib/l10n/app_localizations.dart
@@ -177,6 +177,20 @@ class AppLocalizations {
       'report_profile': 'Reportar perfil',
       'block_profile': 'Bloquear perfil',
       'unblock_profile': 'Desbloquear perfil',
+      'future_plans': 'planes futuros',
+      'followers': 'seguidores',
+      'following': 'seguidos',
+      'send_message': 'Enviar Mensaje',
+      'follow': 'Seguir',
+      'following_status': 'Siguiendo',
+      'requested': 'Solicitado',
+      'memories': 'Memorias',
+      'private_user':
+          'Este usuario es privado. Debes enviar solicitud.',
+      'private_profile_memories':
+          'Este perfil es privado. Debes seguirle y ser aceptado para ver sus memorias.',
+      'plan_and_memories': 'Plan y Memorias',
+      'no_memories_day': 'No hay memorias para este día.',
       'plan_id_label': 'ID del Plan',
       'age_restriction_label': 'Restricción de edad',
       'ends_at_label': 'Finaliza',
@@ -353,6 +367,20 @@ class AppLocalizations {
       'report_profile': 'Report profile',
       'block_profile': 'Block profile',
       'unblock_profile': 'Unblock profile',
+      'future_plans': 'Future plans',
+      'followers': 'Followers',
+      'following': 'Following',
+      'send_message': 'Send Message',
+      'follow': 'Follow',
+      'following_status': 'Following',
+      'requested': 'Requested',
+      'memories': 'Memories',
+      'private_user':
+          'This account is private. You must send a request.',
+      'private_profile_memories':
+          'This profile is private. You must follow and be accepted to view their memories.',
+      'plan_and_memories': 'Plan and Memories',
+      'no_memories_day': 'No memories for this day.',
       'plan_id_label': 'Plan ID',
       'age_restriction_label': 'Age restriction',
       'ends_at_label': 'Ends',
@@ -535,6 +563,18 @@ class AppLocalizations {
   String get planIdLabel => _t('plan_id_label');
   String get ageRestrictionLabel => _t('age_restriction_label');
   String get endsAt => _t('ends_at_label');
+  String get futurePlans => _t('future_plans');
+  String get followers => _t('followers');
+  String get following => _t('following');
+  String get sendMessage => _t('send_message');
+  String get follow => _t('follow');
+  String get followingStatus => _t('following_status');
+  String get requested => _t('requested');
+  String get memories => _t('memories');
+  String get privateUser => _t('private_user');
+  String get privateProfileMemories => _t('private_profile_memories');
+  String get planAndMemories => _t('plan_and_memories');
+  String get noMemoriesDay => _t('no_memories_day');
 
   String planAgeRange(int start, int end) {
     return locale.languageCode == 'en'


### PR DESCRIPTION
## Summary
- extend localized strings with profile-related keys
- localize stats, action buttons, and messages in `user_info_check`
- show calendar months/days in the selected locale
- translate "Plan and Memories" screen headers
- display privilege info popups in selected language

## Testing
- `dart format -o none --set-exit-if-changed app_src/lib/l10n/app_localizations.dart app_src/lib/explore_screen/users_managing/user_info_check.dart app_src/lib/explore_screen/profile/memories_calendar.dart app_src/lib/explore_screen/profile/plan_memories_screen.dart app_src/lib/explore_screen/users_managing/privilege_level_details.dart` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686ffebd6a7c8332be603434db4dc4f7