### PR TITLE
Fix participant count excluding creator

### DIFF
--- a/app_src/lib/explore_screen/plans_managing/plan_card.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_card.dart
@@ -1190,7 +1190,8 @@ class PlanCardState extends State<PlanCard> {
           );
         }
         _participants = snap.data ?? [];
-        final totalP = _participants.length;
+        // Contamos solo los participantes reales (sin incluir al creador)
+        final totalP = widget.plan.participants?.length ?? 0;
         final maxP = plan.maxParticipants ?? 0;
         final bool isFull = (maxP > 0 && totalP >= maxP);
 


### PR DESCRIPTION
## Summary
- avoid counting the creator when displaying plan participant counts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687534499e8083328422500890dfc27f