### PR TITLE
Fix locations read rule and update service

### DIFF
--- a/app_src/lib/services/location_update_service.dart
+++ b/app_src/lib/services/location_update_service.dart
@@ -57,11 +57,17 @@ class LocationUpdateService with WidgetsBindingObserver {
     final geoPoint =
         GeoFirePoint(GeoPoint(position.latitude, position.longitude));
 
+    // Obtener la foto de perfil del usuario para almacenarla junto a la ubicación
+    final uDoc =
+        await FirebaseFirestore.instance.collection('users').doc(_uid).get();
+    final photoUrl = (uDoc.data() as Map<String, dynamic>?)?['photoUrl'];
+
     await _locRef.doc(_uid).set({
       'position': geoPoint.data,
       'accuracy': position.accuracy,
       'updatedAt': FieldValue.serverTimestamp(),
       'expireAt': DateTime.now().add(const Duration(hours: 8)),
+      if (photoUrl != null) 'photoUrl': photoUrl,
     });
 
     await FirebaseFirestore.instance.doc('users/$_uid').update({

--- a/firestore.rules
+++ b/firestore.rules
@@ -69,8 +69,11 @@ service cloud.firestore {
         && request.auth.uid == resource.data.blockerId;
     }
 
-		match /locations/{uid} {
-      allow read, write: if request.auth != null && request.auth.uid == uid;
+        match /locations/{uid} {
+      // Los usuarios autenticados pueden leer las ubicaciones de los demás
+      allow read: if request.auth != null && request.auth.uid != uid;
+      // Solo el propietario del documento puede escribir en su ubicación
+      allow write: if request.auth != null && request.auth.uid == uid;
     }
 
     function isPlanCreator(planId) {


### PR DESCRIPTION
## Summary
- ensure users can only read others' locations
- store profile photo URL when saving user location

## Testing
- `git status --short`
- `flutter analyze` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68757b777c2483329a0b151d18a8283c