### PR TITLE
Fix GeoFlutterFire import in map screen

### DIFF
--- a/app_src/lib/explore_screen/map/plans_in_map_screen.dart
+++ b/app_src/lib/explore_screen/map/plans_in_map_screen.dart
@@ -3,7 +3,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:http/http.dart' as http;
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:geoflutterfire_plus/geoflutterfire_plus.dart';
+import 'package:geoflutterfire_plus/geoflutterfire_plus.dart' as geofire;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 import '../../main/colors.dart';
@@ -215,7 +215,7 @@ class PlansInMapScreen {
     double radiusKm = 5,
     Map<String, dynamic>? filters,
   }) async {
-    final geo = GeoFlutterFire();
+    final geo = geofire.GeoFlutterFire();
     final centerPoint =
         geo.point(latitude: center.latitude, longitude: center.longitude);
     final docs = await geo


### PR DESCRIPTION
## Summary
- alias `geofire` for geoflutterfire_plus import
- use `geofire.GeoFlutterFire()` when loading users on map

## Testing
- `dart format app_src/lib/explore_screen/map/plans_in_map_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68756cded1b483329c379c6547acc9b1