### PR TITLE
Fix missing helper import for profile avatars

### DIFF
--- a/app_src/lib/explore_screen/chats/chats_screen.dart
+++ b/app_src/lib/explore_screen/chats/chats_screen.dart
@@ -8,6 +8,7 @@ import '../../l10n/app_localizations.dart';
 import '../users_managing/user_activity_status.dart';
 import 'chat_screen.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import '../users_grid/users_grid_helpers.dart';
 
 class ChatsScreen extends StatefulWidget {
   final String? sharedText;


### PR DESCRIPTION
## Summary
- import `users_grid_helpers` to allow `buildProfileAvatar` calls in `chats_screen.dart`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68793706efa88332a75576259e95fc58