### PR TITLE
Add English translations to profile UI

### DIFF
--- a/app_src/lib/explore_screen/profile/memories_calendar.dart
+++ b/app_src/lib/explore_screen/profile/memories_calendar.dart
@@ -3,6 +3,8 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:intl/date_symbol_data_local.dart';
+import '../../l10n/app_localizations.dart';
+import '../../services/language_service.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import '../../main/colors.dart';
@@ -43,7 +45,8 @@ class _MemoriesCalendarState extends State<MemoriesCalendar> {
   @override
   void initState() {
     super.initState();
-    initializeDateFormatting('es', null).then((_) {
+    final code = LanguageService.locale.value.languageCode;
+    initializeDateFormatting(code, null).then((_) {
       setState(() {
         _localeInitialized = true;
         _currentMonth = DateTime.now();
@@ -145,7 +148,8 @@ class _MemoriesCalendarState extends State<MemoriesCalendar> {
   void _onDayTapped(DateTime date) {
     final dateKey = DateFormat('yyyy-MM-dd').format(date);
     final dayPlans = _plansByDate[dateKey];
-    final String formattedDate = DateFormat.yMMMMd('es').format(date);
+    final lang = AppLocalizations.of(context).locale.languageCode;
+    final String formattedDate = DateFormat.yMMMMd(lang).format(date);
 
     if (dayPlans == null || dayPlans.isEmpty) {
       // No hay planes => popup "sin memorias".
@@ -157,7 +161,7 @@ class _MemoriesCalendarState extends State<MemoriesCalendar> {
           actions: [
             TextButton(
               onPressed: () => Navigator.of(context).pop(),
-              child: const Text("Cerrar"),
+              child: Text(AppLocalizations.of(context).close),
             ),
           ],
         ),
@@ -212,7 +216,8 @@ class _MemoriesCalendarState extends State<MemoriesCalendar> {
 
   /// Popup para planes futuros (aún no celebrados).
   void _showUpcomingPlanPopup(DateTime date, List<PlanModel> dayPlans) {
-    final String formattedDate = DateFormat.yMMMMd('es').format(date);
+    final lang = AppLocalizations.of(context).locale.languageCode;
+    final String formattedDate = DateFormat.yMMMMd(lang).format(date);
     showDialog(
       context: context,
       builder: (_) {
@@ -233,7 +238,7 @@ class _MemoriesCalendarState extends State<MemoriesCalendar> {
           actions: [
             TextButton(
               onPressed: () => Navigator.of(context).pop(),
-              child: const Text("Cerrar"),
+              child: Text(AppLocalizations.of(context).close),
             ),
           ],
         );
@@ -243,7 +248,8 @@ class _MemoriesCalendarState extends State<MemoriesCalendar> {
 
   /// Popup para planes caducados
   void _showExpiredPlanPopup(DateTime date, List<PlanModel> dayPlans) {
-    final String formattedDate = DateFormat.yMMMMd('es').format(date);
+    final lang = AppLocalizations.of(context).locale.languageCode;
+    final String formattedDate = DateFormat.yMMMMd(lang).format(date);
 
     showDialog(
       context: context,
@@ -256,7 +262,7 @@ class _MemoriesCalendarState extends State<MemoriesCalendar> {
             Container(
               padding: const EdgeInsets.all(16),
               child: Text(
-                'Memorias',
+                AppLocalizations.of(context).memories,
                 style: GoogleFonts.roboto(
                   color: AppColors.white,
                   fontSize: 26,
@@ -308,7 +314,7 @@ class _MemoriesCalendarState extends State<MemoriesCalendar> {
                           ),
                         ),
                         onPressed: () => Navigator.of(context).pop(),
-                        child: const Text("Cerrar"),
+                        child: Text(AppLocalizations.of(context).close),
                       ),
                     ],
                   ),
@@ -323,7 +329,8 @@ class _MemoriesCalendarState extends State<MemoriesCalendar> {
 
   Widget _buildHeader() {
     if (!_localeInitialized) return const SizedBox.shrink();
-    final String monthYear = DateFormat.yMMMM('es').format(_currentMonth);
+    final lang = AppLocalizations.of(context).locale.languageCode;
+    final String monthYear = DateFormat.yMMMM(lang).format(_currentMonth);
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 8),
       child: Row(
@@ -352,7 +359,10 @@ class _MemoriesCalendarState extends State<MemoriesCalendar> {
   }
 
   Widget _buildDaysOfWeekRow() {
-    final daysOfWeek = ["Lu", "Ma", "Mi", "Ju", "Vi", "Sá", "Do"];
+    final lang = AppLocalizations.of(context).locale.languageCode;
+    final daysOfWeek = lang == 'en'
+        ? ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]
+        : ["Lu", "Ma", "Mi", "Ju", "Vi", "Sá", "Do"];
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceAround,
       children: daysOfWeek.map((day) {
@@ -516,11 +526,11 @@ class _MemoriesCalendarState extends State<MemoriesCalendar> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const Padding(
-              padding: EdgeInsets.all(8.0),
+            Padding(
+              padding: const EdgeInsets.all(8.0),
               child: Text(
-                "Memorias",
-                style: TextStyle(
+                AppLocalizations.of(context).memories,
+                style: const TextStyle(
                   fontSize: 22,
                   fontWeight: FontWeight.bold,
                   color: Colors.white,

--- a/app_src/lib/explore_screen/profile/plan_memories_screen.dart
+++ b/app_src/lib/explore_screen/profile/plan_memories_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:image_picker/image_picker.dart';
 import 'user_images_managing.dart';
+import '../../l10n/app_localizations.dart';
 
 import '../plans_managing/plan_card.dart';
 import '../../models/plan_model.dart';
@@ -248,7 +249,7 @@ class _PlanMemoriesScreenState extends State<PlanMemoriesScreen> {
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: AppBar(
-        title: const Text("Plan y Memorias"),
+        title: Text('Plan y ${AppLocalizations.of(context).memories}'),
         backgroundColor: Colors.white,
         elevation: 0,
         iconTheme: const IconThemeData(color: Colors.black),
@@ -337,20 +338,20 @@ class _PlanMemoriesScreenState extends State<PlanMemoriesScreen> {
   /// Cabecera "Memorias" centrada
   Widget _buildMemoriesSection() {
     return Column(
-      children: const [
-        SizedBox(height: 12),
+      children: [
+        const SizedBox(height: 12),
         Center(
           child: Text(
-            "Memorias",
-            style: TextStyle(
+            AppLocalizations.of(context).memories,
+            style: const TextStyle(
               fontSize: 18,
               fontWeight: FontWeight.bold,
             ),
           ),
         ),
-        SizedBox(height: 8),
-        Divider(thickness: 1),
-        SizedBox(height: 16),
+        const SizedBox(height: 8),
+        const Divider(thickness: 1),
+        const SizedBox(height: 16),
       ],
     );
   }

--- a/app_src/lib/explore_screen/profile/profile_screen.dart
+++ b/app_src/lib/explore_screen/profile/profile_screen.dart
@@ -14,6 +14,7 @@ import '../plans_managing/frosted_plan_dialog_state.dart';
 import 'plan_memories_screen.dart';
 import '../follow/following_screen.dart';
 import '../future_plans/future_plans.dart';
+import '../../l10n/app_localizations.dart';
 
 // Manejo de imágenes
 import 'user_images_managing.dart';
@@ -396,16 +397,17 @@ class ProfileScreenState extends State<ProfileScreen> {
       );
 
   String _mapPrivilegeLevelToTitle(String level) {
+    final t = AppLocalizations.of(context);
     final normalized = level.toLowerCase().replaceAll('á', 'a');
     switch (normalized) {
       case 'premium':
-        return "Premium";
+        return 'Premium';
       case 'golden':
-        return "Golden";
+        return 'Golden';
       case 'vip':
-        return "VIP";
+        return 'VIP';
       default:
-        return "Básico";
+        return t.locale.languageCode == 'en' ? 'Basic' : 'Básico';
     }
   }
 
@@ -430,7 +432,7 @@ class ProfileScreenState extends State<ProfileScreen> {
       context: context,
       barrierDismissible: true,
       barrierColor: Colors.transparent,
-      barrierLabel: 'Cerrar',
+      barrierLabel: AppLocalizations.of(context).close,
       transitionDuration: const Duration(milliseconds: 300),
       pageBuilder: (_, __, ___) => const SizedBox.shrink(),
       transitionBuilder: (_, anim, __, child) => FadeTransition(
@@ -526,7 +528,7 @@ class ProfileScreenState extends State<ProfileScreen> {
                 snapIng.connectionState == ConnectionState.waiting) {
               return _buildStatsRow('...', '...', '...');
             }
-            return _buildStatsRow(
+      return _buildStatsRow(
               (snapPlanes.data ?? 0).toString(),
               (snapFol.data ?? 0).toString(),
               (snapIng.data ?? 0).toString(),
@@ -537,19 +539,22 @@ class ProfileScreenState extends State<ProfileScreen> {
     );
   }
 
-  Widget _buildStatsRow(String plans, String followers, String following) =>
-      Row(
-        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-        children: [
-          Expanded(child: _buildStatItem('planes futuros', plans)),
-          Expanded(child: _buildStatItem('seguidores', followers)),
-          Expanded(child: _buildStatItem('seguidos', following)),
-        ],
-      );
+  Widget _buildStatsRow(String plans, String followers, String following) {
+    final t = AppLocalizations.of(context);
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      children: [
+        Expanded(child: _buildStatItem(t.futurePlans, plans)),
+        Expanded(child: _buildStatItem(t.followers, followers)),
+        Expanded(child: _buildStatItem(t.following, following)),
+      ],
+    );
+  }
 
   Widget _buildStatItem(String label, String count) {
-    final isPlans = label == 'planes futuros';
-    final isFollowers = label == 'seguidores';
+    final t = AppLocalizations.of(context);
+    final isPlans = label == t.futurePlans;
+    final isFollowers = label == t.followers;
     final iconPath =
         isPlans ? 'assets/icono-calendario.svg' : 'assets/icono-seguidores.svg';
     final iconColor = isPlans
@@ -720,8 +725,8 @@ class ProfileScreenState extends State<ProfileScreen> {
                     color: Colors.red.withOpacity(0.7),
                     borderRadius: BorderRadius.circular(30),
                   ),
-                  child: const Text('Cerrar sesión',
-                      style: TextStyle(
+                  child: Text(AppLocalizations.of(context).closeSession,
+                      style: const TextStyle(
                           fontSize: 18,
                           fontWeight: FontWeight.bold,
                           color: Colors.white)),

--- a/app_src/lib/explore_screen/users_managing/privilege_level_details.dart
+++ b/app_src/lib/explore_screen/users_managing/privilege_level_details.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import '../../l10n/app_localizations.dart';
 
 class PrivilegeLevelDetails extends StatefulWidget {
   final String userId; // ID del usuario para buscar sus datos en Firestore
@@ -184,41 +185,43 @@ class _PrivilegeLevelDetailsState extends State<PrivilegeLevelDetails> {
     final int maxMaxPartsBar = thresholdReq.minMaxParts;
     final int maxTotalPartsBar = thresholdReq.minTotalParts;
 
+    final t = AppLocalizations.of(context);
+
     Widget createdPlansText = Column(
-      children: const [
+      children: [
         Text(
-          "Planes creados",
-          style: TextStyle(color: Colors.white, fontSize: 10),
+          t.createdPlans,
+          style: const TextStyle(color: Colors.white, fontSize: 10),
           textAlign: TextAlign.center,
         ),
       ],
     );
 
     Widget maxPartsText = Column(
-      children: const [
+      children: [
         Text(
-          "Máx. participantes",
-          style: TextStyle(color: Colors.white, fontSize: 10),
+          t.maxParticipantsText,
+          style: const TextStyle(color: Colors.white, fontSize: 10),
           textAlign: TextAlign.center,
         ),
         Text(
-          "en un plan",
-          style: TextStyle(color: Colors.white, fontSize: 10),
+          t.inAPlan,
+          style: const TextStyle(color: Colors.white, fontSize: 10),
           textAlign: TextAlign.center,
         ),
       ],
     );
 
     Widget totalPartsText = Column(
-      children: const [
+      children: [
         Text(
-          "Total de participantes",
-          style: TextStyle(color: Colors.white, fontSize: 10),
+          t.totalParticipantsText,
+          style: const TextStyle(color: Colors.white, fontSize: 10),
           textAlign: TextAlign.center,
         ),
         Text(
-          "reunidos hasta ahora",
-          style: TextStyle(color: Colors.white, fontSize: 10),
+          t.gatheredSoFar,
+          style: const TextStyle(color: Colors.white, fontSize: 10),
           textAlign: TextAlign.center,
         ),
       ],
@@ -292,22 +295,20 @@ class _PrivilegeLevelDetailsState extends State<PrivilegeLevelDetails> {
   Widget _buildNextLevelHint() {
     final normalized = _privilegeLevel.toLowerCase().replaceAll('á', 'a');
 
+    final t = AppLocalizations.of(context);
     late final String message;
     switch (normalized) {
       case 'premium':
-        message =
-            'Crea 50 planes, logra 50 participantes en un solo plan y reúne 2000 participantes en total para pasar al nivel de privilegio Golden.';
+        message = t.nextHintPremium;
         break;
       case 'golden':
-        message =
-            'Crea 500 planes, logra 500 participantes en un solo plan y reúne 10000 participantes en total para pasar al nivel de privilegio VIP.';
+        message = t.nextHintGolden;
         break;
       case 'vip':
-        message = 'Estás disfrutando del nivel de privilegio VIP.';
+        message = t.nextHintVip;
         break;
       default:
-        message =
-            'Crea 5 planes, logra 5 participantes en un solo plan y reúne 20 participantes en total para pasar al nivel de privilegio Premium.';
+        message = t.nextHintBasic;
     }
 
     return Padding(
@@ -440,36 +441,26 @@ class _PrivilegeLevelDetailsState extends State<PrivilegeLevelDetails> {
   }
 
   void _showPrivilegeInfoPopup(String levelName) {
+    final t = AppLocalizations.of(context);
     String titleText;
     String contentText;
 
     switch (levelName.toLowerCase()) {
       case 'premium':
-        titleText = "Nivel Premium";
-        contentText = "El nivel Premium es el segundo nivel. "
-            "Para pasar al siguiente nivel de Golden:\n"
-            "- Crear 50 planes.\n"
-            "- Máximo de 50 participantes en un plan.\n"
-            "- 2000 participantes en total.";
+        titleText = t.levelPremium;
+        contentText = t.infoPremium;
         break;
       case 'golden':
-        titleText = "Nivel Golden";
-        contentText = "El nivel Golden es el penúltimo nivel. "
-            "Para pasar a VIP:\n"
-            "- Crear 500 planes.\n"
-            "- Alcanzar 500 participantes en un plan.\n"
-            "- 10000 participantes en total.";
+        titleText = t.levelGolden;
+        contentText = t.infoGolden;
         break;
       case 'vip':
-        titleText = "Nivel VIP";
-        contentText = "Este es el nivel más alto, sin límites.";
+        titleText = t.levelVip;
+        contentText = t.infoVip;
         break;
       default:
-        titleText = "Nivel Básico";
-        contentText = "El nivel Básico es el más bajo. Para pasar a Premium:\n"
-            "- Crear 5 planes.\n"
-            "- Alcanzar 5 participantes en un plan.\n"
-            "- 20 participantes en total.";
+        titleText = t.levelBasic;
+        contentText = t.infoBasic;
         break;
     }
 
@@ -513,9 +504,9 @@ class _PrivilegeLevelDetailsState extends State<PrivilegeLevelDetails> {
                       alignment: Alignment.centerRight,
                       child: TextButton(
                         onPressed: () => Navigator.of(context).pop(),
-                        child: const Text(
-                          "Cerrar",
-                          style: TextStyle(color: Colors.white),
+                        child: Text(
+                          AppLocalizations.of(context).close,
+                          style: const TextStyle(color: Colors.white),
                         ),
                       ),
                     ),

--- a/app_src/lib/l10n/app_localizations.dart
+++ b/app_src/lib/l10n/app_localizations.dart
@@ -180,6 +180,31 @@ class AppLocalizations {
       'plan_id_label': 'ID del Plan',
       'age_restriction_label': 'Restricción de edad',
       'ends_at_label': 'Finaliza',
+      'future_plans': 'Planes futuros',
+      'followers': 'Seguidores',
+      'following': 'Seguidos',
+      'memories': 'Memorias',
+      'close': 'Cerrar',
+      'level_basic': 'Nivel Básico',
+      'level_premium': 'Nivel Premium',
+      'level_golden': 'Nivel Golden',
+      'level_vip': 'Nivel VIP',
+      'next_hint_basic':
+          'Crea 5 planes, logra 5 participantes en un solo plan y reúne 20 participantes en total para pasar al nivel de privilegio Premium.',
+      'next_hint_premium':
+          'Crea 50 planes, logra 50 participantes en un solo plan y reúne 2000 participantes en total para pasar al nivel de privilegio Golden.',
+      'next_hint_golden':
+          'Crea 500 planes, logra 500 participantes en un solo plan y reúne 10000 participantes en total para pasar al nivel de privilegio VIP.',
+      'next_hint_vip': 'Estás disfrutando del nivel de privilegio VIP.',
+      'info_basic': 'El nivel Básico es el más bajo. Para pasar a Premium:\n- Crear 5 planes.\n- Alcanzar 5 participantes en un plan.\n- 20 participantes en total.',
+      'info_premium': 'El nivel Premium es el segundo nivel. Para pasar al siguiente nivel de Golden:\n- Crear 50 planes.\n- Máximo de 50 participantes en un plan.\n- 2000 participantes en total.',
+      'info_golden': 'El nivel Golden es el penúltimo nivel. Para pasar a VIP:\n- Crear 500 planes.\n- Alcanzar 500 participantes en un plan.\n- 10000 participantes en total.',
+      'info_vip': 'Este es el nivel más alto, sin límites.',
+      'created_plans': 'Planes creados',
+      'max_participants': 'Máx. participantes',
+      'in_a_plan': 'en un plan',
+      'total_participants': 'Total de participantes',
+      'gathered_so_far': 'reunidos hasta ahora',
     },
     'en': {
       'settings': 'Settings',
@@ -356,6 +381,31 @@ class AppLocalizations {
       'plan_id_label': 'Plan ID',
       'age_restriction_label': 'Age restriction',
       'ends_at_label': 'Ends',
+      'future_plans': 'Future plans',
+      'followers': 'Followers',
+      'following': 'Following',
+      'memories': 'Memories',
+      'close': 'Close',
+      'level_basic': 'Basic Level',
+      'level_premium': 'Premium Level',
+      'level_golden': 'Golden Level',
+      'level_vip': 'VIP Level',
+      'next_hint_basic':
+          'Create 5 plans, get 5 participants in one plan and gather 20 participants in total to reach the Premium privilege level.',
+      'next_hint_premium':
+          'Create 50 plans, get 50 participants in one plan and gather 2000 participants in total to reach the Golden privilege level.',
+      'next_hint_golden':
+          'Create 500 plans, get 500 participants in one plan and gather 10000 participants in total to reach the VIP privilege level.',
+      'next_hint_vip': 'You are enjoying the VIP privilege level.',
+      'info_basic': 'The Basic level is the lowest. To move to Premium:\n- Create 5 plans.\n- Reach 5 participants in a plan.\n- 20 participants in total.',
+      'info_premium': 'The Premium level is the second level. To move to Golden:\n- Create 50 plans.\n- Maximum of 50 participants in a plan.\n- 2000 participants in total.',
+      'info_golden': 'The Golden level is the penultimate level. To move to VIP:\n- Create 500 plans.\n- Reach 500 participants in a plan.\n- 10000 participants in total.',
+      'info_vip': 'This is the highest level, with no limits.',
+      'created_plans': 'Created plans',
+      'max_participants': 'Max. participants',
+      'in_a_plan': 'in one plan',
+      'total_participants': 'Total participants',
+      'gathered_so_far': 'gathered so far',
     },
   };
 
@@ -535,6 +585,28 @@ class AppLocalizations {
   String get planIdLabel => _t('plan_id_label');
   String get ageRestrictionLabel => _t('age_restriction_label');
   String get endsAt => _t('ends_at_label');
+  String get futurePlans => _t('future_plans');
+  String get followers => _t('followers');
+  String get following => _t('following');
+  String get memories => _t('memories');
+  String get close => _t('close');
+  String get levelBasic => _t('level_basic');
+  String get levelPremium => _t('level_premium');
+  String get levelGolden => _t('level_golden');
+  String get levelVip => _t('level_vip');
+  String get nextHintBasic => _t('next_hint_basic');
+  String get nextHintPremium => _t('next_hint_premium');
+  String get nextHintGolden => _t('next_hint_golden');
+  String get nextHintVip => _t('next_hint_vip');
+  String get infoBasic => _t('info_basic');
+  String get infoPremium => _t('info_premium');
+  String get infoGolden => _t('info_golden');
+  String get infoVip => _t('info_vip');
+  String get createdPlans => _t('created_plans');
+  String get maxParticipantsText => _t('max_participants');
+  String get inAPlan => _t('in_a_plan');
+  String get totalParticipantsText => _t('total_participants');
+  String get gatheredSoFar => _t('gathered_so_far');
 
   String planAgeRange(int start, int end) {
     return locale.languageCode == 'en'


### PR DESCRIPTION
## Summary
- translate profile stats labels and sign out text
- add localized privilege info popup text
- localize progress indicators within privilege details
- update memories calendar with locale-based months, days and labels
- support new translation keys

## Testing
- `dart` not available, no tests run

------
https://chatgpt.com/codex/tasks/task_e_68700410c550833280db582ab7f3923a