### PR TITLE
Traducción de ventana Reportar Usuario y corrección de layout

### DIFF
--- a/app_src/lib/explore_screen/users_managing/report_and_block_user.dart
+++ b/app_src/lib/explore_screen/users_managing/report_and_block_user.dart
@@ -4,6 +4,8 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
+import '../../l10n/app_localizations.dart';
+
 /// Pantalla a pantalla completa para reportar a un usuario.
 /// Se seleccionan hasta 6 motivos y un comentario opcional.
 /// Al enviar, se guardan en la colección 'reports' de Firestore.
@@ -20,17 +22,19 @@ class ReportUserScreen extends StatefulWidget {
 }
 
 class _ReportUserScreenState extends State<ReportUserScreen> {
-  final List<String> _reasons = [
-    'Contenido inapropiado',
-    'Suplantación de identidad',
-    'Spam o publicitario',
-    'Lenguaje o comportamiento abusivo',
-    'Imágenes inapropiadas',
-    'Otro (especificar)',
-  ];
+  List<String> _reasons(BuildContext context) {
+    final t = AppLocalizations.of(context);
+    return [
+      t.reasonInappropriateContent,
+      t.reasonImpersonation,
+      t.reasonSpam,
+      t.reasonAbusiveLanguage,
+      t.reasonInappropriateImages,
+    ];
+  }
 
   // booleans para cada motivo
-  final List<bool> _selected = [false, false, false, false, false, false];
+  final List<bool> _selected = [false, false, false, false, false];
   final TextEditingController _optionalCommentController =
       TextEditingController();
 
@@ -38,25 +42,26 @@ class _ReportUserScreenState extends State<ReportUserScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text("Reportar Usuario"),
+        title: Text(AppLocalizations.of(context).reportUserTitle),
       ),
