### PR TITLE
Translate more chat UI strings

### DIFF
--- a/app_src/lib/explore_screen/chats/chat_screen.dart
+++ b/app_src/lib/explore_screen/chats/chat_screen.dart
@@ -1775,9 +1775,10 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
     showDialog(
       context: context,
       builder: (context) {
+        final t = AppLocalizations.of(context);
         return AlertDialog(
-          title: const Text('Seleccionar imagen'),
-          content: const Text('Elige desde dónde obtener la foto'),
+          title: Text(t.selectImage),
+          content: Text(t.choosePhotoSource),
           actions: [
             TextButton(
               onPressed: () async {
@@ -1789,7 +1790,7 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
                   _uploadAndSendImage(image);
                 }
               },
-              child: const Text('Cámara'),
+              child: Text(t.camera),
             ),
             TextButton(
               onPressed: () async {
@@ -1801,7 +1802,7 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
                   _uploadAndSendImage(image);
                 }
               },
-              child: const Text('Galería'),
+              child: Text(t.gallery),
             ),
           ],
         );

--- a/app_src/lib/explore_screen/chats/location_pick_screen.dart
+++ b/app_src/lib/explore_screen/chats/location_pick_screen.dart
@@ -8,6 +8,7 @@ import 'package:geocoding/geocoding.dart'; // para convertir dirección <-> coor
 import '../../main/colors.dart';
 // Si tienes tu getCustomSvgMarker:
 import '../../plan_creation/new_plan_creation_screen.dart' show getCustomSvgMarker;
