### PR TITLE
Add timing checks for chat message editing

### DIFF
--- a/app_src/lib/explore_screen/chats/chat_screen.dart
+++ b/app_src/lib/explore_screen/chats/chat_screen.dart
@@ -713,6 +713,12 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
                 ),
                 child: GestureDetector(
                   onLongPress: () {
+                    bool canEdit = false;
+                    final ts = data['timestamp'];
+                    if (data['senderId'] == currentUserId && ts is Timestamp) {
+                      final sent = ts.toDate();
+                      canEdit = DateTime.now().difference(sent).inMinutes < 5;
+                    }
                     showMessageOptionsDialog(
                       context,
                       {
@@ -723,6 +729,7 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
                         'senderName': isMe ? 'Tú' : widget.chatPartnerName,
                         'timestamp': data['timestamp'],
                       },
+                      canEdit: canEdit,
                       onEdit: () {
                         startEditing({
                           'docId': item.id,

--- a/app_src/lib/explore_screen/chats/inner_chat_utils/answer_a_message.dart
+++ b/app_src/lib/explore_screen/chats/inner_chat_utils/answer_a_message.dart
@@ -157,6 +157,7 @@ mixin AnswerAMessageMixin<T extends StatefulWidget> on State<T> {
     Map<String, dynamic> messageData, {
     VoidCallback? onEdit,
     VoidCallback? onDelete,
+    bool canEdit = false,
   }) {
     showDialog(
       context: context,
@@ -170,6 +171,7 @@ mixin AnswerAMessageMixin<T extends StatefulWidget> on State<T> {
           child: _buildFrostedDialogOptions(
             context,
             messageData,
+            canEdit: canEdit,
             onEdit: onEdit,
             onDelete: onDelete,
           ),
@@ -181,6 +183,7 @@ mixin AnswerAMessageMixin<T extends StatefulWidget> on State<T> {
   Widget _buildFrostedDialogOptions(
     BuildContext context,
     Map<String, dynamic> messageData, {
+    bool canEdit = false,
     VoidCallback? onEdit,
     VoidCallback? onDelete,
   }) {
@@ -205,18 +208,21 @@ mixin AnswerAMessageMixin<T extends StatefulWidget> on State<T> {
               // Bocadillo para ver el mensaje con su hora y nombre
               _buildMessageBubbleForDialog(messageData),
 
-              Divider(color: Colors.black.withOpacity(0.4), height: 1),
+              if (canEdit) ...[
+                Divider(color: Colors.black.withOpacity(0.4), height: 1),
 
-              // Botón "Editar"
-              _buildOptionRow(
-                iconPath: 'assets/icono-escribir.svg',
-                label: 'Editar',
-                onTap: () {
-                  Navigator.pop(context);
-                  if (onEdit != null) onEdit();
-                },
-              ),
-              Divider(color: Colors.black.withOpacity(0.4), height: 1),
+                // Botón "Editar"
+                _buildOptionRow(
+                  iconPath: 'assets/icono-escribir.svg',
+                  label: 'Editar',
+                  onTap: () {
+                    Navigator.pop(context);
+                    if (onEdit != null) onEdit();
+                  },
+                ),
+              ],
+              if (canEdit)
+                Divider(color: Colors.black.withOpacity(0.4), height: 1),
 
               // Botón "Responder"
               _buildOptionRow(


### PR DESCRIPTION
## Summary
- hide edit option for messages not owned by current user
- restrict message editing to within 5 minutes of sending

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687957db723c8332af1d31e8333a6a19