### PR TITLE
Fix localization for block/unblock popups

### DIFF
--- a/app_src/lib/explore_screen/users_managing/report_and_block_user.dart
+++ b/app_src/lib/explore_screen/users_managing/report_and_block_user.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import '../../l10n/app_localizations.dart';
 
 /// Pantalla a pantalla completa para reportar a un usuario.
 /// Se seleccionan hasta 6 motivos y un comentario opcional.
@@ -321,20 +322,21 @@ class ReportAndBlockUser {
     isBlocked = !isCurrentlyBlocked;
 
     // Mostramos popup confirmando acción
+    final t = AppLocalizations.of(context);
     showDialog(
       context: context,
       builder: (ctx) {
         return AlertDialog(
-          title: Text(isBlocked ? "Perfil Bloqueado" : "Perfil Desbloqueado"),
+          title: Text(
+            isBlocked ? t.profileBlockedTitle : t.profileUnblockedTitle,
+          ),
           content: Text(
-            isBlocked
-                ? "Este perfil ha sido bloqueado, ya no podrá interactuar contigo."
-                : "Has desbloqueado a este usuario.",
+            isBlocked ? t.profileBlockedMessage : t.profileUnblockedMessage,
           ),
           actions: [
             TextButton(
               onPressed: () => Navigator.pop(ctx),
-              child: const Text("OK"),
+              child: Text(t.ok),
             ),
           ],
         );

--- a/app_src/lib/l10n/app_localizations.dart
+++ b/app_src/lib/l10n/app_localizations.dart
@@ -177,6 +177,11 @@ class AppLocalizations {
       'report_profile': 'Reportar perfil',
       'block_profile': 'Bloquear perfil',
       'unblock_profile': 'Desbloquear perfil',
+      'profile_blocked_title': 'Perfil Bloqueado',
+      'profile_unblocked_title': 'Perfil Desbloqueado',
+      'profile_blocked_message':
+          'Este perfil ha sido bloqueado, ya no podrá interactuar contigo.',
+      'profile_unblocked_message': 'Has desbloqueado a este usuario.',
       'future_plans': 'planes futuros',
       'followers': 'seguidores',
       'following': 'seguidos',
@@ -392,6 +397,11 @@ class AppLocalizations {
       'report_profile': 'Report profile',
       'block_profile': 'Block profile',
       'unblock_profile': 'Unblock profile',
+      'profile_blocked_title': 'Profile Blocked',
+      'profile_unblocked_title': 'Profile Unblocked',
+      'profile_blocked_message':
+          'This profile has been blocked and will no longer interact with you.',
+      'profile_unblocked_message': 'You have unblocked this user.',
       'future_plans': 'Future plans',
       'followers': 'Followers',
       'following': 'Following',
@@ -610,6 +620,10 @@ class AppLocalizations {
   String get reportProfile => _t('report_profile');
   String get blockProfile => _t('block_profile');
   String get unblockProfile => _t('unblock_profile');
+  String get profileBlockedTitle => _t('profile_blocked_title');
+  String get profileUnblockedTitle => _t('profile_unblocked_title');
+  String get profileBlockedMessage => _t('profile_blocked_message');
+  String get profileUnblockedMessage => _t('profile_unblocked_message');
   String get planIdLabel => _t('plan_id_label');
   String get ageRestrictionLabel => _t('age_restriction_label');
   String get endsAt => _t('ends_at_label');


### PR DESCRIPTION
## Summary
- add translation keys for block/unblock confirmation dialogs
- expose getters for these new keys
- show localized texts in block/unblock popups

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68700bd269688332a74559fcbf83f5be