### PR TITLE
Use local avatar placeholder for map markers

### DIFF
--- a/app_src/lib/explore_screen/map/plans_in_map_screen.dart
+++ b/app_src/lib/explore_screen/map/plans_in_map_screen.dart
@@ -6,6 +6,8 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 import 'dart:collection';
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter_svg/flutter_svg.dart' as svg;
 import '../../main/colors.dart';
 
 import '../plans_managing/frosted_plan_dialog_state.dart';
@@ -364,7 +366,21 @@ class PlansInMapScreen {
         : UserImagesManaging.placeholderImageUrl;
   }
 
-  Future<Uint8List> _downloadImageAsBytes(String url) async {
+  Future<Uint8List> _downloadImageAsBytes(String url,
+      {int width = 256, int height = 256}) async {
+    if (!url.startsWith('http')) {
+      if (url.endsWith('.svg')) {
+        final svgString = await rootBundle.loadString(url);
+        final drawableRoot = await svg.fromSvgString(svgString, url);
+        final picture =
+            drawableRoot.toPicture(size: ui.Size(width.toDouble(), height.toDouble()));
+        final image = await picture.toImage(width, height);
+        final bytes = await image.toByteData(format: ui.ImageByteFormat.png);
+        return bytes!.buffer.asUint8List();
+      }
+      final data = await rootBundle.load(url);
+      return data.buffer.asUint8List();
+    }
     final file = await DefaultCacheManager().getSingleFile(url);
     return await file.readAsBytes();
   }
@@ -383,7 +399,8 @@ class PlansInMapScreen {
       if (cached != null) {
         return _MarkerData(cached, const Offset(0.5, 1.0));
       }
-      final bytes = await _downloadImageAsBytes(finalUrl);
+      final bytes = await _downloadImageAsBytes(finalUrl,
+          width: 256, height: 256);
       final codec = await ui.instantiateImageCodec(bytes,
           targetWidth: 256, targetHeight: 256);
       final frame = await codec.getNextFrame();
@@ -482,7 +499,8 @@ class PlansInMapScreen {
       }
       Uint8List? bytes;
       if (finalUrl.isNotEmpty) {
-        bytes = await _downloadImageAsBytes(finalUrl);
+        bytes = await _downloadImageAsBytes(finalUrl,
+            width: 64, height: 64);
       }
       ui.Image? av;
       if (bytes != null) {

--- a/app_src/lib/explore_screen/profile/profile_screen.dart
+++ b/app_src/lib/explore_screen/profile/profile_screen.dart
@@ -33,7 +33,7 @@ class ProfileScreen extends StatefulWidget {
 }
 
 class ProfileScreenState extends State<ProfileScreen> {
-  final String placeholderImageUrl = "https://via.placeholder.com/150";
+  final String placeholderImageUrl = 'assets/usuario.svg';
 
   // Foto de perfil
   String? profileImageUrl;

--- a/app_src/lib/explore_screen/profile/user_images_managing.dart
+++ b/app_src/lib/explore_screen/profile/user_images_managing.dart
@@ -18,7 +18,7 @@ import '../../l10n/app_localizations.dart';
 
 class UserImagesManaging {
   static final ImagePicker _imagePicker = ImagePicker();
-  static const placeholderImageUrl = "https://via.placeholder.com/150";
+  static const placeholderImageUrl = 'assets/usuario.svg';
 
   static Future<bool> checkExplicit(File image) async {
     try {


### PR DESCRIPTION
## Summary
- use `assets/usuario.svg` as the placeholder image
- load asset images (including SVGs) for marker generation

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68795ee30ca48332a6e4f84f347ed952