### PR TITLE
Localizar textos de LoginScreen

### DIFF
--- a/app_src/lib/l10n/app_localizations.dart
+++ b/app_src/lib/l10n/app_localizations.dart
@@ -252,6 +252,25 @@ class AppLocalizations {
       'camera': 'Cámara',
       'gallery': 'Galería',
       'no_results': 'Sin resultados',
+      'login_title': 'Inicio de sesión',
+      'login': 'Iniciar sesión',
+      'email_label': 'Correo electrónico',
+      'email_short': 'correo',
+      'forgot_password': '¿Olvidaste tu contraseña?',
+      'no_account_register': '¿No tienes una cuenta? Regístrate.',
+      'continue_google': 'Continuar con Google',
+      'remember_login_data': 'Recordar datos de inicio de sesión',
+      'wrong_email_password': 'Correo o contraseña incorrectos.',
+      'google_login_error': 'Error de inicio de sesión con Google.',
+      'not_registered_title': 'No estás registrado',
+      'not_registered_message':
+          'No hay ningún perfil en la base de datos para este usuario. Debes registrarte primero.',
+      'google_no_profile_title': 'No hay perfil',
+      'google_no_profile_message':
+          'No hay un perfil asociado a tu cuenta de Google. ¿Crear una nueva cuenta?',
+      'login_error_title': 'Error de inicio de sesión',
+      'fill_fields_login':
+          'Introduce tu {fields} y después pulsa en "Iniciar sesión".',
     },
     'en': {
       'settings': 'Settings',
@@ -500,6 +519,24 @@ class AppLocalizations {
       'camera': 'Camera',
       'gallery': 'Gallery',
       'no_results': 'No results',
+      'login_title': 'Sign in',
+      'login': 'Sign in',
+      'email_label': 'Email',
+      'email_short': 'email',
+      'forgot_password': 'Forgot your password?',
+      'no_account_register': "Don't have an account? Sign up.",
+      'continue_google': 'Continue with Google',
+      'remember_login_data': 'Remember login data',
+      'wrong_email_password': 'Wrong email or password.',
+      'google_login_error': 'Google sign in error.',
+      'not_registered_title': 'Not registered',
+      'not_registered_message':
+          'There is no profile in the database for this user. You must register first.',
+      'google_no_profile_title': 'No profile',
+      'google_no_profile_message':
+          'There is no profile associated with your Google account. Create a new account?',
+      'login_error_title': 'Sign in error',
+      'fill_fields_login': 'Enter your {fields} then press "Sign in".',
     },
   };
 
