### PR TITLE
Fix profile image actions and translations

### DIFF
--- a/app_src/lib/explore_screen/profile/profile_screen.dart
+++ b/app_src/lib/explore_screen/profile/profile_screen.dart
@@ -112,6 +112,24 @@ class ProfileScreenState extends State<ProfileScreen> {
     }
   }
 
+  void _handleAvatarTap() {
+    final hasPhoto = profileImageUrl != null && profileImageUrl!.isNotEmpty;
+    if (hasPhoto) {
+      UserImagesManaging.openProfileImageFullScreen(
+        context,
+        profileImageUrl!,
+        onProfileDeleted: () => setState(() => profileImageUrl = ''),
+        onProfileChanged: (newUrl) => setState(() => profileImageUrl = newUrl),
+      );
+    } else {
+      UserImagesManaging.changeProfileImage(
+        context,
+        onProfileUpdated: (newUrl) => setState(() => profileImageUrl = newUrl),
+        onLoading: (val) => setState(() => _isLoading = val),
+      );
+    }
+  }
+
   // ---------------------- PLANES ----------------------
 
   Future<List<Map<String, dynamic>>> _fetchParticipants(PlanModel p) async {
@@ -263,14 +281,7 @@ class ProfileScreenState extends State<ProfileScreen> {
                 clipBehavior: Clip.none,
                 children: [
                   InkWell(
-                    onTap: () => UserImagesManaging.openProfileImageFullScreen(
-                      context,
-                      profileImageUrl ?? '',
-                      onProfileDeleted: () =>
-                          setState(() => profileImageUrl = ''),
-                      onProfileChanged: (newUrl) =>
-                          setState(() => profileImageUrl = newUrl),
-                    ),
+                    onTap: _handleAvatarTap,
                     customBorder: const CircleBorder(),
                     child: CircleAvatar(
                       radius: 45,
@@ -311,13 +322,7 @@ class ProfileScreenState extends State<ProfileScreen> {
             clipBehavior: Clip.none,
             children: [
               InkWell(
-                onTap: () => UserImagesManaging.openProfileImageFullScreen(
-                  context,
-                  profileImageUrl ?? '',
-                  onProfileDeleted: () => setState(() => profileImageUrl = ''),
-                  onProfileChanged: (newUrl) =>
-                      setState(() => profileImageUrl = newUrl),
-                ),
+                onTap: _handleAvatarTap,
                 customBorder: const CircleBorder(),
                 child: CircleAvatar(
                   radius: 45,

--- a/app_src/lib/explore_screen/profile/user_images_managing.dart
+++ b/app_src/lib/explore_screen/profile/user_images_managing.dart
@@ -190,7 +190,7 @@ class UserImagesManaging {
         builder: (_) => _FullScreenImagePage(
           initialIndex: 0,
           images: [imageUrl],
-          titleAppBar: "Tu foto de perfil",
+          titleAppBar: AppLocalizations.of(context).yourProfilePhoto,
           isProfile: true,
           onProfileDeleted: onProfileDeleted,
           onProfileChanged: onProfileChanged,
@@ -698,7 +698,7 @@ class _FullScreenImagePageState extends State<_FullScreenImagePage> {
               ListTile(
                 leading: SvgPicture.asset('assets/usuario.svg',
                     width: 24, height: 24),
-                title: const Text('Cambiar imagen de perfil'),
+                title: Text(AppLocalizations.of(context).changeProfileImage),
                 onTap: () async {
                   Navigator.pop(ctx);
                   await UserImagesManaging.changeProfileImage(
@@ -715,7 +715,7 @@ class _FullScreenImagePageState extends State<_FullScreenImagePage> {
               ListTile(
                 leading: SvgPicture.asset('assets/icono-eliminar.svg',
                     width: 24, height: 24),
-                title: const Text('Eliminar imagen de perfil'),
+                title: Text(AppLocalizations.of(context).deleteProfileImage),
                 onTap: () async {
                   Navigator.pop(ctx);
                   await _deleteCurrentImage();
@@ -739,7 +739,7 @@ class _FullScreenImagePageState extends State<_FullScreenImagePage> {
               ListTile(
                 leading: SvgPicture.asset('assets/icono-fondo.svg',
                     width: 24, height: 24),
-                title: const Text('Establecer como imagen de fondo'),
+                title: Text(AppLocalizations.of(context).setAsBackground),
                 onTap: () async {
                   Navigator.pop(ctx);
                   await _setAsCoverBackground();
@@ -749,7 +749,7 @@ class _FullScreenImagePageState extends State<_FullScreenImagePage> {
               ListTile(
                 leading: SvgPicture.asset('assets/usuario.svg',
                     width: 24, height: 24),
-                title: const Text('Establecer como imagen de perfil'),
+                title: Text(AppLocalizations.of(context).setAsProfileImage),
                 onTap: () async {
                   Navigator.pop(ctx);
                   await _setAsProfile();
@@ -759,7 +759,7 @@ class _FullScreenImagePageState extends State<_FullScreenImagePage> {
               ListTile(
                 leading: SvgPicture.asset('assets/icono-eliminar.svg',
                     width: 24, height: 24),
-                title: const Text('Eliminar'),
+                title: Text(AppLocalizations.of(context).delete),
                 onTap: () async {
                   Navigator.pop(ctx);
                   await _deleteCurrentImage();
@@ -783,7 +783,7 @@ class _FullScreenImagePageState extends State<_FullScreenImagePage> {
               ListTile(
                 leading: SvgPicture.asset('assets/usuario.svg',
                     width: 24, height: 24),
-                title: const Text('Establecer como foto de perfil'),
+                title: Text(AppLocalizations.of(context).setAsProfilePhoto),
                 onTap: () async {
                   Navigator.pop(ctx);
                   await _setAsProfile();
@@ -793,7 +793,7 @@ class _FullScreenImagePageState extends State<_FullScreenImagePage> {
               ListTile(
                 leading: SvgPicture.asset('assets/icono-eliminar.svg',
                     width: 24, height: 24),
-                title: const Text('Eliminar'),
+                title: Text(AppLocalizations.of(context).delete),
                 onTap: () async {
                   Navigator.pop(ctx);
                   await _deleteCurrentImage();

--- a/app_src/lib/l10n/app_localizations.dart
+++ b/app_src/lib/l10n/app_localizations.dart
@@ -258,6 +258,13 @@ class AppLocalizations {
       'choose_photo_source': 'Elige desde dónde obtener la foto',
       'camera': 'Cámara',
       'gallery': 'Galería',
+      'your_profile_photo': 'Tu foto de perfil',
+      'change_profile_image': 'Cambiar imagen de perfil',
+      'delete_profile_image': 'Eliminar imagen de perfil',
+      'set_as_background': 'Establecer como imagen de fondo',
+      'set_as_profile_image': 'Establecer como imagen de perfil',
+      'set_as_profile_photo': 'Establecer como foto de perfil',
+      'delete': 'Eliminar',
       'welcome_slogan':
           '¡PLAN es la plataforma social donde los intereses comunes se fusionan!',
       'welcome_question': '¿Y tú? ¿Qué PLAN propones?',
@@ -536,6 +543,13 @@ class AppLocalizations {
       'choose_photo_source': 'Choose where to get the photo',
       'camera': 'Camera',
       'gallery': 'Gallery',
+      'your_profile_photo': 'Your profile photo',
+      'change_profile_image': 'Change profile image',
+      'delete_profile_image': 'Delete profile image',
+      'set_as_background': 'Set as background image',
+      'set_as_profile_image': 'Set as profile image',
+      'set_as_profile_photo': 'Set as profile photo',
+      'delete': 'Delete',
       'welcome_slogan':
           'PLAN is the social platform where common interests come together!',
       'welcome_question': "What about you? What's your PLAN?",
@@ -784,6 +798,13 @@ class AppLocalizations {
   String get choosePhotoSource => _t('choose_photo_source');
   String get camera => _t('camera');
   String get gallery => _t('gallery');
+  String get yourProfilePhoto => _t('your_profile_photo');
+  String get changeProfileImage => _t('change_profile_image');
+  String get deleteProfileImage => _t('delete_profile_image');
+  String get setAsBackground => _t('set_as_background');
+  String get setAsProfileImage => _t('set_as_profile_image');
+  String get setAsProfilePhoto => _t('set_as_profile_photo');
+  String get delete => _t('delete');
   String get noResults => _t('no_results');
   String get loginTitle => _t('login_title');
   String get login => _t('login');

--- a/app_src/lib/start/registration/user_registration_screen.dart
+++ b/app_src/lib/start/registration/user_registration_screen.dart
@@ -695,7 +695,7 @@ class _UserRegistrationScreenState extends State<UserRegistrationScreen> {
         ),
         const SizedBox(height: 5),
         Text(
-          "Tu foto de perfil",
+          AppLocalizations.of(context).yourProfilePhoto,
           style: TextStyle(
             color: MyColors.AppColors.black,
             fontSize: 16,


### PR DESCRIPTION
## Summary
- add translation strings for profile image actions
- use translations in user image dialogs and registration screen
- open image upload menu when avatar has no photo
- translate profile image screen title

## Testing
- `dart format lib/l10n/app_localizations.dart lib/start/registration/user_registration_screen.dart lib/explore_screen/profile/user_images_managing.dart lib/explore_screen/profile/profile_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687116e294848332a3cddf3e6c608f5a