### PR TITLE
Localiza textos de registro

### DIFF
--- a/app_src/lib/l10n/app_localizations.dart
+++ b/app_src/lib/l10n/app_localizations.dart
@@ -252,6 +252,29 @@ class AppLocalizations {
       'camera': 'Cámara',
       'gallery': 'Galería',
       'no_results': 'Sin resultados',
+      'create_account': 'Crea tu cuenta',
+      'continue_with_google': 'Continuar con Google',
+      'email_hint': 'Correo electrónico',
+      'uppercase': 'Mayúscula',
+      'number': 'Número',
+      'repeat_password': 'Repetir contraseña',
+      'by_continuing_prefix': 'Al continuar, confirmo que he leído y acepto los ',
+      'comma_the': ', la ',
+      'and_cookies': ' y de ',
+      'terms_and_conditions': 'Términos y Condiciones',
+      'privacy_policy': 'Política de Privacidad',
+      'cookies': 'Cookies',
+      'register': 'Registrarse',
+      'already_have_account': '¿Ya tienes una cuenta? Inicia sesión',
+      'password_mismatch': 'Las contraseñas no coinciden',
+      'email_already_registered':
+          'Este correo ya está registrado. Inicia sesión para continuar.',
+      'incorrect_password': 'Contraseña incorrecta.',
+      'registration_error': 'Error al iniciar registro:',
+      'introduce_your': 'Introduce tu',
+      'then_press_register': 'y después pulsa en "Registrarse".',
+      'and_word': ' y ',
+      'email_word': 'correo',
     },
     'en': {
       'settings': 'Settings',
@@ -500,6 +523,29 @@ class AppLocalizations {
       'camera': 'Camera',
       'gallery': 'Gallery',
       'no_results': 'No results',
+      'create_account': 'Create your account',
+      'continue_with_google': 'Continue with Google',
+      'email_hint': 'Email',
+      'uppercase': 'Uppercase',
+      'number': 'Number',
+      'repeat_password': 'Repeat password',
+      'by_continuing_prefix': 'By continuing, I confirm that I have read and accept the ',
+      'comma_the': ', the ',
+      'and_cookies': ' and ',
+      'terms_and_conditions': 'Terms and Conditions',
+      'privacy_policy': 'Privacy Policy',
+      'cookies': 'Cookies',
+      'register': 'Register',
+      'already_have_account': 'Already have an account? Sign in',
+      'password_mismatch': 'Passwords do not match',
+      'email_already_registered':
+          'This email is already registered. Log in to continue.',
+      'incorrect_password': 'Incorrect password.',
+      'registration_error': 'Error starting registration:',
+      'introduce_your': 'Enter your',
+      'then_press_register': 'and then press "Register".',
+      'and_word': ' and ',
+      'email_word': 'email',
     },
   };
 
