### PR TITLE
Evitar ver usuarios bloqueados

### DIFF
--- a/app_src/lib/explore_screen/main_screen/explore_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/explore_screen.dart
@@ -16,6 +16,7 @@ import '../chats/chats_screen.dart';
 import '../map/map_screen.dart';
 import '../profile/profile_screen.dart';
 import 'notification_screen.dart';
+import '../users_managing/block_utils.dart';
 import 'package:dating_app/plan_creation/new_plan_creation_screen.dart';
 import 'searcher.dart';
 import '../../tutorial/quick_start_guide.dart';
@@ -357,6 +358,12 @@ class ExploreScreenState extends State<ExploreScreen> {
       validUsers = validUsers.where((doc) {
         final data = doc.data() as Map<String, dynamic>;
         return data['uid']?.toString() != _currentUser!.uid;
+      }).toList();
+
+      final blockedIds = await fetchBlockedIds(_currentUser!.uid);
+      validUsers = validUsers.where((doc) {
+        final uid = (doc.data() as Map<String, dynamic>)['uid']?.toString();
+        return uid != null && !blockedIds.contains(uid);
       }).toList();
     }
 

--- a/app_src/lib/explore_screen/main_screen/searcher.dart
+++ b/app_src/lib/explore_screen/main_screen/searcher.dart
@@ -6,6 +6,8 @@ import '../../models/plan_model.dart';
 import '../plans_managing/frosted_plan_dialog_state.dart';
 import '../users_managing/user_info_check.dart';
 import '../../main/colors.dart';
+import '../users_managing/block_utils.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 
 /// Representa un resultado de búsqueda (usuario o plan).
@@ -195,6 +197,12 @@ class _SearcherState extends State<Searcher> {
             additionalPlans: additional,
           ),
         );
+      }
+
+      final current = FirebaseAuth.instance.currentUser;
+      if (current != null) {
+        final blockedIds = await fetchBlockedIds(current.uid);
+        finalResults.removeWhere((r) => r.isUser && blockedIds.contains(r.id));
       }
 
       if (mounted && _lastQuery == cleanedQuery) {

--- a/app_src/lib/explore_screen/menu_side_bar/settings/privacy.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/settings/privacy.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../users_managing/blocked_users_screen.dart';
 
 class PrivacyScreen extends StatefulWidget {
   const PrivacyScreen({Key? key}) : super(key: key);
@@ -173,6 +174,36 @@ class _PrivacyScreenState extends State<PrivacyScreen> {
                       inactiveThumbColor: Colors.white,
                     ),
                   ],
+                ),
+            ),
+          ),
+            const SizedBox(height: 24),
+            Material(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(24),
+              child: InkWell(
+                borderRadius: BorderRadius.circular(24),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => const BlockedUsersScreen()),
+                  );
+                },
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 16.0, vertical: 12.0),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          t.blockedUsers,
+                          style: const TextStyle(fontSize: 16),
+                        ),
+                      ),
+                      const Icon(Icons.chevron_right),
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/app_src/lib/explore_screen/users_managing/block_utils.dart
+++ b/app_src/lib/explore_screen/users_managing/block_utils.dart
@@ -1,0 +1,43 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// Devuelve el conjunto de IDs de usuarios que han sido bloqueados por
+/// [userId] o que han bloqueado a [userId].
+Future<Set<String>> fetchBlockedIds(String userId) async {
+  final Set<String> ids = {};
+
+  final byMe = await FirebaseFirestore.instance
+      .collection('blocked_users')
+      .where('blockerId', isEqualTo: userId)
+      .get();
+  for (final doc in byMe.docs) {
+    final id = doc.data()['blockedId'] as String?;
+    if (id != null) ids.add(id);
+  }
+
+  final blockingMe = await FirebaseFirestore.instance
+      .collection('blocked_users')
+      .where('blockedId', isEqualTo: userId)
+      .get();
+  for (final doc in blockingMe.docs) {
+    final id = doc.data()['blockerId'] as String?;
+    if (id != null) ids.add(id);
+  }
+
+  return ids;
+}
+
+/// Verifica si existe un bloqueo en cualquier dirección entre [a] y [b].
+Future<bool> areUsersBlocked(String a, String b) async {
+  final doc1 = await FirebaseFirestore.instance
+      .collection('blocked_users')
+      .doc('${a}_$b')
+      .get();
+  if (doc1.exists) return true;
+
+  final doc2 = await FirebaseFirestore.instance
+      .collection('blocked_users')
+      .doc('${b}_$a')
+      .get();
+
+  return doc2.exists;
+}