@@ -722,6 +759,25 @@ class AppLocalizations {
   String get camera => _t('camera');
   String get gallery => _t('gallery');
   String get noResults => _t('no_results');
+  String get loginTitle => _t('login_title');
+  String get login => _t('login');
+  String get emailLabel => _t('email_label');
+  String get emailShort => _t('email_short');
+  String get forgotPassword => _t('forgot_password');
+  String get noAccountRegister => _t('no_account_register');
+  String get continueGoogle => _t('continue_google');
+  String get rememberLoginData => _t('remember_login_data');
+  String get wrongEmailPassword => _t('wrong_email_password');
+  String get googleLoginError => _t('google_login_error');
+  String get notRegisteredTitle => _t('not_registered_title');
+  String get notRegisteredMessage => _t('not_registered_message');
+  String get googleNoProfileTitle => _t('google_no_profile_title');
+  String get googleNoProfileMessage => _t('google_no_profile_message');
+  String get loginErrorTitle => _t('login_error_title');
+
+  String fillFieldsLogin(String fields) {
+    return _t('fill_fields_login').replaceFirst('{fields}', fields);
+  }
   String get sendMessage => _t('send_message');
   String get follow => _t('follow');
   String get followingStatus => _t('following_status');

--- a/app_src/lib/start/login/login_screen.dart
+++ b/app_src/lib/start/login/login_screen.dart
@@ -16,6 +16,7 @@ import '../../explore_screen/main_screen/explore_screen.dart';
 import '../../main/colors.dart';
 import '../../explore_screen/users_managing/presence_service.dart';
 import '../../services/location_update_service.dart';
+import '../../l10n/app_localizations.dart';
 import 'recover_password.dart';
 import '../registration/register_screen.dart';
 import '../welcome_screen.dart';
@@ -85,10 +86,16 @@ class _LoginScreenState extends State<LoginScreen> {
     if (emailController.text.trim().isEmpty ||
         passwordController.text.trim().isEmpty) {
       final missing = <String>[];
-      if (emailController.text.trim().isEmpty) missing.add('correo');
-      if (passwordController.text.trim().isEmpty) missing.add('contraseña');
+      if (emailController.text.trim().isEmpty) {
+        missing.add(AppLocalizations.of(context).emailShort);
+      }
+      if (passwordController.text.trim().isEmpty) {
+        missing.add(AppLocalizations.of(context).password.toLowerCase());
+      }
+      final separator =
+          AppLocalizations.of(context).locale.languageCode == 'en' ? ' and ' : ' y ';
       final msg =
-          'Introduce tu ${missing.join(' y ')} y después pulsa en "Iniciar sesión".';
+          AppLocalizations.of(context).fillFieldsLogin(missing.join(separator));
       _showPopup(msg);
       return;
     }
@@ -131,7 +138,10 @@ class _LoginScreenState extends State<LoginScreen> {
 
       await _goToExplore();
     } on FirebaseAuthException {
-      if (mounted) _showErrorDialog('Correo o contraseña incorrectos.');
+      if (mounted) {
+        _showErrorDialog(
+            AppLocalizations.of(context).wrongEmailPassword);
+      }
     } finally {
       if (mounted) setState(() => isLoading = false);
     }
@@ -191,8 +201,9 @@ class _LoginScreenState extends State<LoginScreen> {
     } catch (_) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-              content: Text('Error de inicio de sesión con Google.')),
+          SnackBar(
+              content:
+                  Text(AppLocalizations.of(context).googleLoginError)),
         );
       }
     } finally {
@@ -207,15 +218,13 @@ class _LoginScreenState extends State<LoginScreen> {
     showDialog(
       context: context,
       builder: (_) => AlertDialog(
-        title: const Text('No estás registrado'),
-        content: const Text(
-          'No hay ningún perfil en la base de datos para este usuario. '
-          'Debes registrarte primero.',
-        ),
+        title: Text(AppLocalizations.of(context).notRegisteredTitle),
+        content:
+            Text(AppLocalizations.of(context).notRegisteredMessage),
         actions: [
           TextButton(
               onPressed: () => Navigator.pop(context),
-              child: const Text('Aceptar')),
+              child: Text(AppLocalizations.of(context).accept)),
         ],
       ),
     );
@@ -225,17 +234,17 @@ class _LoginScreenState extends State<LoginScreen> {
     return showDialog<bool>(
       context: context,
       builder: (_) => AlertDialog(
-        title: const Text('No hay perfil'),
-        content: const Text(
-            'No hay un perfil asociado a tu cuenta de Google. ¿Crear una nueva cuenta?'),
+        title: Text(AppLocalizations.of(context).googleNoProfileTitle),
+        content:
+            Text(AppLocalizations.of(context).googleNoProfileMessage),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
-            child: const Text('Cancelar'),
+            child: Text(AppLocalizations.of(context).cancel),
           ),
           TextButton(
             onPressed: () => Navigator.pop(context, true),
-            child: const Text('Aceptar'),
+            child: Text(AppLocalizations.of(context).accept),
           ),
         ],
       ),
@@ -246,12 +255,12 @@ class _LoginScreenState extends State<LoginScreen> {
     showDialog(
       context: context,
       builder: (_) => AlertDialog(
-        title: const Text('Error de inicio de sesión'),
+        title: Text(AppLocalizations.of(context).loginErrorTitle),
         content: Text(msg),
         actions: [
           TextButton(
               onPressed: () => Navigator.pop(context),
-              child: const Text('Aceptar')),
+              child: Text(AppLocalizations.of(context).accept)),
         ],
       ),
     );
@@ -261,12 +270,12 @@ class _LoginScreenState extends State<LoginScreen> {
     showDialog(
       context: context,
       builder: (_) => AlertDialog(
-        title: const Text('Atención'),
+        title: Text(AppLocalizations.of(context).attention),
         content: Text(msg),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context),
-            child: const Text('OK'),
+            child: Text(AppLocalizations.of(context).ok),
           ),
         ],
       ),
