### PR TITLE
Implement image caching

### DIFF
--- a/app_src/lib/explore_screen/chats/chat_screen.dart
+++ b/app_src/lib/explore_screen/chats/chat_screen.dart
@@ -18,6 +18,8 @@ import '../profile/user_images_managing.dart';
 import '../../l10n/app_localizations.dart';
 
 import '../../main/colors.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import '../users_grid/users_grid_helpers.dart';
 import '../../models/plan_model.dart';
 import '../plans_managing/frosted_plan_dialog_state.dart';
 import '../users_managing/user_info_check.dart';
@@ -332,7 +334,7 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
                         CircleAvatar(
                           radius: 16,
                           backgroundImage: widget.chatPartnerPhoto != null
-                              ? NetworkImage(widget.chatPartnerPhoto!)
+                              ? CachedNetworkImageProvider(widget.chatPartnerPhoto!)
                               : null,
                           backgroundColor: Colors.grey[300],
                         ),
@@ -1171,7 +1173,7 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
                   ),
                   image: planImage.isNotEmpty
                       ? DecorationImage(
-                          image: NetworkImage(planImage),
+                          image: CachedNetworkImageProvider(planImage),
                           fit: BoxFit.cover,
                         )
                       : null,
@@ -1277,7 +1279,7 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
     final Completer<Size> completer = Completer();
 
     final ImageStream imageStream =
