### PR TITLE
Fix localization for privilege and follow screens

### DIFF
--- a/app_src/lib/explore_screen/follow/following_screen.dart
+++ b/app_src/lib/explore_screen/follow/following_screen.dart
@@ -8,6 +8,7 @@ import '../../models/plan_model.dart';
 import '../plans_managing/frosted_plan_dialog_state.dart' as new_frosted;
 import '../users_managing/user_info_check.dart';
 import '../../main/colors.dart';
+import '../../l10n/app_localizations.dart';
 
 /// Pantalla de seguidores/seguidos.
 /// Se muestra como un modal a pantalla casi completa (deja libre el 10 % superior)
@@ -175,7 +176,7 @@ class _FollowingScreenState extends State<FollowingScreen> {
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Error al cargar datos: $e')),
+          SnackBar(content: Text('${AppLocalizations.of(context).error}: $e')),
         );
       }
       setState(() => _loading = false);
@@ -221,7 +222,9 @@ class _FollowingScreenState extends State<FollowingScreen> {
         const SizedBox(height: 12),
         // Título principal dinámico
         Text(
-          _showFollowers ? 'Seguidores' : 'Seguidos',
+          _showFollowers
+              ? AppLocalizations.of(context).followers
+              : AppLocalizations.of(context).following,
           style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
         ),
         const SizedBox(height: 4),
@@ -230,13 +233,13 @@ class _FollowingScreenState extends State<FollowingScreen> {
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             _TabButton(
-              label: 'Seguidores',
+              label: AppLocalizations.of(context).followers,
               selected: _showFollowers,
               onTap: () => _switchTab(true),
             ),
             const SizedBox(width: 16),
             _TabButton(
-              label: 'Seguidos',
+              label: AppLocalizations.of(context).following,
               selected: !_showFollowers,
               onTap: () => _switchTab(false),
             ),
@@ -249,7 +252,7 @@ class _FollowingScreenState extends State<FollowingScreen> {
           child: TextField(
             controller: _searchCtl,
             decoration: InputDecoration(
-              hintText: 'Buscar…',
+              hintText: '${AppLocalizations.of(context).search}…',
               prefixIcon: const Icon(Icons.search),
               border: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
@@ -265,7 +268,7 @@ class _FollowingScreenState extends State<FollowingScreen> {
           child: _loading
               ? const Center(child: CircularProgressIndicator())
               : _filtered.isEmpty
-                  ? const Center(child: Text('Sin resultados'))
+                  ? Center(child: Text(AppLocalizations.of(context).noResults))
                   : ListView.separated(
                       itemCount: _filtered.length,
                       separatorBuilder: (_, __) => const _ThinDivider(),

--- a/app_src/lib/explore_screen/future_plans/future_plans.dart
+++ b/app_src/lib/explore_screen/future_plans/future_plans.dart
@@ -8,6 +8,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 
 import '../../models/plan_model.dart';
 import '../plans_managing/plan_card.dart';
+import '../../l10n/app_localizations.dart';
 
 class FuturePlansScreen extends StatefulWidget {
   final String userId;
@@ -121,8 +122,8 @@ class _FuturePlansScreenState extends State<FuturePlansScreen> {
             ),
           ),
           const SizedBox(height: 12),
-          const Text('Planes futuros',
-              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+          Text(AppLocalizations.of(context).futurePlans,
+              style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
           const SizedBox(height: 8),
           const Divider(height: 1),
 
@@ -142,10 +143,10 @@ class _FuturePlansScreenState extends State<FuturePlansScreen> {
                       return const Center(child: CircularProgressIndicator());
                     }
                     if (!pSnap.hasData || pSnap.data!.isEmpty) {
-                      return const Center(
+                      return Center(
                         child: Text(
-                          'Este usuario no ha creado planes futuros aún...',
-                          style: TextStyle(fontSize: 16),
+                          AppLocalizations.of(context).noFuturePlansUser,
+                          style: const TextStyle(fontSize: 16),
                         ),
                       );
                     }
@@ -213,13 +214,14 @@ class _FuturePlansScreenState extends State<FuturePlansScreen> {
                                               color: Colors.white,
                                             ),
                                             const SizedBox(height: 12),
-                                            const Padding(
-                                              padding: EdgeInsets.symmetric(
+                                            Padding(
+                                              padding: const EdgeInsets.symmetric(
                                                   horizontal: 24),
                                               child: Text(
-                                                'Debes seguir a esta cuenta para ver sus planes futuros',
+                                                AppLocalizations.of(context)
+                                                    .followToViewFuturePlans,
                                                 textAlign: TextAlign.center,
-                                                style: TextStyle(
+                                                style: const TextStyle(
                                                   color: Colors.white,
                                                   fontSize: 15,
                                                   fontWeight: FontWeight.w500,

--- a/app_src/lib/explore_screen/users_managing/privilege_level_details.dart
+++ b/app_src/lib/explore_screen/users_managing/privilege_level_details.dart
@@ -58,7 +58,7 @@ class PrivilegeLevelDetails extends StatefulWidget {
 }
 
 class _PrivilegeLevelDetailsState extends State<PrivilegeLevelDetails> {
-  String _privilegeInfo = "Cargando nivel de privilegios...";
+  String _privilegeInfo = '';
 
   // Estadísticas Firestore
   int _totalCreatedPlans = 0;
@@ -73,6 +73,21 @@ class _PrivilegeLevelDetailsState extends State<PrivilegeLevelDetails> {
   ];
 
   String _privilegeLevel = "Básico";
+
+  String _localizedLevel(String level) {
+    final isEn = Localizations.localeOf(context).languageCode == 'en';
+    final normalized = level.toLowerCase().replaceAll('á', 'a');
+    switch (normalized) {
+      case 'premium':
+        return 'Premium';
+      case 'golden':
+        return 'Golden';
+      case 'vip':
+        return 'VIP';
+      default:
+        return isEn ? 'Basic' : 'Básico';
+    }
+  }
 
   String get _privilegeIcon {
     final normalized = _privilegeLevel.toLowerCase().replaceAll('á', 'a');
@@ -91,6 +106,9 @@ class _PrivilegeLevelDetailsState extends State<PrivilegeLevelDetails> {
   @override
   void initState() {
     super.initState();
+    _privilegeInfo = Localizations.localeOf(context).languageCode == 'en'
+        ? 'Loading privilege level...'
+        : 'Cargando nivel de privilegios...';
     _loadPrivilegeInfo();
   }
 
@@ -125,7 +143,7 @@ class _PrivilegeLevelDetailsState extends State<PrivilegeLevelDetails> {
             (updatedData['privilegeLevel'] ?? 'Básico').toString();
 
         setState(() {
-          _privilegeInfo = _privilegeLevel;
+          _privilegeInfo = _localizedLevel(_privilegeLevel);
         });
       } else {
         setState(() {
@@ -348,7 +366,12 @@ class _PrivilegeLevelDetailsState extends State<PrivilegeLevelDetails> {
       "assets/icono-usuario-golden.png",
       "assets/icono-usuario-vip.png",
     ];
-    final iconNames = ["Básico", "Premium", "Golden", "VIP"];
+    final iconNames = [
+      _localizedLevel('Básico'),
+      'Premium',
+      'Golden',
+      'VIP'
+    ];
 
     Widget arrow =
         const Icon(Icons.arrow_forward, color: Colors.grey, size: 20);

--- a/app_src/lib/l10n/app_localizations.dart
+++ b/app_src/lib/l10n/app_localizations.dart
@@ -219,6 +219,11 @@ class AppLocalizations {
       'in_a_plan': 'en un plan',
       'total_participants': 'Total de participantes',
       'gathered_so_far': 'reunidos hasta ahora',
+      'no_future_plans_user':
+          'Este usuario no ha creado planes futuros aún...',
+      'follow_to_view_future_plans':
+          'Debes seguir a esta cuenta para ver sus planes futuros',
+      'no_results': 'Sin resultados',
     },
     'en': {
       'settings': 'Settings',
@@ -434,6 +439,11 @@ class AppLocalizations {
       'in_a_plan': 'in one plan',
       'total_participants': 'Total participants',
       'gathered_so_far': 'gathered so far',
+      'no_future_plans_user':
+          "This user hasn't created future plans yet...",
+      'follow_to_view_future_plans':
+          'You must follow this account to view their future plans',
+      'no_results': 'No results',
     },
   };
 
@@ -635,6 +645,9 @@ class AppLocalizations {
   String get inAPlan => _t('in_a_plan');
   String get totalParticipantsText => _t('total_participants');
   String get gatheredSoFar => _t('gathered_so_far');
+  String get noFuturePlansUser => _t('no_future_plans_user');
+  String get followToViewFuturePlans => _t('follow_to_view_future_plans');
+  String get noResults => _t('no_results');
   String get sendMessage => _t('send_message');
   String get follow => _t('follow');
   String get followingStatus => _t('following_status');


### PR DESCRIPTION
## Summary
- localize privilege info level name
- translate future plans and follow modals
- add missing localization strings

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68700a8505c08332a0f7e999d88d0a51