### PR TITLE
Implement marker loading improvements

### DIFF
--- a/app_src/lib/explore_screen/menu_side_bar/my_plans_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/my_plans_screen.dart
@@ -324,6 +324,8 @@ Widget _buildPlanTile(BuildContext context, PlanModel plan) {
                       .doc(plan.id)
                       .delete();
 
+                  await PlanModel.updateUserHasActivePlan(currentUser.uid);
+
                   Navigator.pop(ctx);
                   ScaffoldMessenger.of(context).showSnackBar(
                     SnackBar(content: Text('Plan ${plan.type} eliminado.')),

--- a/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
@@ -153,6 +153,8 @@ class SubscribedPlansScreen extends StatelessWidget {
                     'invitedUsers': FieldValue.arrayRemove([userId])
                   });
 
+                  await PlanModel.updateUserHasActivePlan(userId);
+
                   try {
                     final userDoc = await FirebaseFirestore.instance
                         .collection('users')

--- a/app_src/lib/start/registration/user_registration_screen.dart
+++ b/app_src/lib/start/registration/user_registration_screen.dart
@@ -29,6 +29,7 @@ import 'local_registration_service.dart';
 import '../../services/fcm_token_service.dart';
 import 'register_screen.dart';
 import '../../services/language_service.dart';
+import '../../models/plan_model.dart';
 
 class UserRegistrationScreen extends StatefulWidget {
   const UserRegistrationScreen({
@@ -349,6 +350,7 @@ class _UserRegistrationScreenState extends State<UserRegistrationScreen> {
         'coverPhotos': coverPhotoUrls,
         'latitude': latitude,
         'longitude': longitude,
+        'hasActivePlan': false,
         'languageCode': LanguageService.locale.value.languageCode,
         'privilegeLevel': 'Básico',
         'profile_privacy': 0,
@@ -370,6 +372,8 @@ class _UserRegistrationScreenState extends State<UserRegistrationScreen> {
           .collection('users')
           .doc(user.uid)
           .set(userData);
+
+      await PlanModel.updateUserHasActivePlan(user.uid);
 
       // Guardamos token de notificaciones
       await FcmTokenService.register(user);

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -17,6 +17,22 @@
         { "fieldPath": "receiverId", "order": "ASCENDING" },
         { "fieldPath": "isRead", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "users",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "latitude", "order": "ASCENDING" },
+        { "fieldPath": "longitude", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "plans",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "latitude", "order": "ASCENDING" },
+        { "fieldPath": "longitude", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
## Summary
- paginate queries and filter users by map bounds
- add bitmap cache with LRU eviction
- build markers in parallel and use FutureBuilder for map
- add Firestore composite indexes for coordinates
- track user hasActivePlan field

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877e0e033b88332bb5d1ed45c3d700d