@@ -320,21 +329,25 @@ class _LoginScreenState extends State<LoginScreen> {
             SizedBox(
                 height: 150, child: Image.asset('assets/plan-sin-fondo.png')),
             const SizedBox(height: 30),
-            Text('Inicio de sesión',
+            Text(AppLocalizations.of(context).loginTitle,
                 style: GoogleFonts.roboto(
                     fontSize: 28, fontWeight: FontWeight.bold)),
             const SizedBox(height: 20),
             _googleButton(),
             const SizedBox(height: 10),
-            Text('- o -', style: GoogleFonts.roboto(fontSize: 18)),
+            Text(AppLocalizations.of(context).orSeparator,
+                style: GoogleFonts.roboto(fontSize: 18)),
             const SizedBox(height: 10),
             _inputField(
               controller: emailController,
-              hint: 'Correo electrónico',
+              hint: AppLocalizations.of(context).emailLabel,
               keyboardType: TextInputType.emailAddress,
             ),
             const SizedBox(height: 20),
-            _inputField(controller: passwordController, hint: 'Contraseña', obscure: true),
+            _inputField(
+                controller: passwordController,
+                hint: AppLocalizations.of(context).password,
+                obscure: true),
             const SizedBox(height: 10),
             _rememberCheckbox(),
             const SizedBox(height: 20),
@@ -349,8 +362,8 @@ class _LoginScreenState extends State<LoginScreen> {
                       borderRadius: BorderRadius.circular(30)),
                   elevation: 10,
                 ),
-                child: const Text(
-                  'Iniciar sesión',
+                child: Text(
+                  AppLocalizations.of(context).login,
                   style: TextStyle(
                       fontSize: 20, color: Colors.white), // ← color blanco
                 ),
@@ -362,8 +375,8 @@ class _LoginScreenState extends State<LoginScreen> {
                   context,
                   MaterialPageRoute(
                       builder: (_) => const RecoverPasswordScreen())),
-              child: const Text('¿Olvidaste tu contraseña?',
-                  style: TextStyle(decoration: TextDecoration.underline)),
+              child: Text(AppLocalizations.of(context).forgotPassword,
+                  style: const TextStyle(decoration: TextDecoration.underline)),
             ),
             const SizedBox(height: 10),
             GestureDetector(
@@ -371,9 +384,9 @@ class _LoginScreenState extends State<LoginScreen> {
                 context,
                 MaterialPageRoute(builder: (_) => const RegisterScreen()),
               ),
-              child: const Text(
-                '¿No tienes una cuenta? Regístrate.',
-                style: TextStyle(decoration: TextDecoration.underline),
+              child: Text(
+                AppLocalizations.of(context).noAccountRegister,
+                style: const TextStyle(decoration: TextDecoration.underline),
               ),
             ),
             const SizedBox(height: 40),
@@ -390,7 +403,7 @@ class _LoginScreenState extends State<LoginScreen> {
       child: ElevatedButton.icon(
         onPressed: _loginWithGoogle,
         icon: Image.asset('assets/google_logo.png', height: 24, width: 24),
-        label: Text('Continuar con Google',
+        label: Text(AppLocalizations.of(context).continueGoogle,
             style: GoogleFonts.roboto(fontSize: 18, color: Colors.white)),
         style: ElevatedButton.styleFrom(
           padding: const EdgeInsets.symmetric(vertical: 16),
@@ -456,8 +469,8 @@ class _LoginScreenState extends State<LoginScreen> {
             side: const BorderSide(color: AppColors.planColor),
           ),
           const SizedBox(width: 8),
-          const Expanded(
-            child: Text('Recordar datos de inicio de sesión'),
+          Expanded(
+            child: Text(AppLocalizations.of(context).rememberLoginData),
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- use AppLocalizations en LoginScreen para todos los textos
- añadir nuevas claves de traducción en `app_localizations.dart` para español e inglés

## Testing
- `flutter test` *(falla: comando no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_6870290411188332bec375dabc1e6710