### PR TITLE
Mostrar avatar por defecto en chats

### DIFF
--- a/app_src/lib/explore_screen/chats/chat_screen.dart
+++ b/app_src/lib/explore_screen/chats/chat_screen.dart
@@ -40,6 +40,7 @@ class ChatScreen extends StatefulWidget {
   final String chatPartnerId;
   final String chatPartnerName;
   final String? chatPartnerPhoto;
+  final String? chatPartnerCover;
 
   /// Ya no vamos a usar [deletedAt] a nivel de constructor,
   /// porque ahora usaremos las fechas guardadas en userDoc.
@@ -50,6 +51,7 @@ class ChatScreen extends StatefulWidget {
     required this.chatPartnerId,
     required this.chatPartnerName,
     this.chatPartnerPhoto,
+    this.chatPartnerCover,
     this.deletedAt,
   }) : super(key: key);
 
@@ -339,12 +341,10 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
                     },
                     child: Row(
                       children: [
-                        CircleAvatar(
+                        buildProfileAvatar(
+                          widget.chatPartnerPhoto,
+                          coverUrl: widget.chatPartnerCover,
                           radius: 16,
-                          backgroundImage: widget.chatPartnerPhoto != null
-                              ? CachedNetworkImageProvider(widget.chatPartnerPhoto!)
-                              : null,
-                          backgroundColor: Colors.grey[300],
                         ),
                         const SizedBox(width: 8),
                         Expanded(

--- a/app_src/lib/explore_screen/chats/chats_screen.dart
+++ b/app_src/lib/explore_screen/chats/chats_screen.dart
@@ -66,6 +66,7 @@ class _ChatsScreenState extends State<ChatsScreen> {
                       chatPartnerId: destUserId,
                       chatPartnerName: "Contacto Ejemplo",
                       chatPartnerPhoto: "",
+                      chatPartnerCover: "",
                     ),
                   ),
                 );
@@ -292,6 +293,7 @@ class _ChatsScreenState extends State<ChatsScreen> {
 
                 final userName = userData['name']?.toString() ?? 'Usuario';
                 final userPhoto = userData['photoUrl']?.toString() ?? '';
+                final coverUrl = userData['coverPhotoUrl']?.toString() ?? '';
 
                 // Contar no leídos de otherUserId -> currentUserId
                 return FutureBuilder<QuerySnapshot>(
@@ -348,11 +350,9 @@ class _ChatsScreenState extends State<ChatsScreen> {
                       onDismissed: (_) => _deleteChat(otherUserId),
 
                       child: ListTile(
-                        leading: CircleAvatar(
-                          backgroundImage: (userPhoto.isNotEmpty)
-                              ? CachedNetworkImageProvider(userPhoto)
-                              : null,
-                          backgroundColor: Colors.grey[300],
+                        leading: buildProfileAvatar(
+                          userPhoto,
+                          coverUrl: coverUrl,
                         ),
                         title: Text(
                           userName,
@@ -399,6 +399,7 @@ class _ChatsScreenState extends State<ChatsScreen> {
                                 chatPartnerId: otherUserId,
                                 chatPartnerName: userName,
                                 chatPartnerPhoto: userPhoto,
+                                chatPartnerCover: coverUrl,
                               ),
                             ),
                           );
@@ -576,6 +577,7 @@ class _ChatsScreenState extends State<ChatsScreen> {
           'id': doc.id,
           'name': data['name'] ?? '',
           'photoUrl': data['photoUrl'] ?? '',
+          'coverPhotoUrl': data['coverPhotoUrl'] ?? '',
           'age': data['age']?.toString() ?? '',
           'profile_privacy': data['profile_privacy'] ?? 0,
         };
@@ -606,14 +608,14 @@ class _ChatsScreenState extends State<ChatsScreen> {
       children: _searchResults.map((user) {
         final name = user['name'] ?? 'Desconocido';
         final photoUrl = user['photoUrl'] ?? '';
+        final coverUrl = user['coverPhotoUrl'] ?? '';
         final level = user['privilegeLevel'] ?? 'Básico';
         final isPrivate = user['profile_privacy'] == 1;
 
         return ListTile(
-          leading: CircleAvatar(
-            backgroundImage:
-                (photoUrl.isNotEmpty) ? CachedNetworkImageProvider(photoUrl) : null,
-            backgroundColor: Colors.grey[300],
+          leading: buildProfileAvatar(
+            photoUrl,
+            coverUrl: coverUrl,
           ),
           title: Row(
             children: [
@@ -642,6 +644,7 @@ class _ChatsScreenState extends State<ChatsScreen> {
             user['id'].toString(),
             name,
             photoUrl,
+            coverUrl,
             isPrivate,
           ),
         );
@@ -704,15 +707,14 @@ class _ChatsScreenState extends State<ChatsScreen> {
 
                   final followerName = uData['name']?.toString() ?? 'Sin nombre';
                   final followerPhoto = uData['photoUrl']?.toString() ?? '';
+                  final followerCover = uData['coverPhotoUrl']?.toString() ?? '';
                   final level = uData['privilegeLevel'] ?? 'Básico';
                   final isPrivate = (uData['profile_privacy'] ?? 0) == 1;
 
                   return ListTile(
-                    leading: CircleAvatar(
-                      backgroundImage: (followerPhoto.isNotEmpty)
-                          ? CachedNetworkImageProvider(followerPhoto)
-                          : null,
-                      backgroundColor: Colors.grey[300],
+                    leading: buildProfileAvatar(
+                      followerPhoto,
+                      coverUrl: followerCover,
                     ),
                     title: Row(
                       children: [
@@ -741,6 +743,7 @@ class _ChatsScreenState extends State<ChatsScreen> {
                       followerId,
                       followerName,
                       followerPhoto,
+                      followerCover,
                       isPrivate,
                     ),
                   );
@@ -808,15 +811,14 @@ class _ChatsScreenState extends State<ChatsScreen> {
 
                   final followingName = uData['name']?.toString() ?? 'Sin nombre';
                   final followingPhoto = uData['photoUrl']?.toString() ?? '';
+                  final followingCover = uData['coverPhotoUrl']?.toString() ?? '';
                   final level = uData['privilegeLevel'] ?? 'Básico';
                   final isPrivate = (uData['profile_privacy'] ?? 0) == 1;
 
                   return ListTile(
-                    leading: CircleAvatar(
-                      backgroundImage: (followingPhoto.isNotEmpty)
-                          ? CachedNetworkImageProvider(followingPhoto)
-                          : null,
-                      backgroundColor: Colors.grey[300],
+                    leading: buildProfileAvatar(
+                      followingPhoto,
+                      coverUrl: followingCover,
                     ),
                     title: Row(
                       children: [
@@ -845,6 +847,7 @@ class _ChatsScreenState extends State<ChatsScreen> {
                       followingId,
                       followingName,
                       followingPhoto,
+                      followingCover,
                       isPrivate,
                     ),
                   );
@@ -862,6 +865,7 @@ class _ChatsScreenState extends State<ChatsScreen> {
     String userId,
     String name,
     String photoUrl,
+    String coverUrl,
     bool isUserPrivate,
   ) async {
     if (isUserPrivate) {
@@ -903,6 +907,7 @@ class _ChatsScreenState extends State<ChatsScreen> {
           chatPartnerId: userId,
           chatPartnerName: name,
           chatPartnerPhoto: photoUrl,
+          chatPartnerCover: coverUrl,
         ),
       ),
     );

--- a/app_src/lib/explore_screen/users_grid/users_grid.dart
+++ b/app_src/lib/explore_screen/users_grid/users_grid.dart
@@ -221,6 +221,7 @@ class _UsersGridState extends State<UsersGrid> {
           chatPartnerId: userId,
           chatPartnerName: userData['name'] ?? 'Usuario',
           chatPartnerPhoto: userData['photoUrl'] ?? '',
+          chatPartnerCover: userData['coverPhotoUrl'] ?? '',
         ),
       ),
     );

--- a/app_src/lib/explore_screen/users_grid/users_grid_helpers.dart
+++ b/app_src/lib/explore_screen/users_grid/users_grid_helpers.dart
@@ -22,7 +22,8 @@ Widget buildPlaceholder() {
 /// Avatar circular a partir de la foto de perfil. Si no existe, se intenta
 /// utilizar la imagen de fondo como alternativa. Si tampoco hay imagen de
 /// fondo, se muestra un placeholder con silueta.
-Widget buildProfileAvatar(String? photoUrl, {String? coverUrl}) {
+Widget buildProfileAvatar(String? photoUrl,
+    {String? coverUrl, double radius = 20}) {
   String? finalUrl;
   if (photoUrl != null && photoUrl.isNotEmpty) {
     finalUrl = photoUrl;
@@ -32,14 +33,15 @@ Widget buildProfileAvatar(String? photoUrl, {String? coverUrl}) {
 
   if (finalUrl != null) {
     return CircleAvatar(
-      radius: 20,
+      radius: radius,
       backgroundImage: CachedNetworkImageProvider(finalUrl),
     );
   } else {
     return CircleAvatar(
-      radius: 20,
+      radius: radius,
       backgroundColor: Colors.grey[200],
-      child: SvgPicture.asset('assets/usuario.svg', width: 20, height: 20),
+      child: SvgPicture.asset('assets/usuario.svg',
+          width: radius, height: radius),
     );
   }
 }

--- a/app_src/lib/explore_screen/users_managing/user_info_check.dart
+++ b/app_src/lib/explore_screen/users_managing/user_info_check.dart
@@ -935,6 +935,7 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
                     chatPartnerId: widget.userId,
                     chatPartnerName: userName,
                     chatPartnerPhoto: _profileImageUrl ?? '',
+                    chatPartnerCover: _coverImageUrl ?? '',
                   ),
                 ),
               );


### PR DESCRIPTION
## Summary
- corregir avatar en `ChatScreen` usando `buildProfileAvatar`
- usar portada como foto de perfil alternativa en `ChatsScreen`
- actualizar `buildProfileAvatar` para aceptar radio opcional
- propagar parámetro `chatPartnerCover` en constructores y llamadas

## Testing
- `flutter test` *(falló: comando no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_6879347212948332b62aeb622978cc93