### PR TITLE
Manejo de idioma por defecto

### DIFF
--- a/app_src/lib/services/language_service.dart
+++ b/app_src/lib/services/language_service.dart
@@ -7,7 +7,14 @@ class LanguageService {
 
   static Future<void> loadLocale() async {
     final prefs = await SharedPreferences.getInstance();
-    final code = prefs.getString('languageCode') ?? 'es';
+    String code;
+    if (prefs.containsKey('languageCode')) {
+      code = prefs.getString('languageCode') ?? 'es';
+    } else {
+      final systemCode =
+          WidgetsBinding.instance.platformDispatcher.locale.languageCode;
+      code = systemCode.startsWith('es') ? 'es' : 'en';
+    }
     locale.value = Locale(code);
   }
 


### PR DESCRIPTION
## Resumen
- detectar si existe la clave de idioma en `SharedPreferences`
- usar el idioma del sistema cuando no haya preferencia guardada

## Testing
- `dart --version` *(falla: comando no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_68702907452c8332a6aee6b8b01d7ef3