@@ -721,6 +767,28 @@ class AppLocalizations {
   String get choosePhotoSource => _t('choose_photo_source');
   String get camera => _t('camera');
   String get gallery => _t('gallery');
+  String get createAccount => _t('create_account');
+  String get continueWithGoogle => _t('continue_with_google');
+  String get emailHint => _t('email_hint');
+  String get uppercase => _t('uppercase');
+  String get number => _t('number');
+  String get repeatPassword => _t('repeat_password');
+  String get byContinuingPrefix => _t('by_continuing_prefix');
+  String get commaThe => _t('comma_the');
+  String get andCookies => _t('and_cookies');
+  String get termsAndConditions => _t('terms_and_conditions');
+  String get privacyPolicy => _t('privacy_policy');
+  String get cookies => _t('cookies');
+  String get register => _t('register');
+  String get alreadyHaveAccount => _t('already_have_account');
+  String get passwordMismatch => _t('password_mismatch');
+  String get emailAlreadyRegistered => _t('email_already_registered');
+  String get incorrectPassword => _t('incorrect_password');
+  String get registrationError => _t('registration_error');
+  String get introduceYour => _t('introduce_your');
+  String get thenPressRegister => _t('then_press_register');
+  String get andWord => _t('and_word');
+  String get emailWord => _t('email_word');
   String get noResults => _t('no_results');
   String get sendMessage => _t('send_message');
   String get follow => _t('follow');

--- a/app_src/lib/start/registration/register_screen.dart
+++ b/app_src/lib/start/registration/register_screen.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:dating_app/main/colors.dart';
+import '../../l10n/app_localizations.dart';
 import 'register_with_google.dart';
 import 'verification_provider.dart';
 import 'email_verification_screen.dart';
@@ -54,12 +55,13 @@ class _RegisterScreenState extends State<RegisterScreen> {
   }
 
   void _showPopup(String message) {
+    final t = AppLocalizations.of(context);
     showDialog(
       context: context,
       builder: (_) => AlertDialog(
-        title: const Text(
-          'Atención',
-          style: TextStyle(color: AppColors.blue),
+        title: Text(
+          t.attention,
+          style: const TextStyle(color: AppColors.blue),
         ),
         content: Text(
           message,
@@ -68,9 +70,9 @@ class _RegisterScreenState extends State<RegisterScreen> {
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context),
-            child: const Text(
-              'OK',
-              style: TextStyle(color: AppColors.blue),
+            child: Text(
+              t.ok,
+              style: const TextStyle(color: AppColors.blue),
             ),
           ),
         ],
@@ -117,11 +119,12 @@ class _RegisterScreenState extends State<RegisterScreen> {
   Future<void> _register() async {
     if (emailController.text.trim().isEmpty ||
         passwordController.text.trim().isEmpty) {
+      final t = AppLocalizations.of(context);
       final missing = <String>[];
-      if (emailController.text.trim().isEmpty) missing.add('correo');
-      if (passwordController.text.trim().isEmpty) missing.add('contraseña');
+      if (emailController.text.trim().isEmpty) missing.add(t.emailWord);
+      if (passwordController.text.trim().isEmpty) missing.add(t.password);
       final msg =
-          'Introduce tu ${missing.join(' y ')} y después pulsa en "Registrarse".';
+          '${t.introduceYour} ${missing.join(t.andWord)} ${t.thenPressRegister}';
       _showPopup(msg);
       return;
     }
@@ -182,24 +185,23 @@ class _RegisterScreenState extends State<RegisterScreen> {
           await FirebaseAuth.instance.signOut();
           LocationUpdateService.dispose();
           ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text(
-                  'Este correo ya está registrado. Inicia sesión para continuar.'),
+            SnackBar(
+              content: Text(t.emailAlreadyRegistered),
             ),
           );
         } on FirebaseAuthException {
           ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Contraseña incorrecta.')),
+            SnackBar(content: Text(t.incorrectPassword)),
           );
         }
       } else {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Error al iniciar registro: ${e.message}')),
+          SnackBar(content: Text('${t.registrationError} ${e.message}')),
         );
       }
     } catch (e) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Error al iniciar registro: $e')),
+        SnackBar(content: Text('${t.registrationError} $e')),
       );
     } finally {
       setState(() => isLoading = false);
@@ -209,6 +211,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context);
     const Color backgroundColor = AppColors.background;
 
     return WillPopScope(
@@ -237,7 +240,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
 
                     // Título
                     Text(
-                      'Crea tu cuenta',
+                      t.createAccount,
                       style: GoogleFonts.roboto(
                         fontSize: 28,
                         fontWeight: FontWeight.bold,
@@ -265,7 +268,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                           width: 24,
                         ),
                         label: Text(
-                          'Continuar con Google',
+                          t.continueWithGoogle,
                           style: GoogleFonts.roboto(
                             fontSize: 18,
                             color: Colors.white,
@@ -287,7 +290,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
 
                     // Separador
                     Text(
-                      '- o -',
+                      t.orSeparator,
                       style: GoogleFonts.roboto(
                         fontSize: 18,
                         color: Colors.black,
@@ -313,7 +316,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                         controller: emailController,
                         keyboardType: TextInputType.emailAddress,
                         decoration: InputDecoration(
-                          hintText: 'Correo electrónico',
+                          hintText: t.emailHint,
                           hintStyle: GoogleFonts.roboto(
                             fontSize: 16,
                             color: Colors.grey,
@@ -346,7 +349,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                         controller: passwordController,
                         obscureText: !_showPassword,
                         decoration: InputDecoration(
-                          hintText: 'Contraseña',
+                          hintText: t.password,
                           hintStyle: GoogleFonts.roboto(
                             fontSize: 16,
                             color: Colors.grey,
@@ -375,12 +378,12 @@ class _RegisterScreenState extends State<RegisterScreen> {
                         children: [
                           _buildRequirement(
                             ok: _hasUppercase,
-                            text: 'Mayúscula',
+                            text: t.uppercase,
                           ),
                           const SizedBox(width: 8),
                           _buildRequirement(
                             ok: _hasNumber,
-                            text: 'Número',
+                            text: t.number,
                           ),
                         ],
                       ),
@@ -405,7 +408,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                         controller: confirmController,
                         obscureText: !_showConfirm,
                         decoration: InputDecoration(
-                          hintText: 'Repetir contraseña',
+                          hintText: t.repeatPassword,
                           hintStyle: GoogleFonts.roboto(
                             fontSize: 16,
                             color: Colors.grey,
@@ -439,11 +442,9 @@ class _RegisterScreenState extends State<RegisterScreen> {
                             decoration: TextDecoration.none,
                           ),
                           children: [
-                            const TextSpan(
-                                text:
-                                    'Al continuar, confirmo que he leído y acepto los '),
+                            TextSpan(text: t.byContinuingPrefix),
                             TextSpan(
-                              text: 'Términos y Condiciones',
+                              text: t.termsAndConditions,
                               style: const TextStyle(color: Colors.blue),
                               recognizer: TapGestureRecognizer()
                                 ..onTap = () => launchUrl(
@@ -452,9 +453,9 @@ class _RegisterScreenState extends State<RegisterScreen> {
                                       mode: LaunchMode.externalApplication,
                                     ),
                             ),
-                            const TextSpan(text: ', la '),
+                            TextSpan(text: t.commaThe),
                             TextSpan(
-                              text: 'Política de Privacidad',
+                              text: t.privacyPolicy,
                               style: const TextStyle(color: Colors.blue),
                               recognizer: TapGestureRecognizer()
                                 ..onTap = () => launchUrl(
@@ -463,9 +464,9 @@ class _RegisterScreenState extends State<RegisterScreen> {
                                       mode: LaunchMode.externalApplication,
                                     ),
                             ),
-                            const TextSpan(text: ' y de '),
+                            TextSpan(text: t.andCookies),
                             TextSpan(
-                              text: 'Cookies',
+                              text: t.cookies,
                               style: const TextStyle(color: Colors.blue),
                               recognizer: TapGestureRecognizer()
                                 ..onTap = () => launchUrl(
@@ -490,7 +491,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                             ? null
                             : () {
                                 if (!_match) {
-                                  _showPopup('Las contraseñas no coinciden');
+                                  _showPopup(t.passwordMismatch);
                                 } else {
                                   _register();
                                 }
@@ -506,7 +507,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                           elevation: 10,
                         ),
                         child: Text(
-                          'Registrarse',
+                          t.register,
                           style: GoogleFonts.roboto(
                             fontSize: 20,
                             color: Colors.white,
@@ -525,9 +526,9 @@ class _RegisterScreenState extends State<RegisterScreen> {
                           ),
                         );
                       },
-                      child: const Text(
-                        '¿Ya tienes una cuenta? Inicia sesión',
-                        style: TextStyle(
+                      child: Text(
+                        t.alreadyHaveAccount,
+                        style: const TextStyle(
                           color: Colors.black,
                           decoration: TextDecoration.underline,
                         ),


### PR DESCRIPTION
## Resumen
- traducir la pantalla de registro a AppLocalizations
- agregar nuevas cadenas en ambos idiomas

## Testing
- `flutter` y `dart` no están disponibles en el entorno, por lo que no se pudieron ejecutar verificaciones automáticas

------
https://chatgpt.com/codex/tasks/task_e_687029072c208332a5fc668d2d7b5a76