### PR TITLE
Mostrar insignias y última conexión

### DIFF
--- a/app_src/lib/explore_screen/follow/following_screen.dart
+++ b/app_src/lib/explore_screen/follow/following_screen.dart
@@ -7,6 +7,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import '../../models/plan_model.dart';
 import '../plans_managing/frosted_plan_dialog_state.dart' as new_frosted;
 import '../users_managing/user_info_check.dart';
+import '../users_managing/user_activity_status.dart';
 import '../../main/colors.dart';
 import '../../l10n/app_localizations.dart';
 
@@ -157,9 +158,7 @@ class _FollowingScreenState extends State<FollowingScreen> {
           _UserItem(
             uid: relatedUid,
             name: data['name'] ?? 'Usuario',
-            age: (data['age']?.toString() ?? '').isNotEmpty
-                ? data['age'].toString()
-                : null,
+            privilegeLevel: (data['privilegeLevel'] ?? 'Básico').toString(),
             photoUrl: data['photoUrl'] ?? '',
             upcomingPlanId: planInfo?.id,
             upcomingPlanName: planInfo?.name,
@@ -280,8 +279,18 @@ class _FollowingScreenState extends State<FollowingScreen> {
                                 ? u.photoUrl
                                 : 'https://via.placeholder.com/150'),
                           ),
-                          title: Text(u.name),
-                          subtitle: u.age != null ? Text('${u.age} años') : null,
+                          title: Row(
+                            children: [
+                              Expanded(child: Text(u.name)),
+                              const SizedBox(width: 4),
+                              Image.asset(
+                                _getPrivilegeIcon(u.privilegeLevel),
+                                width: 14,
+                                height: 14,
+                              ),
+                            ],
+                          ),
+                          subtitle: UserActivityStatus(userId: u.uid),
                           trailing: u.upcomingPlanId != null
                               ? InkWell(
                                   onTap: () => _onPlanTap(u.upcomingPlanId!),
@@ -357,8 +366,8 @@ class _FollowingScreenState extends State<FollowingScreen> {
         res.add({
           'uid': uid,
           'name': d['name'] ?? 'Usuario',
-          'age': d['age']?.toString() ?? '',
           'photoUrl': d['photoUrl'] ?? '',
+          'privilegeLevel': (d['privilegeLevel'] ?? 'Básico').toString(),
           'isCreator': uid == plan.createdBy,
         });
       }
@@ -413,7 +422,7 @@ class _ThinDivider extends StatelessWidget {
 class _UserItem {
   final String uid;
   final String name;
-  final String? age;
+  final String privilegeLevel;
   final String photoUrl;
   final String? upcomingPlanId;
   final String? upcomingPlanName;
@@ -422,7 +431,7 @@ class _UserItem {
   _UserItem({
     required this.uid,
     required this.name,
-    required this.age,
+    required this.privilegeLevel,
     required this.photoUrl,
     this.upcomingPlanId,
     this.upcomingPlanName,
@@ -436,4 +445,18 @@ class _PlanInfo {
   final int additional;
 
   _PlanInfo({required this.id, required this.name, required this.additional});
+}
+
+String _getPrivilegeIcon(String level) {
+  final normalized = level.toLowerCase().replaceAll('á', 'a');
+  switch (normalized) {
+    case 'premium':
+      return 'assets/icono-usuario-premium.png';
+    case 'golden':
+      return 'assets/icono-usuario-golden.png';
+    case 'vip':
+      return 'assets/icono-usuario-vip.png';
+    default:
+      return 'assets/icono-usuario-basico.png';
+  }
 }

--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -13,6 +13,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 
 import '../../models/plan_model.dart';
 import '../users_managing/user_info_check.dart';
+import '../users_managing/user_activity_status.dart';
 import 'attendance_managing.dart';
 import '../../main/colors.dart';
 import '../profile/profile_screen.dart';
@@ -1018,14 +1019,11 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
     if (count == 1) {
       final p = filtered[0];
       final pic = p['photoUrl'] ?? '';
-      String name = p['name'] ?? 'Usuario';
-      final age = p['age']?.toString() ?? '';
+      final name = p['name'] ?? 'Usuario';
+      final uid = p['uid']?.toString() ?? '';
+      final level = p['privilegeLevel']?.toString() ?? 'Básico';
 
-      String displayText = '$name, $age';
-      if (displayText.length > 10) {
-        final cut = math.min(displayText.length, 14);
-        displayText = '${displayText.substring(0, cut)}...';
-      }
+      String displayText = _truncate(name, 14);
 
       return GestureDetector(
         onTap: () async {
@@ -1047,12 +1045,29 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                 backgroundColor: Colors.blueGrey[400],
               ),
               const SizedBox(width: 8),
-              Flexible(
-                child: Text(
-                  displayText,
-                  style: const TextStyle(color: Colors.white),
-                  overflow: TextOverflow.ellipsis,
-                ),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Flexible(
+                        child: Text(
+                          displayText,
+                          style: const TextStyle(color: Colors.white),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      const SizedBox(width: 4),
+                      Image.asset(
+                        _getPrivilegeIcon(level),
+                        width: 14,
+                        height: 14,
+                      ),
+                    ],
+                  ),
+                  if (uid.isNotEmpty) UserActivityStatus(userId: uid),
+                ],
               ),
             ],
           ),
@@ -1201,8 +1216,8 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                       final p = participants[i];
                       final pic = p['photoUrl'] ?? '';
                       final name = p['name'] ?? 'Usuario';
-                      final age = p['age']?.toString() ?? '';
                       final uid = p['uid']?.toString() ?? '';
+                      final level = p['privilegeLevel']?.toString() ?? 'Básico';
                       final bool isCheckedIn = checkedInUsers.contains(uid);
 
                       final tile = ListTile(
@@ -1216,13 +1231,28 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                               pic.isNotEmpty ? NetworkImage(pic) : null,
                           backgroundColor: Colors.blueGrey[400],
                         ),
-                        title: Text(
-                          '$name, $age',
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontWeight: FontWeight.bold,
-                          ),
+                        title: Row(
+                          children: [
+                            Expanded(
+                              child: Text(
+                                name,
+                                style: const TextStyle(
+                                  color: Colors.white,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                            const SizedBox(width: 4),
+                            Image.asset(
+                              _getPrivilegeIcon(level),
+                              width: 14,
+                              height: 14,
+                            ),
+                          ],
                         ),
+                        subtitle:
+                            uid.isNotEmpty ? UserActivityStatus(userId: uid) : null,
                         trailing: (widget.plan.special_plan != 1 && isCheckedIn)
                             ? Container(
                                 padding: const EdgeInsets.symmetric(
@@ -1492,7 +1522,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
             child: GestureDetector(
               onTap: _openCreator,
               child: Text(
-                age.isNotEmpty ? '$name, $age' : name,
+                name,
                 style: const TextStyle(
                   color: Colors.white,
                   fontWeight: FontWeight.bold,
@@ -2086,7 +2116,7 @@ class _CustomShareDialogContentState extends State<_CustomShareDialogContent> {
               backgroundImage: (photo.isNotEmpty) ? NetworkImage(photo) : null,
             ),
             title: Text(
-              "$name, $age",
+              name,
               style: const TextStyle(color: Colors.white),
             ),
             trailing: GestureDetector(
@@ -2117,6 +2147,25 @@ class _CustomShareDialogContentState extends State<_CustomShareDialogContent> {
       }).toList(),
     );
   }
+}
+
+String _getPrivilegeIcon(String level) {
+  final normalized = level.toLowerCase().replaceAll('á', 'a');
+  switch (normalized) {
+    case 'premium':
+      return 'assets/icono-usuario-premium.png';
+    case 'golden':
+      return 'assets/icono-usuario-golden.png';
+    case 'vip':
+      return 'assets/icono-usuario-vip.png';
+    default:
+      return 'assets/icono-usuario-basico.png';
+  }
+}
+
+String _truncate(String text, int maxChars) {
+  if (text.length <= maxChars) return text;
+  return text.substring(0, math.min(maxChars, text.length)) + '…';
 }
 
 class FullScreenGalleryPage extends StatefulWidget {

--- a/app_src/lib/explore_screen/plans_managing/plan_card.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_card.dart
@@ -704,12 +704,12 @@ class PlanCardState extends State<PlanCard> {
     if (count == 1) {
       final p = participants[0];
       final pic = p['photoUrl'] ?? '';
-      String name = p['name'] ?? 'Usuario';
-      final age = p['age']?.toString() ?? '';
+      final name = p['name'] ?? 'Usuario';
+      final uid = p['uid']?.toString() ?? '';
+      final level = p['privilegeLevel']?.toString() ?? 'Básico';
 
       const int maxChars = 14;
-      String displayText = '$name, $age';
-      displayText = _truncate(displayText, maxChars);
+      final truncated = _truncate(name, maxChars);
 
       return GestureDetector(
         onTap: () => _showParticipantsModal(participants),
@@ -728,12 +728,29 @@ class PlanCardState extends State<PlanCard> {
                 backgroundColor: Colors.blueGrey[400],
               ),
               const SizedBox(width: 8),
-              Flexible(
-                child: Text(
-                  displayText,
-                  style: const TextStyle(color: Colors.white),
-                  overflow: TextOverflow.ellipsis,
-                ),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Flexible(
+                        child: Text(
+                          truncated,
+                          style: const TextStyle(color: Colors.white),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      const SizedBox(width: 4),
+                      Image.asset(
+                        _getPrivilegeIcon(level),
+                        width: 14,
+                        height: 14,
+                      ),
+                    ],
+                  ),
+                  if (uid.isNotEmpty) UserActivityStatus(userId: uid),
+                ],
               ),
             ],
           ),
@@ -892,7 +909,6 @@ class PlanCardState extends State<PlanCard> {
                       final p = participants[i];
                       final pic = p['photoUrl'] ?? '';
                       final name = p['name'] ?? 'Usuario';
-                      final age = p['age']?.toString() ?? '';
                       final uid = p['uid']?.toString() ?? '';
 
                       final bool isCheckedIn = checkedInUsers.contains(uid);
@@ -908,13 +924,30 @@ class PlanCardState extends State<PlanCard> {
                               pic.isNotEmpty ? NetworkImage(pic) : null,
                           backgroundColor: Colors.blueGrey[400],
                         ),
-                        title: Text(
-                          '$name, $age',
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontWeight: FontWeight.bold,
-                          ),
+                        title: Row(
+                          children: [
+                            Expanded(
+                              child: Text(
+                                name,
+                                style: const TextStyle(
+                                  color: Colors.white,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                            const SizedBox(width: 4),
+                            Image.asset(
+                              _getPrivilegeIcon(
+                                  p['privilegeLevel']?.toString() ?? 'Básico'),
+                              width: 14,
+                              height: 14,
+                            ),
+                          ],
                         ),
+                        subtitle: uid.isNotEmpty
+                            ? UserActivityStatus(userId: uid)
+                            : null,
                         trailing: (widget.plan.special_plan != 1 && isCheckedIn)
                             ? Container(
                                 padding: const EdgeInsets.symmetric(

--- a/app_src/lib/explore_screen/profile/profile_screen.dart
+++ b/app_src/lib/explore_screen/profile/profile_screen.dart
@@ -129,8 +129,8 @@ class ProfileScreenState extends State<ProfileScreen> {
         participants.add({
           'uid': uid,
           'name': uData['name'] ?? 'Sin nombre',
-          'age': uData['age']?.toString() ?? '',
           'photoUrl': uData['photoUrl'] ?? uData['profilePic'] ?? '',
+          'privilegeLevel': (uData['privilegeLevel'] ?? 'Básico').toString(),
           'isCreator': (p.createdBy == uid),
         });
       }

--- a/app_src/lib/explore_screen/users_managing/user_info_check.dart
+++ b/app_src/lib/explore_screen/users_managing/user_info_check.dart
@@ -1179,8 +1179,8 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
         res.add({
           'uid': uid,
           'name': d['name'] ?? 'Usuario',
-          'age': d['age']?.toString() ?? '',
           'photoUrl': d['photoUrl'] ?? '',
+          'privilegeLevel': (d['privilegeLevel'] ?? 'Básico').toString(),
           'isCreator': uid == plan.createdBy,
         });
       }


### PR DESCRIPTION
## Resumen
- se agregan insignias y estado de conexión en la lista de seguidores/seguidos
- se muestra insignia y estado de conexión en participantes de planes
- se eliminan referencias a la edad en estas listas

## Testing
- `npm --version`
- `dart --version` *(falló: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68710cd2cd708332ae51d0632e06de56