### PR TITLE
Fix GeoFirePoint constructor usage

### DIFF
--- a/app_src/lib/explore_screen/map/plans_in_map_screen.dart
+++ b/app_src/lib/explore_screen/map/plans_in_map_screen.dart
@@ -212,7 +212,9 @@ class PlansInMapScreen {
     Map<String, dynamic>? filters,
   }) async {
     // 1) Punto central
-    final centerPoint = GeoFirePoint(center.latitude, center.longitude);
+    final centerPoint = GeoFirePoint(
+      GeoPoint(center.latitude, center.longitude),
+    );
 
     // 2) Colección geoespacial
     final geoCol = GeoCollectionReference<Map<String, dynamic>>(


### PR DESCRIPTION
## Summary
- adjust GeoFirePoint initialization to use GeoPoint object

## Testing
- `apt-get update` *(fails: repository signatures forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6875759b0df88332be783752e1d7ff4b