### PR TITLE
Fix hasActivePlan update logic

### DIFF
--- a/app_src/lib/models/plan_model.dart
+++ b/app_src/lib/models/plan_model.dart
@@ -421,7 +421,7 @@ class PlanModel {
         .where('special_plan', isEqualTo: 0)
         .get();
     for (final d in createdSnap.docs) {
-      final ts = d.data()['start_timestamp'] as Timestamp?;
+      final ts = d.data()['finish_timestamp'] as Timestamp?;
       if (ts != null && ts.toDate().isAfter(now)) {
         active = true;
         break;
@@ -435,7 +435,7 @@ class PlanModel {
           .where('special_plan', isEqualTo: 0)
           .get();
       for (final d in joinedSnap.docs) {
-        final ts = d.data()['start_timestamp'] as Timestamp?;
+        final ts = d.data()['finish_timestamp'] as Timestamp?;
         if (ts != null && ts.toDate().isAfter(now)) {
           active = true;
           break;

--- a/app_src/lib/plan_creation/new_plan_creation_screen.dart
+++ b/app_src/lib/plan_creation/new_plan_creation_screen.dart
@@ -1718,6 +1718,12 @@ class __NewPlanPopupContentState extends State<_NewPlanPopupContent> {
           originalImages: uploadedOriginalImages,
           videoUrl: null,
         );
+
+        // Actualizar el estado de planes activos del usuario
+        final user = FirebaseAuth.instance.currentUser;
+        if (user != null) {
+          await PlanModel.updateUserHasActivePlan(user.uid);
+        }
       }
 
       // Regresar y cerrar el popup


### PR DESCRIPTION
## Summary
- update `updateUserHasActivePlan` to check for unfinished plans using `finish_timestamp`
- refresh active plan status after creating a new plan

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_6877f3841db08332bdd06a9316a64c4e