--- a/app_src/lib/explore_screen/users_managing/blocked_users_screen.dart
+++ b/app_src/lib/explore_screen/users_managing/blocked_users_screen.dart
@@ -1,0 +1,253 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+
+import 'user_activity_status.dart';
+import '../../l10n/app_localizations.dart';
+
+class BlockedUsersScreen extends StatefulWidget {
+  const BlockedUsersScreen({Key? key}) : super(key: key);
+
+  @override
+  State<BlockedUsersScreen> createState() => _BlockedUsersScreenState();
+}
+
+class _BlockedUsersScreenState extends State<BlockedUsersScreen> {
+  bool _loading = true;
+  List<_UserItem> _users = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadBlockedUsers();
+  }
+
+  Future<void> _loadBlockedUsers() async {
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) {
+      setState(() => _loading = false);
+      return;
+    }
+
+    try {
+      final snap = await FirebaseFirestore.instance
+          .collection('blocked_users')
+          .where('blockerId', isEqualTo: uid)
+          .get();
+
+      final List<_UserItem> list = [];
+      for (final doc in snap.docs) {
+        final blockedId = doc.data()['blockedId'];
+        if (blockedId == null) continue;
+        final uDoc = await FirebaseFirestore.instance
+            .collection('users')
+            .doc(blockedId)
+            .get();
+        if (!uDoc.exists || uDoc.data() == null) continue;
+        final data = uDoc.data()!;
+        final planInfo = await _getNextPlanInfo(blockedId);
+        list.add(_UserItem(
+          uid: blockedId,
+          name: data['name'] ?? 'Usuario',
+          privilegeLevel: (data['privilegeLevel'] ?? 'Básico').toString(),
+          photoUrl: data['photoUrl'] ?? '',
+          upcomingPlanId: planInfo?.id,
+          upcomingPlanName: planInfo?.name,
+          additionalPlans: planInfo?.additional ?? 0,
+        ));
+      }
+
+      if (mounted) {
+        setState(() {
+          _users = list;
+          _loading = false;
+        });
+      }
+    } catch (_) {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  Future<_PlanInfo?> _getNextPlanInfo(String userId) async {
+    try {
+      final snap = await FirebaseFirestore.instance
+          .collection('plans')
+          .where('createdBy', isEqualTo: userId)
+          .where('special_plan', isEqualTo: 0)
+          .get();
+
+      final now = DateTime.now();
+      final futures = snap.docs
+          .map((d) {
+            final data = d.data() as Map<String, dynamic>;
+            final ts = data['start_timestamp'];
+            if (ts is Timestamp && ts.toDate().isAfter(now)) {
+              return {
+                'id': d.id,
+                'type': data['type'] ?? '',
+                'start': ts.toDate(),
+              };
+            }
+            return null;
+          })
+          .whereType<Map<String, dynamic>>()
+          .toList();
+
+      if (futures.isEmpty) return null;
+
+      futures.sort((a, b) => (a['start'] as DateTime)
+          .compareTo(b['start'] as DateTime));
+
+      return _PlanInfo(
+        id: futures.first['id'] as String,
+        name: futures.first['type'] as String,
+        additional: futures.length - 1,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> _unblock(String userId) async {
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) return;
+    final docId = '${uid}_$userId';
+    await FirebaseFirestore.instance
+        .collection('blocked_users')
+        .doc(docId)
+        .delete();
+  }
+
+  void _onUserTap(_UserItem item) {
+    final t = AppLocalizations.of(context);
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        content: Text(t.unblockQuestion),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: Text(t.no),
+          ),
+          TextButton(
+            onPressed: () async {
+              Navigator.pop(ctx);
+              await _unblock(item.uid);
+              if (mounted) {
+                setState(() => _users.removeWhere((u) => u.uid == item.uid));
+              }
+            },
+            child: Text(t.yes),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(t.blockedUsers),
+        leading: BackButton(onPressed: () => Navigator.of(context).pop()),
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _users.isEmpty
+              ? Center(child: Text(t.noResults))
+              : ListView.separated(
+                  padding: const EdgeInsets.all(16),
+                  itemCount: _users.length,
+                  separatorBuilder: (_, __) => const Divider(height: 1),
+                  itemBuilder: (_, idx) {
+                    final u = _users[idx];
+                    return ListTile(
+                      leading: CircleAvatar(
+                        backgroundImage: u.photoUrl.isNotEmpty
+                            ? CachedNetworkImageProvider(u.photoUrl)
+                            : null,
+                      ),
+                      title: Row(
+                        children: [
+                          Text(u.name),
+                          const SizedBox(width: 2),
+                          Image.asset(
+                            _getPrivilegeIcon(u.privilegeLevel),
+                            width: 14,
+                            height: 14,
+                          ),
+                        ],
+                      ),
+                      subtitle: UserActivityStatus(
+                        userId: u.uid,
+                        key: ValueKey('black_${u.uid}'),
+                      ),
+                      trailing: u.upcomingPlanName != null
+                          ? Container(
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 8, vertical: 4),
+                              decoration: BoxDecoration(
+                                borderRadius: BorderRadius.circular(20),
+                                border:
+                                    Border.all(color: Colors.blueGrey.shade700),
+                              ),
+                              child: Text(
+                                u.additionalPlans > 0
+                                    ? '${u.upcomingPlanName} +${u.additionalPlans}'
+                                    : u.upcomingPlanName!,
+                                style: const TextStyle(
+                                    color: Colors.blueGrey, fontSize: 12),
+                              ),
+                            )
+                          : null,
+                      onTap: () => _onUserTap(u),
+                    );
+                  },
+                ),
+    );
+  }
+}
+
+class _UserItem {
+  final String uid;
+  final String name;
+  final String privilegeLevel;
+  final String photoUrl;
+  final String? upcomingPlanId;
+  final String? upcomingPlanName;
+  final int additionalPlans;
+
+  _UserItem({
+    required this.uid,
+    required this.name,
+    required this.privilegeLevel,
+    required this.photoUrl,
+    this.upcomingPlanId,
+    this.upcomingPlanName,
+    this.additionalPlans = 0,
+  });
+}
+
+class _PlanInfo {
+  final String id;
+  final String name;
+  final int additional;
+
+  _PlanInfo({required this.id, required this.name, required this.additional});
+}
+
+String _getPrivilegeIcon(String level) {
+  final normalized = level.toLowerCase().replaceAll('á', 'a');
+  switch (normalized) {
+    case 'premium':
+      return 'assets/icono-usuario-premium.png';
+    case 'golden':
+      return 'assets/icono-usuario-golden.png';
+    case 'vip':
+      return 'assets/icono-usuario-vip.png';
+    default:
+      return 'assets/icono-usuario-basico.png';
+  }
+}

