### PR TITLE
Enable custom scheme deep links

### DIFF
--- a/app_src/android/app/src/main/AndroidManifest.xml
+++ b/app_src/android/app/src/main/AndroidManifest.xml
@@ -46,6 +46,12 @@
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <data android:scheme="https" android:host="plansocialapp.es" android:pathPrefix="/plan"/>
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="plansocialapp" android:pathPrefix="/plan"/>
+            </intent-filter>
         </activity>
 
         <!-- uCrop -->

--- a/app_src/ios/Runner/Info.plist
+++ b/app_src/ios/Runner/Info.plist
@@ -45,7 +45,16 @@
 		<true/>
 		<key>UIApplicationSupportsIndirectInputEvents</key>
 		<true/>
-		<key>UIStatusBarHidden</key>
-		<false/>
-	</dict>
+                <key>UIStatusBarHidden</key>
+                <false/>
+                <key>CFBundleURLTypes</key>
+                <array>
+                        <dict>
+                                <key>CFBundleURLSchemes</key>
+                                <array>
+                                        <string>plansocialapp</string>
+                                </array>
+                        </dict>
+                </array>
+        </dict>
 </plist>

--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -125,6 +125,10 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
     } catch (e) {}
   }
 
+  String _buildAppLink(String planId) {
+    return 'plansocialapp:/plan?planId=$planId';
+  }
+
   Future<void> _checkIfLiked() async {
     final user = FirebaseAuth.instance.currentUser;
     if (user == null) return;
@@ -631,9 +635,10 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
   // Comparte el plan junto con su imagen
   //--------------------------------------------------------------------------
   Future<void> _sharePlanWithImage(PlanModel plan) async {
-    final shareUrl = 'https://plansocialapp.es/plan?planId=${plan.id}';
+    final shareUrl = _buildAppLink(plan.id);
+    final webLink = 'https://plansocialapp.es/plan?planId=${plan.id}';
     final shareText =
-        '$shareUrl\n\n¡Mira este plan!\nTítulo: ${plan.type}\nDescripción: ${plan.description}';
+        '$shareUrl\n$webLink\n\n¡Mira este plan!\nTítulo: ${plan.type}\nDescripción: ${plan.description}';
 
     final imageUrl = plan.backgroundImage ??
         ((plan.images != null && plan.images!.isNotEmpty)
@@ -1993,8 +1998,7 @@ class _CustomShareDialogContentState extends State<_CustomShareDialogContent> {
       return;
     }
 
-    final shareUrl =
-        'https://plansocialapp.es/plan?planId=${widget.plan.id}';
+    final shareUrl = _buildAppLink(widget.plan.id);
     final planId = widget.plan.id;
     final planTitle = widget.plan.type;
     final planDesc = widget.plan.description;

--- a/app_src/lib/explore_screen/plans_managing/plan_share_sheet.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_share_sheet.dart
@@ -93,15 +93,20 @@ class PlanShareSheetState extends State<PlanShareSheet> {
     return usersData;
   }
 
+
+  String _buildAppLink(String planId) {
+    return 'plansocialapp:/plan?planId=$planId';
+  }
+
   @override
   Widget build(BuildContext context) {
     final t = AppLocalizations.of(context);
     final String planTitle = widget.plan.type;
     final String planDesc = widget.plan.description;
-    final String shareUrl =
-        'https://plansocialapp.es/plan?planId=${widget.plan.id}';
+    final String appLink = _buildAppLink(widget.plan.id);
+    final String webLink = 'https://plansocialapp.es/plan?planId=${widget.plan.id}';
     final String shareText =
-        '¡Mira este plan!\nTítulo: $planTitle\nDescripción: $planDesc \n\n$shareUrl';
+        '¡Mira este plan!\nTítulo: $planTitle\nDescripción: $planDesc\n\n$appLink\n$webLink';
 
     return Container(
       decoration: BoxDecoration(
@@ -321,10 +326,10 @@ class PlanShareSheetState extends State<PlanShareSheet> {
   Future<void> _sharePlanWithImage() async {
     final String planTitle = widget.plan.type;
     final String planDesc = widget.plan.description;
-    final String shareUrl =
-        'https://plansocialapp.es/plan?planId=${widget.plan.id}';
+    final String appLink = _buildAppLink(widget.plan.id);
+    final String webLink = 'https://plansocialapp.es/plan?planId=${widget.plan.id}';
     final String shareText =
-        '¡Mira este plan!\nTítulo: $planTitle\nDescripción: $planDesc \n\n$shareUrl';
+        '¡Mira este plan!\nTítulo: $planTitle\nDescripción: $planDesc\n\n$appLink\n$webLink';
 
     final imageUrl = widget.plan.backgroundImage ??
         ((widget.plan.images != null && widget.plan.images!.isNotEmpty)
@@ -356,8 +361,7 @@ class PlanShareSheetState extends State<PlanShareSheet> {
       return;
     }
 
-    final String shareUrl =
-        'https://plansocialapp.es/plan?planId=${widget.plan.id}';
+    final String shareUrl = _buildAppLink(widget.plan.id);
     final String planId = widget.plan.id;
     final String planTitle = widget.plan.type;
     final String planDesc = widget.plan.description;

--- a/app_src/lib/main.dart
+++ b/app_src/lib/main.dart
@@ -169,8 +169,13 @@ class _MyAppState extends State<MyApp> {
     }, onError: (_) {});
   }
 
+
   Future<void> _handleUri(Uri uri) async {
-    if (uri.path == '/plan') {
+    final bool isPlanLink =
+        (uri.scheme == 'https' && uri.host == 'plansocialapp.es' && uri.path == '/plan') ||
+        (uri.scheme == 'plansocialapp' && uri.path == '/plan');
+
+    if (isPlanLink) {
       final planId = uri.queryParameters['planId'];
       if (planId != null && planId.isNotEmpty) {
         final user = FirebaseAuth.instance.currentUser;


### PR DESCRIPTION
## Summary
- implement app-specific deep links instead of Firebase Dynamic Links
- share links include custom scheme `plansocialapp:/plan?planId=<id>` along with website fallback
- handle new scheme in main app navigation
- configure Android and iOS for the `plansocialapp` scheme

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68713a87cc68833285fcfe463264fff0