### PR TITLE
Mostrar avatar placeholder en todas partes

### DIFF
--- a/app_src/lib/explore_screen/follow/following_screen.dart
+++ b/app_src/lib/explore_screen/follow/following_screen.dart
@@ -11,6 +11,7 @@ import '../users_managing/user_activity_status.dart';
 import '../../main/colors.dart';
 import '../../l10n/app_localizations.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import '../users_grid/users_grid_helpers.dart';
 
 /// Pantalla de seguidores/seguidos.
 /// Se muestra como un modal a pantalla casi completa (deja libre el 10 % superior)
@@ -275,11 +276,9 @@ class _FollowingScreenState extends State<FollowingScreen> {
                       itemBuilder: (_, idx) {
                         final u = _filtered[idx];
                         return ListTile(
-                          leading: CircleAvatar(
-                            backgroundImage: CachedNetworkImageProvider(
-                                u.photoUrl.isNotEmpty
-                                    ? u.photoUrl
-                                    : 'https://via.placeholder.com/150'),
+                          leading: buildProfileAvatar(
+                            u.photoUrl,
+                            radius: 20,
                           ),
                           title: Row(
                             crossAxisAlignment: CrossAxisAlignment.center,

--- a/app_src/lib/explore_screen/main_screen/notification_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/notification_screen.dart
@@ -14,6 +14,7 @@ import '../users_managing/user_info_check.dart';
 import '../plans_managing/plan_card.dart'; // <--- Asegúrate de importar tu PlanCard
 import '../plans_managing/firebase_services.dart'; // <--- Para fetchPlanParticipants, si lo tienes
 import '../plans_managing/frosted_plan_dialog_state.dart';
+import '../users_grid/users_grid_helpers.dart';
 import '../../l10n/app_localizations.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 
@@ -583,13 +584,9 @@ class _NotificationScreenState extends State<NotificationScreen> {
                                 ),
                               );
                             },
-                            child: CircleAvatar(
+                            child: buildProfileAvatar(
+                              senderPhoto,
                               radius: 25,
-                              backgroundImage: senderPhoto.isNotEmpty
-                                  ? CachedNetworkImageProvider(senderPhoto)
-                                  : CachedNetworkImageProvider(
-                                      'https://cdn-icons-png.flaticon.com/512/847/847969.png',
-                                    ),
                             ),
                           );
 
@@ -1027,9 +1024,9 @@ class _NotificationScreenState extends State<NotificationScreen> {
 
     Widget buildAvatar(Map<String, dynamic> data) {
       final url = data['photoUrl'] ?? '';
-      return CircleAvatar(
+      return buildProfileAvatar(
+        url,
         radius: 20,
-        backgroundImage: url.isNotEmpty ? CachedNetworkImageProvider(url) : null,
       );
     }
 

--- a/app_src/lib/explore_screen/main_screen/searcher.dart
+++ b/app_src/lib/explore_screen/main_screen/searcher.dart
@@ -9,6 +9,7 @@ import '../../main/colors.dart';
 import '../users_managing/block_utils.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import '../users_grid/users_grid_helpers.dart';
 
 /// Representa un resultado de búsqueda (usuario o plan).
 class SearchResultItem {
@@ -315,12 +316,9 @@ class _SearcherState extends State<Searcher> {
                     Widget tile = ListTile(
                       dense: true,
                       contentPadding: const EdgeInsets.symmetric(horizontal: 8.0),
-                      leading: CircleAvatar(
+                      leading: buildProfileAvatar(
+                        item.avatarUrl,
                         radius: 20,
-                        backgroundImage: (item.avatarUrl.isNotEmpty)
-                            ? CachedNetworkImageProvider(item.avatarUrl)
-                            : null,
-                        backgroundColor: Colors.grey[300],
                       ),
                       title: Text(
                         item.title,

--- a/app_src/lib/explore_screen/menu_side_bar/my_plans_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/my_plans_screen.dart
@@ -6,6 +6,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:intl/intl.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import '../users_grid/users_grid_helpers.dart';
 
 import '../../models/plan_model.dart';
 import '../../main/colors.dart';
@@ -355,9 +356,9 @@ Widget _buildPlanTile(BuildContext context, PlanModel plan) {
 
     Widget buildAvatar(Map<String, dynamic> data) {
       final url = data['photoUrl'] ?? '';
-      return CircleAvatar(
+      return buildProfileAvatar(
+        url,
         radius: 20,
-        backgroundImage: url.isNotEmpty ? CachedNetworkImageProvider(url) : null,
       );
     }
 

--- a/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/subscribed_plans_screen.dart
@@ -6,6 +6,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import '../users_grid/users_grid_helpers.dart';
 
 import '../../models/plan_model.dart';
 import '../../main/colors.dart';
@@ -210,9 +211,9 @@ class SubscribedPlansScreen extends StatelessWidget {
 
     Widget buildAvatar(Map<String, dynamic> data) {
       final url = data['photoUrl'] ?? '';
-      return CircleAvatar(
+      return buildProfileAvatar(
+        url,
         radius: 20,
-        backgroundImage: url.isNotEmpty ? CachedNetworkImageProvider(url) : null,
       );
     }
 

--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -13,6 +13,7 @@ import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';
 import '../../l10n/app_localizations.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import '../users_grid/users_grid_helpers.dart';
 
 import '../../models/plan_model.dart';
 import '../users_managing/user_info_check.dart';
@@ -877,12 +878,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
           UserInfoCheck.open(context, senderId);
         }
       },
-      child: CircleAvatar(
-        radius: 20,
-        backgroundImage:
-            senderPic.isNotEmpty ? CachedNetworkImageProvider(senderPic) : null,
-        backgroundColor: Colors.blueGrey[100],
-      ),
+      child: buildProfileAvatar(senderPic, radius: 20),
     );
 
     final nameWidget = GestureDetector(
@@ -1070,12 +1066,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              CircleAvatar(
-                radius: 16,
-                backgroundImage:
-                    pic.isNotEmpty ? CachedNetworkImageProvider(pic) : null,
-                backgroundColor: Colors.blueGrey[400],
-              ),
+              buildProfileAvatar(pic, radius: 16),
               const SizedBox(width: 8),
               Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -1132,20 +1123,16 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
             children: [
               Positioned(
                 left: 0,
-                child: CircleAvatar(
+                child: buildProfileAvatar(
+                  pic1,
                   radius: avatarSize / 2,
-                  backgroundImage:
-                      pic1.isNotEmpty ? CachedNetworkImageProvider(pic1) : null,
-                  backgroundColor: Colors.blueGrey[400],
                 ),
               ),
               Positioned(
                 left: overlapOffset,
-                child: CircleAvatar(
+                child: buildProfileAvatar(
+                  pic2,
                   radius: avatarSize / 2,
-                  backgroundImage:
-                      pic2.isNotEmpty ? CachedNetworkImageProvider(pic2) : null,
-                  backgroundColor: Colors.blueGrey[400],
                 ),
               ),
               if (hasExtras)
@@ -1259,11 +1246,9 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                           if (uid.isEmpty || uid == _currentUser?.uid) return;
                           UserInfoCheck.open(context, uid);
                         },
-                        leading: CircleAvatar(
+                        leading: buildProfileAvatar(
+                          pic,
                           radius: 22,
-                          backgroundImage:
-                              pic.isNotEmpty ? CachedNetworkImageProvider(pic) : null,
-                          backgroundColor: Colors.blueGrey[400],
                         ),
                         title: Row(
                           mainAxisSize: MainAxisSize.min,
@@ -1531,25 +1516,9 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
         children: [
           GestureDetector(
             onTap: _openCreator,
-            child: CircleAvatar(
+            child: buildProfileAvatar(
+              _creatorPhotoUrl,
               radius: 20,
-              backgroundColor: Colors.blueGrey[400],
-              child: ClipOval(
-                child: (_creatorPhotoUrl?.isNotEmpty ?? false)
-                    ? CachedNetworkImage(
-                        imageUrl: _creatorPhotoUrl!,
-                        width: 40,
-                        height: 40,
-                        fit: BoxFit.cover,
-                        placeholder: (context, url) => const SizedBox(
-                            width: 20,
-                            height: 20,
-                            child: CircularProgressIndicator(strokeWidth: 2)),
-                        errorWidget: (context, url, error) =>
-                            const Icon(Icons.person, color: Colors.white),
-                      )
-                    : const Icon(Icons.person, color: Colors.white),
-              ),
             ),
           ),
           const SizedBox(width: 8),
@@ -2152,10 +2121,9 @@ class _CustomShareDialogContentState extends State<_CustomShareDialogContent> {
             borderRadius: BorderRadius.circular(8),
           ),
           child: ListTile(
-            leading: CircleAvatar(
-              backgroundColor: Colors.blueGrey,
-              backgroundImage:
-                  (photo.isNotEmpty) ? CachedNetworkImageProvider(photo) : null,
+            leading: buildProfileAvatar(
+              photo,
+              radius: 20,
             ),
             title: Text(
               name,

--- a/app_src/lib/explore_screen/plans_managing/plan_chat_screen.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_chat_screen.dart
@@ -8,6 +8,7 @@ import '../users_managing/user_info_check.dart';
 import '../../l10n/app_localizations.dart';
 import '../../main/colors.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import '../users_grid/users_grid_helpers.dart';
 
 class PlanChatScreen extends StatefulWidget {
   final PlanModel plan;
@@ -56,12 +57,7 @@ class _PlanChatScreenState extends State<PlanChatScreen> {
           UserInfoCheck.open(context, senderId);
         }
       },
-      child: CircleAvatar(
-        radius: 20,
-        backgroundImage:
-            senderPic.isNotEmpty ? CachedNetworkImageProvider(senderPic) : null,
-        backgroundColor: Colors.blueGrey[100],
-      ),
+      child: buildProfileAvatar(senderPic, radius: 20),
     );
 
     final nameWidget = GestureDetector(

--- a/app_src/lib/explore_screen/plans_managing/plan_share_sheet.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_share_sheet.dart
@@ -278,11 +278,9 @@ class PlanShareSheetState extends State<PlanShareSheet> {
             borderRadius: BorderRadius.circular(8),
           ),
           child: ListTile(
-            leading: CircleAvatar(
+            leading: buildProfileAvatar(
+              photo,
               radius: 20,
-              backgroundColor: Colors.blueGrey,
-              backgroundImage:
-                  (photo.isNotEmpty) ? CachedNetworkImageProvider(photo) : null,
             ),
             title: Text(
               "$name, $age",

--- a/app_src/lib/explore_screen/profile/image_share_sheet.dart
+++ b/app_src/lib/explore_screen/profile/image_share_sheet.dart
@@ -5,6 +5,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:share_plus/share_plus.dart';
 import '../../main/colors.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import '../users_grid/users_grid_helpers.dart';
 
 class ImageShareSheet extends StatefulWidget {
   final String imageUrl;
@@ -240,10 +241,9 @@ class _ImageShareSheetState extends State<ImageShareSheet> {
             borderRadius: BorderRadius.circular(8),
           ),
           child: ListTile(
-            leading: CircleAvatar(
+            leading: buildProfileAvatar(
+              photo,
               radius: 20,
-              backgroundColor: Colors.blueGrey,
-              backgroundImage: (photo.isNotEmpty) ? CachedNetworkImageProvider(photo) : null,
             ),
             title: Text(
               age.isNotEmpty ? "$name, $age" : name,

--- a/app_src/lib/explore_screen/users_managing/blocked_users_screen.dart
+++ b/app_src/lib/explore_screen/users_managing/blocked_users_screen.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import '../users_grid/users_grid_helpers.dart';
 
 import 'user_activity_status.dart';
 import '../../l10n/app_localizations.dart';
@@ -164,10 +165,9 @@ class _BlockedUsersScreenState extends State<BlockedUsersScreen> {
                   itemBuilder: (_, idx) {
                     final u = _users[idx];
                     return ListTile(
-                      leading: CircleAvatar(
-                        backgroundImage: u.photoUrl.isNotEmpty
-                            ? CachedNetworkImageProvider(u.photoUrl)
-                            : null,
+                      leading: buildProfileAvatar(
+                        u.photoUrl,
+                        radius: 20,
                       ),
                       title: Row(
                         children: [


### PR DESCRIPTION
## Resumen
- usa `buildProfileAvatar` en `frosted_plan_dialog_state.dart` para todos los avatares
- aplica el mismo widget en pantallas de chat y listados
- ajusta pantallas de notificaciones, búsqueda y menús
- se importó `users_grid_helpers.dart` donde era necesario

## Testing
- `dart` o `flutter` no están disponibles en el contenedor, por lo que no se pudieron ejecutar las pruebas ni formatear automáticamente

------
https://chatgpt.com/codex/tasks/task_e_6879455c59448332b158e947cb10b44f