### PR TITLE
Fix missing helper

### DIFF
--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -125,9 +125,6 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
     } catch (e) {}
   }
 
-  String _buildAppLink(String planId) {
-    return 'plansocialapp:/plan?planId=$planId';
-  }
 
   Future<void> _checkIfLiked() async {
     final user = FirebaseAuth.instance.currentUser;
@@ -2186,6 +2183,10 @@ class _CustomShareDialogContentState extends State<_CustomShareDialogContent> {
       }).toList(),
     );
   }
+}
+
+String _buildAppLink(String planId) {
+  return 'plansocialapp:/plan?planId=$planId';
 }
 
 String _getPrivilegeIcon(String level) {


### PR DESCRIPTION
## Summary
- resolve undefined method `_buildAppLink`
- add `_buildAppLink` as a file-level helper in `frosted_plan_dialog_state.dart`

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871499cc41483328ae50faef52fafb0