### PR TITLE
Fix memory screen English translations

### DIFF
--- a/app_src/lib/explore_screen/profile/plan_memories_screen.dart
+++ b/app_src/lib/explore_screen/profile/plan_memories_screen.dart
@@ -274,7 +274,7 @@ class _PlanMemoriesScreenState extends State<PlanMemoriesScreen> {
           borderRadius: BorderRadius.circular(24),
         ),
         icon: const Icon(Icons.camera_alt),
-        label: const Text("Añadir"),
+        label: Text(t.add),
       ),
       body: SingleChildScrollView(
         controller: _scrollController,
@@ -366,12 +366,13 @@ class _PlanMemoriesScreenState extends State<PlanMemoriesScreen> {
 
   /// Cuadrícula de imágenes (sin selección múltiple)
   Widget _buildMemoriesGrid() {
+    final t = AppLocalizations.of(context);
     if (_memories.isEmpty) {
-      return const Padding(
-        padding: EdgeInsets.all(16.0),
+      return Padding(
+        padding: const EdgeInsets.all(16.0),
         child: Text(
-          "Añade fotos para rememorar este plan.",
-          style: TextStyle(color: Colors.black54),
+          t.addPhotosToRememberPlan,
+          style: const TextStyle(color: Colors.black54),
           textAlign: TextAlign.center,
         ),
       );

--- a/app_src/lib/l10n/app_localizations.dart
+++ b/app_src/lib/l10n/app_localizations.dart
@@ -198,6 +198,9 @@ class AppLocalizations {
           'Este perfil es privado. Debes seguirle y ser aceptado para ver sus memorias.',
       'plan_and_memories': 'Plan y Memorias',
       'no_memories_day': 'No hay memorias para este día.',
+      'add_photos_to_remember_plan':
+          'Añade fotos para rememorar este plan.',
+      'add': 'Añadir',
       'plan_id_label': 'ID del Plan',
       'age_restriction_label': 'Restricción de edad',
       'ends_at_label': 'Finaliza',
@@ -470,6 +473,9 @@ class AppLocalizations {
           'This profile is private. You must follow and be accepted to view their memories.',
       'plan_and_memories': 'Plan and Memories',
       'no_memories_day': 'No memories for this day.',
+      'add_photos_to_remember_plan':
+          'Add photos to remember this plan.',
+      'add': 'Add',
       'plan_id_label': 'Plan ID',
       'age_restriction_label': 'Age restriction',
       'ends_at_label': 'Ends',
@@ -796,6 +802,8 @@ class AppLocalizations {
   String get privateProfileMemories => _t('private_profile_memories');
   String get planAndMemories => _t('plan_and_memories');
   String get noMemoriesDay => _t('no_memories_day');
+  String get addPhotosToRememberPlan => _t('add_photos_to_remember_plan');
+  String get add => _t('add');
   String get welcomeSlogan => _t('welcome_slogan');
   String get welcomeQuestion => _t('welcome_question');
   String get login => _t('login');


### PR DESCRIPTION
## Summary
- add English translations for memory placeholders
- localize memory screen floating button
- localize empty memories helper text

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68710be288e883329434e46b06618fe9