### PR TITLE
Añadir edición de mensajes y actualizar burbujas

### DIFF
--- a/app_src/lib/explore_screen/chats/inner_chat_utils/answer_a_message.dart
+++ b/app_src/lib/explore_screen/chats/inner_chat_utils/answer_a_message.dart
@@ -155,6 +155,7 @@ mixin AnswerAMessageMixin<T extends StatefulWidget> on State<T> {
   void showMessageOptionsDialog(
     BuildContext context,
     Map<String, dynamic> messageData, {
+    VoidCallback? onEdit,
     VoidCallback? onDelete,
   }) {
     showDialog(
@@ -169,6 +170,7 @@ mixin AnswerAMessageMixin<T extends StatefulWidget> on State<T> {
           child: _buildFrostedDialogOptions(
             context,
             messageData,
+            onEdit: onEdit,
             onDelete: onDelete,
           ),
         );
@@ -179,6 +181,7 @@ mixin AnswerAMessageMixin<T extends StatefulWidget> on State<T> {
   Widget _buildFrostedDialogOptions(
     BuildContext context,
     Map<String, dynamic> messageData, {
+    VoidCallback? onEdit,
     VoidCallback? onDelete,
   }) {
     return ClipRRect(
@@ -202,6 +205,17 @@ mixin AnswerAMessageMixin<T extends StatefulWidget> on State<T> {
               // Bocadillo para ver el mensaje con su hora y nombre
               _buildMessageBubbleForDialog(messageData),
 
+              Divider(color: Colors.black.withOpacity(0.4), height: 1),
+
+              // Botón "Editar"
+              _buildOptionRow(
+                iconPath: 'assets/icono-escribir.svg',
+                label: 'Editar',
+                onTap: () {
+                  Navigator.pop(context);
+                  if (onEdit != null) onEdit();
+                },
+              ),
               Divider(color: Colors.black.withOpacity(0.4), height: 1),
 
               // Botón "Responder"


### PR DESCRIPTION
## Resumen
- permitir editar un mensaje desde el menú contextual
- mostrar vista previa de edición sobre el campo de texto
- actualizar el color de las burbujas del interlocutor a `AppColors.planColor`
- indicar con la palabra *Editado* los mensajes modificados

## Testing
- `flutter analyze` *(falló: comando no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_68794a248b188332b40bd062dd1e3fc9