-      body: Column(
+      body: SafeArea(
+        child: Column(
         children: [
           const SizedBox(height: 16),
-          const Padding(
-            padding: EdgeInsets.symmetric(horizontal: 16),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
             child: Text(
-              "Selecciona los motivos por los que deseas reportar este perfil",
-              style: TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+              AppLocalizations.of(context).selectReportReasons,
+              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
             ),
           ),
           const SizedBox(height: 8),
           Expanded(
             child: ListView.builder(
-              itemCount: _reasons.length,
+              itemCount: _reasons(context).length,
               itemBuilder: (ctx, i) {
                 return ListTile(
-                  title: Text(_reasons[i]),
+                  title: Text(_reasons(context)[i]),
                   trailing: Checkbox(
                     value: _selected[i],
                     onChanged: (val) {
@@ -75,7 +80,7 @@ class _ReportUserScreenState extends State<ReportUserScreen> {
             child: Align(
               alignment: Alignment.centerLeft,
               child: Text(
-                "¿Por qué quieres reportar este perfil? (opcional)",
+                AppLocalizations.of(context).reportOptionalComment,
                 style: TextStyle(fontSize: 14, color: Colors.grey[700]),
               ),
             ),
@@ -85,9 +90,9 @@ class _ReportUserScreenState extends State<ReportUserScreen> {
             padding: const EdgeInsets.symmetric(horizontal: 16),
             child: TextField(
               controller: _optionalCommentController,
-              decoration: const InputDecoration(
-                border: OutlineInputBorder(),
-                hintText: 'Describe brevemente...',
+              decoration: InputDecoration(
+                border: const OutlineInputBorder(),
+                hintText: AppLocalizations.of(context).describeBrieflyHint,
               ),
               maxLines: 3,
             ),
@@ -99,11 +104,11 @@ class _ReportUserScreenState extends State<ReportUserScreen> {
             children: [
               OutlinedButton(
                 onPressed: () => Navigator.pop(context),
-                child: const Text("Volver"),
+                child: Text(AppLocalizations.of(context).back),
               ),
               ElevatedButton(
                 onPressed: _sendReport,
-                child: const Text("Enviar"),
+                child: Text(AppLocalizations.of(context).send),
               ),
             ],
           ),
@@ -119,9 +124,10 @@ class _ReportUserScreenState extends State<ReportUserScreen> {
 
     // Recolecta los motivos marcados
     final selectedReasons = <String>[];
-    for (int i = 0; i < _reasons.length; i++) {
+    final reasons = _reasons(context);
+    for (int i = 0; i < reasons.length; i++) {
       if (_selected[i]) {
-        selectedReasons.add(_reasons[i]);
+        selectedReasons.add(reasons[i]);
       }
     }
 
@@ -138,13 +144,13 @@ class _ReportUserScreenState extends State<ReportUserScreen> {
       });
 
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text("Reporte enviado con éxito")),
+        SnackBar(content: Text(AppLocalizations.of(context).reportSentSuccess)),
       );
 
       Navigator.pop(context); // cierra la pantalla
     } catch (e) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text("Ocurrió un error al enviar reporte.")),
+        SnackBar(content: Text(AppLocalizations.of(context).reportError)),
       );
     }
   }
@@ -220,10 +226,11 @@ class ReportAndBlockUser {
                                         height: 24,
                                       ),
                                       const SizedBox(width: 12),
-                                      const Expanded(
+                                      Expanded(
                                         child: Text(
-                                          'Reportar Perfil',
-                                          style: TextStyle(
+                                          AppLocalizations.of(context)
+                                              .reportProfile,
+                                          style: const TextStyle(
                                             color: Colors.black87,
                                             fontSize: 16,
                                           ),
@@ -263,8 +270,10 @@ class ReportAndBlockUser {
                                       Expanded(
                                         child: Text(
                                           isBlocked
-                                              ? 'Desbloquear Perfil'
-                                              : 'Bloquear Perfil',
+                                              ? AppLocalizations.of(context)
+                                                  .unblockProfile
+                                              : AppLocalizations.of(context)
+                                                  .blockProfile,
                                           style: const TextStyle(
                                             color: Colors.black87,
                                             fontSize: 16,

--- a/app_src/lib/l10n/app_localizations.dart
+++ b/app_src/lib/l10n/app_localizations.dart
@@ -219,6 +219,20 @@ class AppLocalizations {
       'in_a_plan': 'en un plan',
       'total_participants': 'Total de participantes',
       'gathered_so_far': 'reunidos hasta ahora',
+      'report_user_title': 'Reportar Usuario',
+      'select_report_reasons':
+          'Selecciona los motivos por los que deseas reportar este perfil',
+      'report_optional_comment':
+          '¿Por qué quieres reportar este perfil? (opcional)',
+      'describe_briefly_hint': 'Describe brevemente...',
+      'back': 'Volver',
+      'report_sent_success': 'Reporte enviado con éxito',
+      'report_error': 'Ocurrió un error al enviar reporte.',
+      'reason_inappropriate_content': 'Contenido inapropiado',
+      'reason_impersonation': 'Suplantación de identidad',
+      'reason_spam': 'Spam o publicitario',
+      'reason_abusive_language': 'Lenguaje o comportamiento abusivo',
+      'reason_inappropriate_images': 'Imágenes inapropiadas',
     },
     'en': {
       'settings': 'Settings',
@@ -434,6 +448,20 @@ class AppLocalizations {
       'in_a_plan': 'in one plan',
       'total_participants': 'Total participants',
       'gathered_so_far': 'gathered so far',
+      'report_user_title': 'Report User',
+      'select_report_reasons':
+          'Select the reasons why you want to report this profile',
+      'report_optional_comment':
+          'Why do you want to report this profile? (optional)',
+      'describe_briefly_hint': 'Briefly describe...',
+      'back': 'Back',
+      'report_sent_success': 'Report sent successfully',
+      'report_error': 'An error occurred while sending the report.',
+      'reason_inappropriate_content': 'Inappropriate content',
+      'reason_impersonation': 'Impersonation',
+      'reason_spam': 'Spam or advertising',
+      'reason_abusive_language': 'Abusive language or behavior',
+      'reason_inappropriate_images': 'Inappropriate images',
     },
   };
 
@@ -644,6 +672,19 @@ class AppLocalizations {
   String get privateProfileMemories => _t('private_profile_memories');
   String get planAndMemories => _t('plan_and_memories');
   String get noMemoriesDay => _t('no_memories_day');
+
+  String get reportUserTitle => _t('report_user_title');
+  String get selectReportReasons => _t('select_report_reasons');
+  String get reportOptionalComment => _t('report_optional_comment');
+  String get describeBrieflyHint => _t('describe_briefly_hint');
+  String get back => _t('back');
+  String get reportSentSuccess => _t('report_sent_success');
+  String get reportError => _t('report_error');
+  String get reasonInappropriateContent => _t('reason_inappropriate_content');
+  String get reasonImpersonation => _t('reason_impersonation');
+  String get reasonSpam => _t('reason_spam');
+  String get reasonAbusiveLanguage => _t('reason_abusive_language');
+  String get reasonInappropriateImages => _t('reason_inappropriate_images');
 
   String planAgeRange(int start, int end) {
     return locale.languageCode == 'en'


### PR DESCRIPTION
## Summary
- translate report-user screen using `AppLocalizations`
- remove "Otro (especificar)" option from reasons list
- adjust layout using `SafeArea` so buttons are visible
- localize pop-up menu texts for report/block actions

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68700b7cd4dc8332869b9cdea927b5f9