### PR TITLE
Implement private plan calendar restriction

### DIFF
--- a/app_src/lib/explore_screen/profile/memories_calendar.dart
+++ b/app_src/lib/explore_screen/profile/memories_calendar.dart
@@ -7,6 +7,7 @@ import '../../l10n/app_localizations.dart';
 import '../../services/language_service.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import '../../main/colors.dart';
 import '../../models/plan_model.dart';
 import 'plan_memories_screen.dart'; // Asegúrate de importar tu pantalla de memorias
@@ -123,6 +124,7 @@ class _MemoriesCalendarState extends State<MemoriesCalendar> {
       visibility: original.visibility,
       iconAsset: original.iconAsset,
       participants: original.participants,
+      invitedUsers: original.invitedUsers,
       likes: original.likes,
       special_plan: original.special_plan,
       images: original.images,
@@ -171,6 +173,15 @@ class _MemoriesCalendarState extends State<MemoriesCalendar> {
     } else {
       // Tomamos el primer plan de ese día (o podrías mostrar lista)
       final PlanModel plan = dayPlans.first;
+
+      final currentUid = FirebaseAuth.instance.currentUser?.uid;
+      final bool isCreator = plan.createdBy == currentUid;
+      final bool isInvited = plan.invitedUsers?.contains(currentUid) ?? false;
+
+      // Si es un plan privado y no eres creador ni invitado, no abrimos nada
+      if (plan.special_plan == 1 && !(isCreator || isInvited)) {
+        return;
+      }
 
       // En lugar de callback o popup => abrimos la nueva pantalla:
       Navigator.push(


### PR DESCRIPTION
## Summary
- restrict viewing private plans in `MemoriesCalendar`
- copy `invitedUsers` when duplicating `PlanModel`
- add Firebase Auth import for access control

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_687535cb2ef08332b65f8e5ba1ef40fd