-        NetworkImage(imageUrl).resolve(const ImageConfiguration());
+        CachedNetworkImageProvider(imageUrl).resolve(const ImageConfiguration());
     late ImageStreamListener listener;
 
     listener = ImageStreamListener((ImageInfo info, bool _) {
@@ -1383,9 +1385,12 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
                     child: SizedBox(
                       width: displayWidth,
                       height: displayHeight,
-                      child: Image.network(
-                        imageUrl,
+                      child: CachedNetworkImage(
+                        imageUrl: imageUrl,
                         fit: BoxFit.fill,
+                        placeholder: (_, __) =>
+                            const Center(child: CircularProgressIndicator()),
+                        errorWidget: (_, __, ___) => const Icon(Icons.error),
                       ),
                     ),
                   ),

--- a/app_src/lib/explore_screen/chats/chats_screen.dart
+++ b/app_src/lib/explore_screen/chats/chats_screen.dart
@@ -7,6 +7,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../l10n/app_localizations.dart';
 import '../users_managing/user_activity_status.dart';
 import 'chat_screen.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 
 class ChatsScreen extends StatefulWidget {
   final String? sharedText;
@@ -349,7 +350,7 @@ class _ChatsScreenState extends State<ChatsScreen> {
                       child: ListTile(
                         leading: CircleAvatar(
                           backgroundImage: (userPhoto.isNotEmpty)
-                              ? NetworkImage(userPhoto)
+                              ? CachedNetworkImageProvider(userPhoto)
                               : null,
                           backgroundColor: Colors.grey[300],
                         ),
@@ -611,7 +612,7 @@ class _ChatsScreenState extends State<ChatsScreen> {
         return ListTile(
           leading: CircleAvatar(
             backgroundImage:
-                (photoUrl.isNotEmpty) ? NetworkImage(photoUrl) : null,
+                (photoUrl.isNotEmpty) ? CachedNetworkImageProvider(photoUrl) : null,
             backgroundColor: Colors.grey[300],
           ),
           title: Row(
@@ -709,7 +710,7 @@ class _ChatsScreenState extends State<ChatsScreen> {
                   return ListTile(
                     leading: CircleAvatar(
                       backgroundImage: (followerPhoto.isNotEmpty)
-                          ? NetworkImage(followerPhoto)
+                          ? CachedNetworkImageProvider(followerPhoto)
                           : null,
                       backgroundColor: Colors.grey[300],
                     ),
@@ -813,7 +814,7 @@ class _ChatsScreenState extends State<ChatsScreen> {
                   return ListTile(
                     leading: CircleAvatar(
                       backgroundImage: (followingPhoto.isNotEmpty)
-                          ? NetworkImage(followingPhoto)
+                          ? CachedNetworkImageProvider(followingPhoto)
                           : null,
                       backgroundColor: Colors.grey[300],
                     ),

--- a/app_src/lib/explore_screen/chats/inner_chat_utils/picture_managing.dart
+++ b/app_src/lib/explore_screen/chats/inner_chat_utils/picture_managing.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:screen_protector/screen_protector.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 
 /// Función para navegar a la vista de la imagen completa.
 void openFullImage(BuildContext context, String imageUrl) {
@@ -102,7 +103,12 @@ class _FullImageViewerScreenState extends State<FullImageViewerScreen> {
             child: GestureDetector(
               onTap: () => Navigator.pop(context), // Cierra al hacer tap
               child: InteractiveViewer(
-                child: Image.network(widget.imageUrl),
+                child: CachedNetworkImage(
+                  imageUrl: widget.imageUrl,
+                  placeholder: (_, __) =>
+                      const Center(child: CircularProgressIndicator()),
+                  errorWidget: (_, __, ___) => const Icon(Icons.error),
+                ),
               ),
             ),
           ),

--- a/app_src/lib/explore_screen/follow/following_screen.dart
+++ b/app_src/lib/explore_screen/follow/following_screen.dart
@@ -10,6 +10,7 @@ import '../users_managing/user_info_check.dart';
 import '../users_managing/user_activity_status.dart';
 import '../../main/colors.dart';
 import '../../l10n/app_localizations.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 
 /// Pantalla de seguidores/seguidos.
 /// Se muestra como un modal a pantalla casi completa (deja libre el 10 % superior)
@@ -275,9 +276,10 @@ class _FollowingScreenState extends State<FollowingScreen> {
                         final u = _filtered[idx];
                         return ListTile(
                           leading: CircleAvatar(
-                            backgroundImage: NetworkImage(u.photoUrl.isNotEmpty
-                                ? u.photoUrl
-                                : 'https://via.placeholder.com/150'),
+                            backgroundImage: CachedNetworkImageProvider(
+                                u.photoUrl.isNotEmpty
+                                    ? u.photoUrl
+                                    : 'https://via.placeholder.com/150'),
                           ),
                           title: Row(
                             crossAxisAlignment: CrossAxisAlignment.center,

--- a/app_src/lib/explore_screen/main_screen/notification_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/notification_screen.dart
@@ -15,6 +15,7 @@ import '../plans_managing/plan_card.dart'; // <--- Asegúrate de importar tu Pla
 import '../plans_managing/firebase_services.dart'; // <--- Para fetchPlanParticipants, si lo tienes
 import '../plans_managing/frosted_plan_dialog_state.dart';
 import '../../l10n/app_localizations.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 
 class NotificationScreen extends StatefulWidget {
   final String currentUserId;
@@ -585,8 +586,8 @@ class _NotificationScreenState extends State<NotificationScreen> {
                             child: CircleAvatar(
                               radius: 25,
                               backgroundImage: senderPhoto.isNotEmpty
-                                  ? NetworkImage(senderPhoto)
-                                  : const NetworkImage(
+                                  ? CachedNetworkImageProvider(senderPhoto)
+                                  : CachedNetworkImageProvider(
                                       'https://cdn-icons-png.flaticon.com/512/847/847969.png',
                                     ),
                             ),
@@ -1028,7 +1029,7 @@ class _NotificationScreenState extends State<NotificationScreen> {
       final url = data['photoUrl'] ?? '';
       return CircleAvatar(
         radius: 20,
-        backgroundImage: url.isNotEmpty ? NetworkImage(url) : null,
+        backgroundImage: url.isNotEmpty ? CachedNetworkImageProvider(url) : null,
       );
     }
 

--- a/app_src/lib/explore_screen/main_screen/searcher.dart
+++ b/app_src/lib/explore_screen/main_screen/searcher.dart
@@ -6,6 +6,7 @@ import '../../models/plan_model.dart';
 import '../plans_managing/frosted_plan_dialog_state.dart';
 import '../users_managing/user_info_check.dart';
 import '../../main/colors.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 
 /// Representa un resultado de búsqueda (usuario o plan).
 class SearchResultItem {
@@ -309,7 +310,7 @@ class _SearcherState extends State<Searcher> {
                       leading: CircleAvatar(
                         radius: 20,
                         backgroundImage: (item.avatarUrl.isNotEmpty)
-                            ? NetworkImage(item.avatarUrl)
+                            ? CachedNetworkImageProvider(item.avatarUrl)
                             : null,
                         backgroundColor: Colors.grey[300],
                       ),

--- a/app_src/lib/explore_screen/menu_side_bar/menu_side_bar_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/menu_side_bar_screen.dart
@@ -14,6 +14,7 @@ import 'favourites_screen.dart';
 import 'settings/settings_screen.dart';
 import 'close_session_screen.dart';
 import 'subscribed_plans_screen.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 
 class MainSideBarScreen extends StatefulWidget {
   final ValueChanged<bool>? onMenuToggled;
@@ -305,7 +306,7 @@ class MainSideBarScreenState extends State<MainSideBarScreen> {
                       children: [
                         CircleAvatar(
                           radius: 50,
-                          backgroundImage: NetworkImage(profileImageUrl),
+                          backgroundImage: CachedNetworkImageProvider(profileImageUrl),
                         ),
                         const SizedBox(height: 8),
                         Text(
@@ -329,7 +330,7 @@ class MainSideBarScreenState extends State<MainSideBarScreen> {
                     children: [
                       CircleAvatar(
                         radius: 50,
-                        backgroundImage: NetworkImage(profileImageUrl),
+                        backgroundImage: CachedNetworkImageProvider(profileImageUrl),
                         backgroundColor: Colors.grey.shade200,
                         onBackgroundImageError: (_, __) => const Icon(
                           Icons.person,

--- a/app_src/lib/explore_screen/menu_side_bar/my_plans_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/my_plans_screen.dart
@@ -5,6 +5,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:intl/intl.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 
 import '../../models/plan_model.dart';
 import '../../main/colors.dart';
@@ -354,7 +355,7 @@ Widget _buildPlanTile(BuildContext context, PlanModel plan) {
       final url = data['photoUrl'] ?? '';
       return CircleAvatar(
         radius: 20,
-        backgroundImage: url.isNotEmpty ? NetworkImage(url) : null,
+        backgroundImage: url.isNotEmpty ? CachedNetworkImageProvider(url) : null,
       );
     }
 

--- a/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
@@ -5,6 +5,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 
 import '../../models/plan_model.dart';
 import '../../main/colors.dart';
@@ -209,7 +210,7 @@ class SubscribedPlansScreen extends StatelessWidget {
       final url = data['photoUrl'] ?? '';
       return CircleAvatar(
         radius: 20,
-        backgroundImage: url.isNotEmpty ? NetworkImage(url) : null,
+        backgroundImage: url.isNotEmpty ? CachedNetworkImageProvider(url) : null,
       );
     }
 

--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -879,7 +879,8 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
       },
       child: CircleAvatar(
         radius: 20,
-        backgroundImage: senderPic.isNotEmpty ? NetworkImage(senderPic) : null,
+        backgroundImage:
+            senderPic.isNotEmpty ? CachedNetworkImageProvider(senderPic) : null,
         backgroundColor: Colors.blueGrey[100],
       ),
     );
@@ -1071,7 +1072,8 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
             children: [
               CircleAvatar(
                 radius: 16,
-                backgroundImage: pic.isNotEmpty ? NetworkImage(pic) : null,
+                backgroundImage:
+                    pic.isNotEmpty ? CachedNetworkImageProvider(pic) : null,
                 backgroundColor: Colors.blueGrey[400],
               ),
               const SizedBox(width: 8),
@@ -1132,7 +1134,8 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                 left: 0,
                 child: CircleAvatar(
                   radius: avatarSize / 2,
-                  backgroundImage: pic1.isNotEmpty ? NetworkImage(pic1) : null,
+                  backgroundImage:
+                      pic1.isNotEmpty ? CachedNetworkImageProvider(pic1) : null,
                   backgroundColor: Colors.blueGrey[400],
                 ),
               ),
@@ -1140,7 +1143,8 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                 left: overlapOffset,
                 child: CircleAvatar(
                   radius: avatarSize / 2,
-                  backgroundImage: pic2.isNotEmpty ? NetworkImage(pic2) : null,
+                  backgroundImage:
+                      pic2.isNotEmpty ? CachedNetworkImageProvider(pic2) : null,
                   backgroundColor: Colors.blueGrey[400],
                 ),
               ),
@@ -1258,7 +1262,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                         leading: CircleAvatar(
                           radius: 22,
                           backgroundImage:
-                              pic.isNotEmpty ? NetworkImage(pic) : null,
+                              pic.isNotEmpty ? CachedNetworkImageProvider(pic) : null,
                           backgroundColor: Colors.blueGrey[400],
                         ),
                         title: Row(
@@ -1394,7 +1398,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                 child: Container(
                   decoration: BoxDecoration(
                     image: DecorationImage(
-                      image: NetworkImage(imageUrl),
+                      image: CachedNetworkImageProvider(imageUrl),
                       fit: BoxFit.cover,
                     ),
                   ),
@@ -2150,7 +2154,8 @@ class _CustomShareDialogContentState extends State<_CustomShareDialogContent> {
           child: ListTile(
             leading: CircleAvatar(
               backgroundColor: Colors.blueGrey,
-              backgroundImage: (photo.isNotEmpty) ? NetworkImage(photo) : null,
+              backgroundImage:
+                  (photo.isNotEmpty) ? CachedNetworkImageProvider(photo) : null,
             ),
             title: Text(
               name,
@@ -2244,7 +2249,13 @@ class _FullScreenGalleryPageState extends State<FullScreenGalleryPage> {
             itemBuilder: (context, index) {
               final url = widget.images[index];
               return Center(
-                child: Image.network(url, fit: BoxFit.contain),
+                child: CachedNetworkImage(
+                  imageUrl: url,
+                  fit: BoxFit.contain,
+                  placeholder: (_, __) =>
+                      const Center(child: CircularProgressIndicator()),
+                  errorWidget: (_, __, ___) => const Icon(Icons.error),
+                ),
               );
             },
           ),

--- a/app_src/lib/explore_screen/plans_managing/plan_card.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_card.dart
@@ -15,6 +15,7 @@ import '../users_managing/user_info_check.dart';
 import 'frosted_plan_dialog_state.dart';
 import '../../l10n/app_localizations.dart';
 import 'plan_chat_screen.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 
 // Importamos el widget de estado de actividad:
 import '../users_managing/user_activity_status.dart';
@@ -441,7 +442,8 @@ class PlanCardState extends State<PlanCard> {
       },
       child: CircleAvatar(
         radius: 20,
-        backgroundImage: senderPic.isNotEmpty ? NetworkImage(senderPic) : null,
+        backgroundImage:
+            senderPic.isNotEmpty ? CachedNetworkImageProvider(senderPic) : null,
         backgroundColor: Colors.blueGrey[100],
       ),
     );
@@ -724,7 +726,8 @@ class PlanCardState extends State<PlanCard> {
             children: [
               CircleAvatar(
                 radius: 16,
-                backgroundImage: pic.isNotEmpty ? NetworkImage(pic) : null,
+                backgroundImage:
+                    pic.isNotEmpty ? CachedNetworkImageProvider(pic) : null,
                 backgroundColor: Colors.blueGrey[400],
               ),
               const SizedBox(width: 8),
@@ -785,7 +788,8 @@ class PlanCardState extends State<PlanCard> {
                 left: 0,
                 child: CircleAvatar(
                   radius: avatarSize / 2,
-                  backgroundImage: pic1.isNotEmpty ? NetworkImage(pic1) : null,
+                  backgroundImage:
+                      pic1.isNotEmpty ? CachedNetworkImageProvider(pic1) : null,
                   backgroundColor: Colors.blueGrey[400],
                 ),
               ),
@@ -793,7 +797,8 @@ class PlanCardState extends State<PlanCard> {
                 left: overlapOffset,
                 child: CircleAvatar(
                   radius: avatarSize / 2,
-                  backgroundImage: pic2.isNotEmpty ? NetworkImage(pic2) : null,
+                  backgroundImage:
+                      pic2.isNotEmpty ? CachedNetworkImageProvider(pic2) : null,
                   backgroundColor: Colors.blueGrey[400],
                 ),
               ),
@@ -921,7 +926,7 @@ class PlanCardState extends State<PlanCard> {
                         leading: CircleAvatar(
                           radius: 22,
                           backgroundImage:
-                              pic.isNotEmpty ? NetworkImage(pic) : null,
+                              pic.isNotEmpty ? CachedNetworkImageProvider(pic) : null,
                           backgroundColor: Colors.blueGrey[400],
                         ),
                         title: Row(
@@ -1251,11 +1256,12 @@ class PlanCardState extends State<PlanCard> {
                             borderRadius: BorderRadius.circular(16),
                             child: AspectRatio(
                               aspectRatio: 16 / 13,
-                              child: Image.network(
-                                plan.backgroundImage!,
+                              child: CachedNetworkImage(
+                                imageUrl: plan.backgroundImage!,
                                 fit: BoxFit.cover,
-                                errorBuilder: (_, __, ___) =>
-                                    buildPlaceholder(),
+                                placeholder: (_, __) => const Center(
+                                    child: CircularProgressIndicator()),
+                                errorWidget: (_, __, ___) => buildPlaceholder(),
                               ),
                             ),
                           )

--- a/app_src/lib/explore_screen/plans_managing/plan_chat_screen.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_chat_screen.dart
@@ -7,6 +7,7 @@ import '../../models/plan_model.dart';
 import '../users_managing/user_info_check.dart';
 import '../../l10n/app_localizations.dart';
 import '../../main/colors.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 
 class PlanChatScreen extends StatefulWidget {
   final PlanModel plan;
@@ -57,7 +58,8 @@ class _PlanChatScreenState extends State<PlanChatScreen> {
       },
       child: CircleAvatar(
         radius: 20,
-        backgroundImage: senderPic.isNotEmpty ? NetworkImage(senderPic) : null,
+        backgroundImage:
+            senderPic.isNotEmpty ? CachedNetworkImageProvider(senderPic) : null,
         backgroundColor: Colors.blueGrey[100],
       ),
     );

--- a/app_src/lib/explore_screen/plans_managing/plan_share_sheet.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_share_sheet.dart
@@ -10,6 +10,7 @@ import '../../models/plan_model.dart';
 import '../users_grid/users_grid_helpers.dart'; // Para funciones de ayuda si hiciera falta
 import '../../main/colors.dart';
 import '../../l10n/app_localizations.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 
 /// Muestra un bottom sheet para compartir el plan con seguidores/seguidos,
 /// y también la opción de compartir con otras apps.
@@ -280,7 +281,8 @@ class PlanShareSheetState extends State<PlanShareSheet> {
             leading: CircleAvatar(
               radius: 20,
               backgroundColor: Colors.blueGrey,
-              backgroundImage: (photo.isNotEmpty) ? NetworkImage(photo) : null,
+              backgroundImage:
+                  (photo.isNotEmpty) ? CachedNetworkImageProvider(photo) : null,
             ),
             title: Text(
               "$name, $age",

--- a/app_src/lib/explore_screen/profile/image_share_sheet.dart
+++ b/app_src/lib/explore_screen/profile/image_share_sheet.dart
@@ -4,6 +4,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:share_plus/share_plus.dart';
 import '../../main/colors.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 
 class ImageShareSheet extends StatefulWidget {
   final String imageUrl;
@@ -242,7 +243,7 @@ class _ImageShareSheetState extends State<ImageShareSheet> {
             leading: CircleAvatar(
               radius: 20,
               backgroundColor: Colors.blueGrey,
-              backgroundImage: (photo.isNotEmpty) ? NetworkImage(photo) : null,
+              backgroundImage: (photo.isNotEmpty) ? CachedNetworkImageProvider(photo) : null,
             ),
             title: Text(
               age.isNotEmpty ? "$name, $age" : name,

--- a/app_src/lib/explore_screen/profile/plan_memories_screen.dart
+++ b/app_src/lib/explore_screen/profile/plan_memories_screen.dart
@@ -11,6 +11,8 @@ import '../../l10n/app_localizations.dart';
 
 import '../plans_managing/plan_card.dart';
 import '../../models/plan_model.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import '../users_grid/users_grid_helpers.dart';
 
 // Importa nuestra hoja de compartir imágenes (análogo a tu PlanShareSheet)
 import 'image_share_sheet.dart';
@@ -393,9 +395,12 @@ class _PlanMemoriesScreenState extends State<PlanMemoriesScreen> {
           final imageUrl = _memories[index];
           return GestureDetector(
             onTap: () => _openPhotoViewer(index),
-            child: Image.network(
-              imageUrl,
+            child: CachedNetworkImage(
+              imageUrl: imageUrl,
               fit: BoxFit.cover,
+              placeholder: (_, __) =>
+                  const Center(child: CircularProgressIndicator()),
+              errorWidget: (_, __, ___) => buildPlaceholder(),
             ),
           );
         },
@@ -442,9 +447,12 @@ class _FullScreenImageViewerState extends State<_FullScreenImageViewer> {
       ),
       body: Center(
         child: InteractiveViewer(
-          child: Image.network(
-            widget.imageUrl,
+          child: CachedNetworkImage(
+            imageUrl: widget.imageUrl,
             fit: BoxFit.contain,
+            placeholder: (_, __) =>
+                const Center(child: CircularProgressIndicator()),
+            errorWidget: (_, __, ___) => const Icon(Icons.error),
           ),
         ),
       ),

--- a/app_src/lib/explore_screen/profile/profile_screen.dart
+++ b/app_src/lib/explore_screen/profile/profile_screen.dart
@@ -20,6 +20,8 @@ import '../../l10n/app_localizations.dart';
 import 'user_images_managing.dart';
 import '../users_managing/presence_service.dart';
 import '../../services/location_update_service.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import '../users_grid/users_grid_helpers.dart';
 
 import 'package:firebase_messaging/firebase_messaging.dart';
 
@@ -222,11 +224,14 @@ class ProfileScreenState extends State<ProfileScreen> {
                 onProfileUpdated: (url) =>
                     setState(() => profileImageUrl = url),
               ),
-              child: Image.network(
-                coverImages[index],
+              child: CachedNetworkImage(
+                imageUrl: coverImages[index],
                 fit: BoxFit.cover,
                 width: double.infinity,
                 height: 300,
+                placeholder: (_, __) =>
+                    const Center(child: CircularProgressIndicator()),
+                errorWidget: (_, __, ___) => buildPlaceholder(),
               ),
             ),
           ),
@@ -352,7 +357,8 @@ class ProfileScreenState extends State<ProfileScreen> {
     return CircleAvatar(
       radius: 42,
       backgroundColor: hasPhoto ? Colors.transparent : Colors.grey[300],
-      backgroundImage: hasPhoto ? NetworkImage(profileImageUrl!) : null,
+      backgroundImage:
+          hasPhoto ? CachedNetworkImageProvider(profileImageUrl!) : null,
       child: hasPhoto
           ? null
           : const Icon(Icons.person, size: 42, color: Colors.white70),

--- a/app_src/lib/explore_screen/profile/user_images_managing.dart
+++ b/app_src/lib/explore_screen/profile/user_images_managing.dart
@@ -12,6 +12,8 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import '../users_grid/users_grid_helpers.dart';
 import '../../l10n/app_localizations.dart';
 
 class UserImagesManaging {
@@ -828,9 +830,12 @@ class _FullScreenImagePageState extends State<_FullScreenImagePage> {
                   child: Container(
                     color: Colors.white,
                     child: InteractiveViewer(
-                      child: Image.network(
-                        images[i],
+                      child: CachedNetworkImage(
+                        imageUrl: images[i],
                         fit: BoxFit.contain,
+                        placeholder: (_, __) =>
+                            const Center(child: CircularProgressIndicator()),
+                        errorWidget: (_, __, ___) => const Icon(Icons.error),
                       ),
                     ),
                   ),

--- a/app_src/lib/explore_screen/users_managing/user_info_check.dart
+++ b/app_src/lib/explore_screen/users_managing/user_info_check.dart
@@ -15,6 +15,8 @@ import '../follow/following_screen.dart';
 import '../future_plans/future_plans.dart';
 import 'report_and_block_user.dart'; // Import para Reportar/Bloquear
 import '../../l10n/app_localizations.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import '../users_grid/users_grid_helpers.dart';
 
 class UserInfoCheck extends StatefulWidget {
   final String userId;
@@ -363,7 +365,13 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
         width: double.infinity,
         color: Colors.grey[300],
         child: hasCover
-            ? Image.network(_coverImageUrl!, fit: BoxFit.cover)
+            ? CachedNetworkImage(
+                imageUrl: _coverImageUrl!,
+                fit: BoxFit.cover,
+                placeholder: (_, __) =>
+                    const Center(child: CircularProgressIndicator()),
+                errorWidget: (_, __, ___) => buildPlaceholder(),
+              )
             : Center(
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
@@ -402,7 +410,7 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
                   backgroundColor: Colors.white,
                   child: CircleAvatar(
                     radius: 42,
-                    backgroundImage: NetworkImage(avatarUrl),
+                    backgroundImage: CachedNetworkImageProvider(avatarUrl),
                   ),
                 ),
               ),
@@ -433,7 +441,13 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
             children: [
               Center(
                 child: InteractiveViewer(
-                  child: Image.network(imageUrl, fit: BoxFit.contain),
+                  child: CachedNetworkImage(
+                    imageUrl: imageUrl,
+                    fit: BoxFit.contain,
+                    placeholder: (_, __) =>
+                        const Center(child: CircularProgressIndicator()),
+                    errorWidget: (_, __, ___) => const Icon(Icons.error),
+                  ),
                 ),
               ),
               Positioned(

--- a/app_src/lib/plan_creation/new_plan_creation_screen.dart
+++ b/app_src/lib/plan_creation/new_plan_creation_screen.dart
@@ -15,6 +15,8 @@ import 'meeting_location_screen.dart';
 import '../utils/plans_list.dart';
 import '../l10n/app_localizations.dart';
 import 'package:intl/intl.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import '../explore_screen/users_grid/users_grid_helpers.dart';
 
 /// Función auxiliar para convertir un SVG en BitmapDescriptor aplicando un color.
 Future<BitmapDescriptor> getCustomSvgMarker(
@@ -2156,7 +2158,13 @@ class _FullScreenImageViewerState extends State<_FullScreenImageViewer> {
           final imageUrl = widget.originalImages[index];
           return InteractiveViewer(
             child: Center(
-              child: Image.network(imageUrl, fit: BoxFit.contain),
+              child: CachedNetworkImage(
+                imageUrl: imageUrl,
+                fit: BoxFit.contain,
+                placeholder: (_, __) =>
+                    const Center(child: CircularProgressIndicator()),
+                errorWidget: (_, __, ___) => const Icon(Icons.error),
+              ),
             ),
           );
         },


### PR DESCRIPTION
## Summary
- cache user grid images via `CachedNetworkImage`
- use the same caching strategy in profile, user info and photo viewers
- apply CachedNetworkImageProvider for avatars and thumbnails across screens
- update menu screens and notification handlers to use cached images

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6877e2eeace8833299a3cb6f48c27067