### PR TITLE
Add custom domain image sharing

### DIFF
--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -7,7 +7,10 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'dart:io';
 import 'package:share_plus/share_plus.dart';
+import 'package:http/http.dart' as http;
+import 'package:path_provider/path_provider.dart';
 import '../../l10n/app_localizations.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 
@@ -595,13 +598,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                     padding:
                         const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
                     child: ElevatedButton.icon(
-                      onPressed: () {
-                        final shareUrl =
-                            'https://plansocialapp.es/plan?planId=${plan.id}';
-                        final shareText =
-                            '¡Mira este plan!\n\nTítulo: ${plan.type}\nDescripción: ${plan.description}\n$shareUrl';
-                        Share.share(shareText);
-                      },
+                      onPressed: () => _sharePlanWithImage(plan),
                       icon: const Icon(Icons.share, color: Colors.white),
                       label: Text(
                         t.shareWithOtherApps,
@@ -628,6 +625,35 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
         );
       },
     );
+  }
+
+  //--------------------------------------------------------------------------
+  // Comparte el plan junto con su imagen
+  //--------------------------------------------------------------------------
+  Future<void> _sharePlanWithImage(PlanModel plan) async {
+    final shareUrl = 'https://plansocialapp.es/plan?planId=${plan.id}';
+    final shareText =
+        '¡Mira este plan!\n\nTítulo: ${plan.type}\nDescripción: ${plan.description}\n$shareUrl';
+
+    final imageUrl = plan.backgroundImage ??
+        ((plan.images != null && plan.images!.isNotEmpty)
+            ? plan.images!.first
+            : null);
+
+    if (imageUrl != null && imageUrl.isNotEmpty) {
+      try {
+        final response = await http.get(Uri.parse(imageUrl));
+        final tempDir = await getTemporaryDirectory();
+        final file = File('${tempDir.path}/plan_share.jpg');
+        await file.writeAsBytes(response.bodyBytes);
+        await Share.shareXFiles([XFile(file.path)], text: shareText);
+        return;
+      } catch (_) {
+        // Si la descarga falla, se comparte solo el texto
+      }
+    }
+
+    await Share.share(shareText);
   }
 
   Widget _buildActionButtonsRow(PlanModel plan) {
@@ -1968,7 +1994,7 @@ class _CustomShareDialogContentState extends State<_CustomShareDialogContent> {
     }
 
     final shareUrl =
-        'https://plan-social-app.web.app/plan?planId=${widget.plan.id}';
+        'https://plansocialapp.es/plan?planId=${widget.plan.id}';
     final planId = widget.plan.id;
     final planTitle = widget.plan.type;
     final planDesc = widget.plan.description;

--- a/app_src/pubspec.yaml
+++ b/app_src/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
   permission_handler: ^10.2.0
   image_cropper: ^9.0.0
   http: ^1.3.0
+  path_provider: ^2.1.5
   intl: ^0.19.0
   share_plus: ^10.1.4
   video_player: ^2.5.5


### PR DESCRIPTION
## Summary
- share plans with `plan_share.jpg` temp file
- share plan images directly from the share sheet and dialog
- include custom domain `https://plansocialapp.es` in shared links
- add `path_provider` dependency

## Testing
- `flutter pub get` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687113a8daa483328b70c26bac408b2a