### PR TITLE
Actualizar textos de welcome_screen con traducciones

### DIFF
--- a/app_src/lib/l10n/app_localizations.dart
+++ b/app_src/lib/l10n/app_localizations.dart
@@ -251,6 +251,11 @@ class AppLocalizations {
       'choose_photo_source': 'Elige desde dónde obtener la foto',
       'camera': 'Cámara',
       'gallery': 'Galería',
+      'welcome_slogan':
+          '¡PLAN es la plataforma social donde los intereses comunes se fusionan!',
+      'welcome_question': '¿Y tú? ¿Qué PLAN propones?',
+      'login': 'Iniciar sesión',
+      'register': 'Registrarse',
       'no_results': 'Sin resultados',
     },
     'en': {
@@ -499,6 +504,11 @@ class AppLocalizations {
       'choose_photo_source': 'Choose where to get the photo',
       'camera': 'Camera',
       'gallery': 'Gallery',
+      'welcome_slogan':
+          'PLAN is the social platform where common interests come together!',
+      'welcome_question': "What about you? What's your PLAN?",
+      'login': 'Log in',
+      'register': 'Register',
       'no_results': 'No results',
     },
   };
@@ -730,6 +740,10 @@ class AppLocalizations {
   String get privateProfileMemories => _t('private_profile_memories');
   String get planAndMemories => _t('plan_and_memories');
   String get noMemoriesDay => _t('no_memories_day');
+  String get welcomeSlogan => _t('welcome_slogan');
+  String get welcomeQuestion => _t('welcome_question');
+  String get login => _t('login');
+  String get register => _t('register');
 
   String get reportUserTitle => _t('report_user_title');
   String get selectReportReasons => _t('select_report_reasons');

--- a/app_src/lib/start/welcome_screen.dart
+++ b/app_src/lib/start/welcome_screen.dart
@@ -13,6 +13,7 @@ import 'registration/verification_provider.dart';
 import 'registration/email_verification_screen.dart';
 import '../../explore_screen/users_managing/presence_service.dart';
 import '../services/location_update_service.dart';
+import '../l10n/app_localizations.dart';
 
 class WelcomeScreen extends StatefulWidget {
   const WelcomeScreen({Key? key}) : super(key: key);
@@ -174,6 +175,8 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
       );
     }
 
+    final t = AppLocalizations.of(context);
+
     return Scaffold(
       body: Stack(
         children: [
@@ -200,7 +203,7 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
                     child: Column(
                       children: [
                         Text(
-                          '¡PLAN es la plataforma social donde los intereses comunes se fusionan!',
+                          t.welcomeSlogan,
                           style: GoogleFonts.roboto(
                             fontSize: 18,
                             color: Colors.white,
@@ -210,7 +213,7 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
                         ),
                         const SizedBox(height: 10),
                         Text(
-                          '¿Y tú? ¿Qué PLAN propones?',
+                          t.welcomeQuestion,
                           style: GoogleFonts.roboto(
                             fontSize: 20,
                             color: Colors.white,
@@ -243,7 +246,7 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
                         elevation: 10,
                       ),
                       child: Text(
-                        'Iniciar sesión',
+                        t.login,
                         style: GoogleFonts.roboto(
                           fontSize: 20,
                           color: Colors.white,
@@ -276,7 +279,7 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
                         ),
                       ),
                       child: Text(
-                        'Registrarse',
+                        t.register,
                         style: GoogleFonts.roboto(
                           fontSize: 20,
                           color: const Color.fromARGB(236, 0, 4, 227),


### PR DESCRIPTION
## Resumen
- agregadas claves de traducción `welcome_slogan`, `welcome_question`, `login` y `register`
- reemplazados los textos incrustados en `welcome_screen.dart` por llamadas a `AppLocalizations`

## Testing
- `flutter analyze` *(falló: comando no encontrado)*
- `dart format` *(falló: comando no encontrado)*


------
https://chatgpt.com/codex/tasks/task_e_68702904ad3c8332b762c7c3deabb684