--- a/app_src/lib/l10n/app_localizations.dart
+++ b/app_src/lib/l10n/app_localizations.dart
@@ -26,6 +26,10 @@ class AppLocalizations {
       'delete_question': '¿Estás seguro de que quieres eliminar tu perfil?',
       'cancel': 'Cancelar',
       'accept': 'Aceptar',
+      'yes': 'Sí',
+      'no': 'No',
+      'blocked_users': 'Usuarios bloqueados',
+      'unblock_question': '¿Desbloquear a este usuario?',
       'delete_success': 'Tu cuenta se ha eliminado correctamente.',
       'reauth_required': 'Reautenticación requerida',
       'reauth_explanation': 'Por cuestiones de seguridad debes introducir tus credenciales de inicio de sesión para eliminar tu cuenta definitivamente',
@@ -318,6 +322,10 @@ class AppLocalizations {
       'delete_question': 'Are you sure you want to delete your profile?',
       'cancel': 'Cancel',
       'accept': 'Accept',
+      'yes': 'Yes',
+      'no': 'No',
+      'blocked_users': 'Blocked users',
+      'unblock_question': 'Unblock this user?',
       'delete_success': 'Your account has been deleted successfully.',
       'reauth_required': 'Reauthentication required',
       'reauth_explanation': 'For security reasons you must enter your login credentials to permanently delete your account',
@@ -616,6 +624,10 @@ class AppLocalizations {
   String get deleteQuestion => _t('delete_question');
   String get cancel => _t('cancel');
   String get accept => _t('accept');
+  String get yes => _t('yes');
+  String get no => _t('no');
+  String get blockedUsers => _t('blocked_users');
+  String get unblockQuestion => _t('unblock_question');
   String get deleteSuccess => _t('delete_success');
   String get reauthRequired => _t('reauth_required');
   String get reauthExplanation => _t('reauth_explanation');


### PR DESCRIPTION
## Resumen
- utilidades para consultar bloqueos (`block_utils.dart`)
- filtrado de usuarios bloqueados en `ExploreScreen`
- exclusión de usuarios bloqueados en los resultados de `Searcher`
- nueva pantalla de "Usuarios bloqueados" accesible desde Ajustes > Privacidad

## Testing
- ❌ `flutter analyze` (comando no encontrado)


------
https://chatgpt.com/codex/tasks/task_e_68781151232883329f0964e77bda44d5