### PR TITLE
Fix translation and popup dismiss

### DIFF
--- a/app_src/lib/explore_screen/profile/user_images_managing.dart
+++ b/app_src/lib/explore_screen/profile/user_images_managing.dart
@@ -190,7 +190,7 @@ class UserImagesManaging {
         builder: (_) => _FullScreenImagePage(
           initialIndex: 0,
           images: [imageUrl],
-          titleAppBar: "Tu foto de perfil",
+          titleAppBar: AppLocalizations.of(context).yourProfilePhoto,
           isProfile: true,
           onProfileDeleted: onProfileDeleted,
           onProfileChanged: onProfileChanged,
@@ -353,7 +353,7 @@ class UserImagesManaging {
         builder: (_) => _FullScreenImagePage(
           initialIndex: initialIndex,
           images: coverImages,
-          titleAppBar: "Tu colección de fotos",
+          titleAppBar: AppLocalizations.of(context).photoCollection,
           isProfile: false,
           onCoverImagesUpdated: onImagesUpdated,
           onProfileChanged: onProfileUpdated,
@@ -505,7 +505,7 @@ class UserImagesManaging {
         builder: (_) => _FullScreenImagePage(
           images: photos,
           initialIndex: initialIndex,
-          titleAppBar: "Tu colección de fotos",
+          titleAppBar: AppLocalizations.of(context).photoCollection,
           isAdditional: true,
           onAdditionalUpdated: onNewList,
           onProfileChanged: onProfileUpdated,
@@ -698,7 +698,7 @@ class _FullScreenImagePageState extends State<_FullScreenImagePage> {
               ListTile(
                 leading: SvgPicture.asset('assets/usuario.svg',
                     width: 24, height: 24),
-                title: const Text('Cambiar imagen de perfil'),
+                title: Text(AppLocalizations.of(context).changeProfileImage),
                 onTap: () async {
                   Navigator.pop(ctx);
                   await UserImagesManaging.changeProfileImage(
@@ -715,7 +715,7 @@ class _FullScreenImagePageState extends State<_FullScreenImagePage> {
               ListTile(
                 leading: SvgPicture.asset('assets/icono-eliminar.svg',
                     width: 24, height: 24),
-                title: const Text('Eliminar imagen de perfil'),
+                title: Text(AppLocalizations.of(context).deleteProfileImage),
                 onTap: () async {
                   Navigator.pop(ctx);
                   await _deleteCurrentImage();
@@ -739,7 +739,8 @@ class _FullScreenImagePageState extends State<_FullScreenImagePage> {
               ListTile(
                 leading: SvgPicture.asset('assets/icono-fondo.svg',
                     width: 24, height: 24),
-                title: const Text('Establecer como imagen de fondo'),
+                title:
+                    Text(AppLocalizations.of(context).setAsBackgroundImage),
                 onTap: () async {
                   Navigator.pop(ctx);
                   await _setAsCoverBackground();
@@ -749,7 +750,7 @@ class _FullScreenImagePageState extends State<_FullScreenImagePage> {
               ListTile(
                 leading: SvgPicture.asset('assets/usuario.svg',
                     width: 24, height: 24),
-                title: const Text('Establecer como imagen de perfil'),
+                title: Text(AppLocalizations.of(context).setAsProfileImage),
                 onTap: () async {
                   Navigator.pop(ctx);
                   await _setAsProfile();
@@ -759,7 +760,7 @@ class _FullScreenImagePageState extends State<_FullScreenImagePage> {
               ListTile(
                 leading: SvgPicture.asset('assets/icono-eliminar.svg',
                     width: 24, height: 24),
-                title: const Text('Eliminar'),
+                title: Text(AppLocalizations.of(context).deleteGeneric),
                 onTap: () async {
                   Navigator.pop(ctx);
                   await _deleteCurrentImage();
@@ -783,7 +784,7 @@ class _FullScreenImagePageState extends State<_FullScreenImagePage> {
               ListTile(
                 leading: SvgPicture.asset('assets/usuario.svg',
                     width: 24, height: 24),
-                title: const Text('Establecer como foto de perfil'),
+                title: Text(AppLocalizations.of(context).setAsProfileImage),
                 onTap: () async {
                   Navigator.pop(ctx);
                   await _setAsProfile();
@@ -793,7 +794,7 @@ class _FullScreenImagePageState extends State<_FullScreenImagePage> {
               ListTile(
                 leading: SvgPicture.asset('assets/icono-eliminar.svg',
                     width: 24, height: 24),
-                title: const Text('Eliminar'),
+                title: Text(AppLocalizations.of(context).deleteGeneric),
                 onTap: () async {
                   Navigator.pop(ctx);
                   await _deleteCurrentImage();
@@ -895,34 +896,42 @@ class _FrostedPopup extends StatelessWidget {
     return Dialog(
       backgroundColor: Colors.transparent,
       insetPadding: EdgeInsets.zero,
-      child: Stack(
-        alignment: Alignment.center,
-        children: [
-          // Fondo borroso
-          BackdropFilter(
-            filter: ImageFilter.blur(sigmaX: 6, sigmaY: 6),
-            child: Container(color: Colors.black54),
-          ),
-          // Cuadro de opciones
-          Positioned(
-            top: MediaQuery.of(context).size.height * 0.4,
-            left: 24, //  <--  nuevo: margen izquierdo
-            right: 24, //  <--  nuevo: margen derecho
-            child: Material(
-              color: Colors.white,
-              borderRadius: BorderRadius.circular(12),
-              child: ConstrainedBox(
-                // da un ancho máximo cómodo
-                constraints: const BoxConstraints(maxWidth: 360),
-                child: Padding(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                  child: child,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => Navigator.of(context).pop(),
+        child: Stack(
+          alignment: Alignment.center,
+          children: [
+            // Fondo borroso
+            Positioned.fill(
+              child: BackdropFilter(
+                filter: ImageFilter.blur(sigmaX: 6, sigmaY: 6),
+                child: Container(color: Colors.black54),
+              ),
+            ),
+            // Cuadro de opciones
+            Positioned(
+              top: MediaQuery.of(context).size.height * 0.4,
+              left: 24,
+              right: 24,
+              child: GestureDetector(
+                onTap: () {},
+                child: Material(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(12),
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 360),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 16, vertical: 8),
+                      child: child,
+                    ),
+                  ),
                 ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/app_src/lib/l10n/app_localizations.dart
+++ b/app_src/lib/l10n/app_localizations.dart
@@ -96,6 +96,13 @@ class AppLocalizations {
       'pick_from_gallery': 'Seleccionar de la galería',
       'take_photo': 'Hacer una foto',
       'only_one_image': 'Solo se permite subir una imagen.',
+      'photo_collection': 'Tu colección de fotos',
+      'your_profile_photo': 'Tu foto de perfil',
+      'change_profile_image': 'Cambiar imagen de perfil',
+      'delete_profile_image': 'Eliminar imagen de perfil',
+      'set_as_background_image': 'Establecer como imagen de fondo',
+      'set_as_profile_image': 'Establecer como imagen de perfil',
+      'delete_generic': 'Eliminar',
       'attention': 'Atención',
       'ok': 'OK',
       'meeting_point': 'Punto de encuentro para el Plan',
@@ -374,6 +381,13 @@ class AppLocalizations {
       'pick_from_gallery': 'Select from gallery',
       'take_photo': 'Take a photo',
       'only_one_image': 'Only one image is allowed.',
+      'photo_collection': 'Your photo collection',
+      'your_profile_photo': 'Your profile photo',
+      'change_profile_image': 'Change profile image',
+      'delete_profile_image': 'Delete profile image',
+      'set_as_background_image': 'Set as background image',
+      'set_as_profile_image': 'Set as profile image',
+      'delete_generic': 'Delete',
       'attention': 'Attention',
       'ok': 'OK',
       'meeting_point': 'Meeting point for the Plan',
@@ -657,6 +671,13 @@ class AppLocalizations {
   String get pickFromGallery => _t('pick_from_gallery');
   String get takePhoto => _t('take_photo');
   String get onlyOneImage => _t('only_one_image');
+  String get photoCollection => _t('photo_collection');
+  String get yourProfilePhoto => _t('your_profile_photo');
+  String get changeProfileImage => _t('change_profile_image');
+  String get deleteProfileImage => _t('delete_profile_image');
+  String get setAsBackgroundImage => _t('set_as_background_image');
+  String get setAsProfileImage => _t('set_as_profile_image');
+  String get deleteGeneric => _t('delete_generic');
   String get attention => _t('attention');
   String get ok => _t('ok');
   String get meetingPoint => _t('meeting_point');


### PR DESCRIPTION
## Summary
- localize text in image dialogs
- add translations for English and Spanish
- allow tapping outside popups to close them

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(not run due to missing flutter)*

------
https://chatgpt.com/codex/tasks/task_e_687117911d4483328c8f9f53e0653ea5