### PR TITLE
Fix invite popup methods and add localization import

### DIFF
--- a/app_src/lib/explore_screen/profile/user_images_managing.dart
+++ b/app_src/lib/explore_screen/profile/user_images_managing.dart
@@ -12,6 +12,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import '../../l10n/app_localizations.dart';
 
 class UserImagesManaging {
   static final ImagePicker _imagePicker = ImagePicker();

--- a/app_src/lib/explore_screen/special_plans/invite_users_to_plan_screen.dart
+++ b/app_src/lib/explore_screen/special_plans/invite_users_to_plan_screen.dart
@@ -1376,8 +1376,6 @@ class _NewPlanInviteContentState extends State<_NewPlanInviteContent> {
       },
     );
   }
-}
-
 Future<void> _pickImage(ImageSource source) async {
   final picker = ImagePicker();
   final pickedFile = await picker.pickImage(source: source);
@@ -1496,6 +1494,7 @@ Future<void> _onFinishPlan() async {
       SnackBar(content: Text("Error al crear el plan: $err")),
     );
   }
+}
 }
 
 // MÉTODOS AUXILIARES GLOBALES (idénticos al original)


### PR DESCRIPTION
## Summary
- keep invite popup methods inside state class
- close `_NewPlanInviteContentState` after `_onFinishPlan`
- add missing `AppLocalizations` import for user images managing

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870286775e48332b1dcb37dd1afcb23