+import '../../l10n/app_localizations.dart';
 
 class LocationPickScreen extends StatefulWidget {
   final double? initialLat;
@@ -175,12 +176,13 @@ class _LocationPickScreenState extends State<LocationPickScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context);
     final markerLat = _selectedLat ?? 0.0;
     final markerLng = _selectedLng ?? 0.0;
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text("Elegir ubicación"),
+        title: Text(t.chooseLocation),
         backgroundColor: AppColors.white,
         actions: [
           IconButton(
@@ -200,7 +202,7 @@ class _LocationPickScreenState extends State<LocationPickScreen> {
                   child: TextField(
                     controller: _searchController,
                     decoration: InputDecoration(
-                      hintText: "Busca una dirección...",
+                      hintText: t.searchAddressHint,
                       prefixIcon: const Icon(Icons.search),
                       suffixIcon: _isSearching
                           ? const Padding(
@@ -256,7 +258,7 @@ class _LocationPickScreenState extends State<LocationPickScreen> {
               color: Colors.grey.shade200,
               padding: const EdgeInsets.all(8.0),
               child: Text(
-                "Dirección actual: $_selectedAddress",
+                '${t.currentAddressLabel} $_selectedAddress',
                 style: const TextStyle(fontSize: 14),
               ),
             ),
@@ -267,7 +269,7 @@ class _LocationPickScreenState extends State<LocationPickScreen> {
               child: ElevatedButton.icon(
                 onPressed: _onConfirmLocation,
                 icon: const Icon(Icons.check),
-                label: const Text("Confirmar ubicación"),
+                label: Text(t.confirmLocation),
                 style: ElevatedButton.styleFrom(
                   foregroundColor: Colors.white,
                   backgroundColor: AppColors.planColor,

--- a/app_src/lib/explore_screen/chats/my_plans_selection.dart
+++ b/app_src/lib/explore_screen/chats/my_plans_selection.dart
@@ -4,6 +4,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 
 import '../../models/plan_model.dart';
 import '../plans_managing/plan_card.dart'; // Ajusta la ruta a tu plan_card.dart
+import '../../l10n/app_localizations.dart';
 
 class MyPlansSelection extends StatelessWidget {
   final Set<String> selectedIds;
@@ -80,10 +81,11 @@ class MyPlansSelection extends StatelessWidget {
           return const Center(child: CircularProgressIndicator());
         }
         if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
-          return const Center(
+          final t = AppLocalizations.of(context);
+          return Center(
             child: Text(
-              'No tienes planes aún.',
-              style: TextStyle(color: Colors.black),
+              t.noPlansYet,
+              style: const TextStyle(color: Colors.black),
             ),
           );
         }

--- a/app_src/lib/explore_screen/chats/select_plan_screen.dart
+++ b/app_src/lib/explore_screen/chats/select_plan_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../../l10n/app_localizations.dart';
 import 'my_plans_selection.dart';
 import 'subscribed_plans_selection.dart';
 
@@ -34,14 +35,15 @@ class _SelectPlanScreenState extends State<SelectPlanScreen>
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context);
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Seleccionar Planes'),
+        title: Text(t.selectPlans),
         bottom: TabBar(
           controller: _tabController,
-          tabs: const [
-            Tab(text: 'Mis Planes'),
-            Tab(text: 'Suscritos'),
+          tabs: [
+            Tab(text: t.myPlansTab),
+            Tab(text: t.subscribedTab),
           ],
         ),
         actions: [

--- a/app_src/lib/explore_screen/chats/subscribed_plans_selection.dart
+++ b/app_src/lib/explore_screen/chats/subscribed_plans_selection.dart
@@ -5,6 +5,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import '../../models/plan_model.dart';
 // IMPORTA plan_card.dart
 import '../plans_managing/plan_card.dart';
+import '../../l10n/app_localizations.dart';
 
 class SubscribedPlansSelection extends StatelessWidget {
   final Set<String> selectedIds;
@@ -115,10 +116,11 @@ class SubscribedPlansSelection extends StatelessWidget {
           return const Center(child: CircularProgressIndicator());
         }
         if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
-          return const Center(
+          final t = AppLocalizations.of(context);
+          return Center(
             child: Text(
-              'No tienes planes suscritos aún.',
-              style: TextStyle(color: Colors.black),
+              t.noSubscribedPlansYet,
+              style: const TextStyle(color: Colors.black),
             ),
           );
         }
@@ -140,10 +142,11 @@ class SubscribedPlansSelection extends StatelessWidget {
             }
             final plans = planSnapshot.data ?? [];
             if (plans.isEmpty) {
-              return const Center(
+              final t = AppLocalizations.of(context);
+              return Center(
                 child: Text(
-                  'No tienes planes suscritos aún.',
-                  style: TextStyle(color: Colors.black),
+                  t.noSubscribedPlansYet,
+                  style: const TextStyle(color: Colors.black),
                 ),
               );
             }

--- a/app_src/lib/l10n/app_localizations.dart
+++ b/app_src/lib/l10n/app_localizations.dart
@@ -237,6 +237,18 @@ class AppLocalizations {
           'Este usuario no ha creado planes futuros aún...',
       'follow_to_view_future_plans':
           'Debes seguir a esta cuenta para ver sus planes futuros',
+      'choose_location': 'Elegir ubicación',
+      'search_address_hint': 'Busca una dirección...',
+      'current_address_label': 'Dirección actual:',
+      'confirm_location': 'Confirmar ubicación',
+      'select_plans': 'Seleccionar Planes',
+      'my_plans_tab': 'Mis Planes',
+      'subscribed_tab': 'Suscritos',
+      'no_subscribed_plans_yet': 'No tienes planes suscritos aún.',
+      'select_image': 'Seleccionar imagen',
+      'choose_photo_source': 'Elige desde dónde obtener la foto',
+      'camera': 'Cámara',
+      'gallery': 'Galería',
       'no_results': 'Sin resultados',
     },
     'en': {
@@ -471,6 +483,18 @@ class AppLocalizations {
           "This user hasn't created future plans yet...",
       'follow_to_view_future_plans':
           'You must follow this account to view their future plans',
+      'choose_location': 'Choose Location',
+      'search_address_hint': 'Search for an address...',
+      'current_address_label': 'Current address:',
+      'confirm_location': 'Confirm location',
+      'select_plans': 'Select Plans',
+      'my_plans_tab': 'My Plans',
+      'subscribed_tab': 'Subscribed',
+      'no_subscribed_plans_yet': "You don't have subscribed plans yet.",
+      'select_image': 'Select image',
+      'choose_photo_source': 'Choose where to get the photo',
+      'camera': 'Camera',
+      'gallery': 'Gallery',
       'no_results': 'No results',
     },
   };
@@ -679,6 +703,18 @@ class AppLocalizations {
   String get gatheredSoFar => _t('gathered_so_far');
   String get noFuturePlansUser => _t('no_future_plans_user');
   String get followToViewFuturePlans => _t('follow_to_view_future_plans');
+  String get chooseLocation => _t('choose_location');
+  String get searchAddressHint => _t('search_address_hint');
+  String get currentAddressLabel => _t('current_address_label');
+  String get confirmLocation => _t('confirm_location');
+  String get selectPlans => _t('select_plans');
+  String get myPlansTab => _t('my_plans_tab');
+  String get subscribedTab => _t('subscribed_tab');
+  String get noSubscribedPlansYet => _t('no_subscribed_plans_yet');
+  String get selectImage => _t('select_image');
+  String get choosePhotoSource => _t('choose_photo_source');
+  String get camera => _t('camera');
+  String get gallery => _t('gallery');
   String get noResults => _t('no_results');
   String get sendMessage => _t('send_message');
   String get follow => _t('follow');


### PR DESCRIPTION
## Summary
- add new localization keys for location picker and plan selection flows
- localize labels in LocationPickScreen
- localize plan selection screens and photo picker dialog

## Testing
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68701bf7a3e883328bb1856dcceaf870