### PR TITLE
Muestra iniciales cuando falta la foto de perfil

### DIFF
--- a/app_src/lib/explore_screen/chats/chat_screen.dart
+++ b/app_src/lib/explore_screen/chats/chat_screen.dart
@@ -353,6 +353,7 @@ class _ChatScreenState extends State<ChatScreen> with AnswerAMessageMixin {
                           widget.chatPartnerPhoto,
                           coverUrl: widget.chatPartnerCover,
                           radius: 16,
+                          userName: widget.chatPartnerName,
                         ),
                         const SizedBox(width: 8),
                         Expanded(

--- a/app_src/lib/explore_screen/chats/chats_screen.dart
+++ b/app_src/lib/explore_screen/chats/chats_screen.dart
@@ -354,6 +354,7 @@ class _ChatsScreenState extends State<ChatsScreen> {
                         leading: buildProfileAvatar(
                           userPhoto,
                           coverUrl: coverUrl,
+                          userName: userName,
                         ),
                         title: Text(
                           userName,
@@ -617,6 +618,7 @@ class _ChatsScreenState extends State<ChatsScreen> {
           leading: buildProfileAvatar(
             photoUrl,
             coverUrl: coverUrl,
+            userName: name,
           ),
           title: Row(
             children: [
@@ -716,6 +718,7 @@ class _ChatsScreenState extends State<ChatsScreen> {
                     leading: buildProfileAvatar(
                       followerPhoto,
                       coverUrl: followerCover,
+                      userName: followerName,
                     ),
                     title: Row(
                       children: [
@@ -820,6 +823,7 @@ class _ChatsScreenState extends State<ChatsScreen> {
                     leading: buildProfileAvatar(
                       followingPhoto,
                       coverUrl: followingCover,
+                      userName: followingName,
                     ),
                     title: Row(
                       children: [

--- a/app_src/lib/explore_screen/map/plans_in_map_screen.dart
+++ b/app_src/lib/explore_screen/map/plans_in_map_screen.dart
@@ -14,6 +14,7 @@ import '../../models/plan_model.dart';
 import '../users_managing/user_info_check.dart';
 import '../profile/user_images_managing.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import '../users_grid/users_grid_helpers.dart';
 
 class _MarkerData {
   final BitmapDescriptor icon;
@@ -294,12 +295,13 @@ class PlansInMapScreen {
         continue;
 
       String photoUrl = data['photoUrl']?.toString() ?? '';
+      final String name = data['name']?.toString() ?? '';
       if (photoUrl.isEmpty) {
         final cover = data['coverPhotoUrl']?.toString() ?? '';
         photoUrl = cover;
       }
       final pos = LatLng(lat, lng);
-      final _MarkerData iconData = await _buildNoPlanMarker(photoUrl);
+      final _MarkerData iconData = await _buildNoPlanMarker(photoUrl, name);
       markers.add(
         Marker(
           markerId: MarkerId('noPlanUser_$uid'),
@@ -479,13 +481,16 @@ class PlansInMapScreen {
     }
   }
 
-  Future<_MarkerData> _buildNoPlanMarker(String photoUrl) async {
+  Future<_MarkerData> _buildNoPlanMarker(String photoUrl, String name) async {
     try {
       // Aumentamos el tamaño base del marcador de usuario sin plan para que la
       // imagen no se muestre achatada en vertical.
       const double sz = 120, r = 45;
       final String finalUrl = photoUrl;
-      final cacheKey = 'user:' + (finalUrl.isNotEmpty ? finalUrl : 'noimage');
+      // Incluimos el nombre en el key cuando no hay foto para evitar
+      // que todos los usuarios compartan el mismo marcador en caché.
+      final cacheKey =
+          'user:' + (finalUrl.isNotEmpty ? finalUrl : 'noimage:$name');
       final cached = _getFromCache(cacheKey);
       if (cached != null) {
         return _MarkerData(cached, const Offset(0.5, 0.5));
@@ -528,7 +533,19 @@ class PlansInMapScreen {
             ..strokeWidth = 3,
         );
       } else {
-        canvas.drawCircle(center, r, Paint()..color = const Color(0xFFE0E0E0));
+        canvas.drawCircle(center, r, Paint()..color = avatarColor(name));
+        final tp = TextPainter(
+          text: TextSpan(
+            text: getInitials(name),
+            style: const TextStyle(
+                color: Colors.white, fontWeight: FontWeight.bold, fontSize: 24),
+          ),
+          textDirection: TextDirection.ltr,
+        );
+        tp.layout();
+        tp.paint(
+            canvas,
+            Offset(center.dx - tp.width / 2, center.dy - tp.height / 2));
       }
       final pic = rec.endRecording();
       final img = await pic.toImage(sz.toInt(), sz.toInt());
@@ -539,7 +556,7 @@ class PlansInMapScreen {
       return _MarkerData(icon, const Offset(0.5, 0.5));
     } catch (_) {
       if (photoUrl.isNotEmpty) {
-        return _buildNoPlanMarker('');
+        return _buildNoPlanMarker('', name);
       }
       // Si por algún motivo no se puede cargar la imagen de usuario ni el
       // placeholder, generamos un marcador básico en forma de círculo gris

--- a/app_src/lib/explore_screen/menu_side_bar/menu_side_bar_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/menu_side_bar_screen.dart
@@ -15,6 +15,7 @@ import 'settings/settings_screen.dart';
 import 'close_session_screen.dart';
 import 'subscribed_plans_screen.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import '../users_grid/users_grid_helpers.dart';
 
 class MainSideBarScreen extends StatefulWidget {
   final ValueChanged<bool>? onMenuToggled;
@@ -307,9 +308,14 @@ class MainSideBarScreenState extends State<MainSideBarScreen> {
                       children: [
                         CircleAvatar(
                           radius: 50,
-                          backgroundColor: Colors.grey.shade200,
-                          child: SvgPicture.asset('assets/usuario.svg',
-                              width: 50, height: 50),
+                          backgroundColor: avatarColor(userName),
+                          child: Text(
+                            getInitials(userName),
+                            style: const TextStyle(
+                                color: Colors.white,
+                                fontWeight: FontWeight.bold,
+                                fontSize: 30),
+                          ),
                         ),
                         const SizedBox(height: 8),
                         Text(
@@ -340,10 +346,17 @@ class MainSideBarScreenState extends State<MainSideBarScreen> {
                         backgroundImage: finalUrl != null
                             ? CachedNetworkImageProvider(finalUrl)
                             : null,
-                        backgroundColor: Colors.grey.shade200,
+                        backgroundColor: finalUrl != null
+                            ? Colors.grey.shade200
+                            : avatarColor(userName),
                         child: finalUrl == null
-                            ? SvgPicture.asset('assets/usuario.svg',
-                                width: 50, height: 50)
+                            ? Text(
+                                getInitials(userName),
+                                style: const TextStyle(
+                                    color: Colors.white,
+                                    fontWeight: FontWeight.bold,
+                                    fontSize: 30),
+                              )
                             : null,
                       ),
                       const SizedBox(height: 8),

--- a/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
+++ b/app_src/lib/explore_screen/plans_managing/frosted_plan_dialog_state.dart
@@ -878,7 +878,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
           UserInfoCheck.open(context, senderId);
         }
       },
-      child: buildProfileAvatar(senderPic, radius: 20),
+      child: buildProfileAvatar(senderPic, radius: 20, userName: senderName),
     );
 
     final nameWidget = GestureDetector(
@@ -1066,7 +1066,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              buildProfileAvatar(pic, radius: 16),
+              buildProfileAvatar(pic, radius: 16, userName: name),
               const SizedBox(width: 8),
               Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -1126,6 +1126,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                 child: buildProfileAvatar(
                   pic1,
                   radius: avatarSize / 2,
+                  userName: p1['name'] ?? '',
                 ),
               ),
               Positioned(
@@ -1133,6 +1134,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                 child: buildProfileAvatar(
                   pic2,
                   radius: avatarSize / 2,
+                  userName: p2['name'] ?? '',
                 ),
               ),
               if (hasExtras)
@@ -1249,6 +1251,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
                         leading: buildProfileAvatar(
                           pic,
                           radius: 22,
+                          userName: name,
                         ),
                         title: Row(
                           mainAxisSize: MainAxisSize.min,
@@ -1519,6 +1522,7 @@ class _FrostedPlanDialogState extends State<FrostedPlanDialog> {
             child: buildProfileAvatar(
               _creatorPhotoUrl,
               radius: 20,
+              userName: name,
             ),
           ),
           const SizedBox(width: 8),
@@ -2124,6 +2128,7 @@ class _CustomShareDialogContentState extends State<_CustomShareDialogContent> {
             leading: buildProfileAvatar(
               photo,
               radius: 20,
+              userName: name,
             ),
             title: Text(
               name,

--- a/app_src/lib/explore_screen/plans_managing/plan_card.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_card.dart
@@ -444,7 +444,15 @@ class PlanCardState extends State<PlanCard> {
         radius: 20,
         backgroundImage:
             senderPic.isNotEmpty ? CachedNetworkImageProvider(senderPic) : null,
-        backgroundColor: Colors.blueGrey[100],
+        backgroundColor:
+            senderPic.isNotEmpty ? Colors.blueGrey[100] : avatarColor(senderName),
+        child: senderPic.isEmpty
+            ? Text(
+                getInitials(senderName),
+                style: const TextStyle(
+                    color: Colors.white, fontWeight: FontWeight.bold),
+              )
+            : null,
       ),
     );
 
@@ -626,7 +634,8 @@ class PlanCardState extends State<PlanCard> {
             mainAxisSize: MainAxisSize.min,
             children: [
               // Avatar
-              buildProfileAvatar(photoUrl, coverUrl: coverUrl),
+              buildProfileAvatar(photoUrl,
+                  coverUrl: coverUrl, userName: name),
               const SizedBox(width: 8),
 
               // Nombre y estado de actividad
@@ -728,7 +737,15 @@ class PlanCardState extends State<PlanCard> {
                 radius: 16,
                 backgroundImage:
                     pic.isNotEmpty ? CachedNetworkImageProvider(pic) : null,
-                backgroundColor: Colors.blueGrey[400],
+                backgroundColor:
+                    pic.isNotEmpty ? Colors.blueGrey[400] : avatarColor(name),
+                child: pic.isEmpty
+                    ? Text(
+                        getInitials(name),
+                        style: const TextStyle(
+                            color: Colors.white, fontWeight: FontWeight.bold),
+                      )
+                    : null,
               ),
               const SizedBox(width: 8),
               Column(
@@ -790,7 +807,15 @@ class PlanCardState extends State<PlanCard> {
                   radius: avatarSize / 2,
                   backgroundImage:
                       pic1.isNotEmpty ? CachedNetworkImageProvider(pic1) : null,
-                  backgroundColor: Colors.blueGrey[400],
+                  backgroundColor:
+                      pic1.isNotEmpty ? Colors.blueGrey[400] : avatarColor(p1['name'] ?? ''),
+                  child: pic1.isEmpty
+                      ? Text(
+                          getInitials(p1['name'] ?? ''),
+                          style: const TextStyle(
+                              color: Colors.white, fontWeight: FontWeight.bold),
+                        )
+                      : null,
                 ),
               ),
               Positioned(
@@ -799,7 +824,15 @@ class PlanCardState extends State<PlanCard> {
                   radius: avatarSize / 2,
                   backgroundImage:
                       pic2.isNotEmpty ? CachedNetworkImageProvider(pic2) : null,
-                  backgroundColor: Colors.blueGrey[400],
+                  backgroundColor:
+                      pic2.isNotEmpty ? Colors.blueGrey[400] : avatarColor(p2['name'] ?? ''),
+                  child: pic2.isEmpty
+                      ? Text(
+                          getInitials(p2['name'] ?? ''),
+                          style: const TextStyle(
+                              color: Colors.white, fontWeight: FontWeight.bold),
+                        )
+                      : null,
                 ),
               ),
               if (hasExtras)
@@ -927,7 +960,15 @@ class PlanCardState extends State<PlanCard> {
                           radius: 22,
                           backgroundImage:
                               pic.isNotEmpty ? CachedNetworkImageProvider(pic) : null,
-                          backgroundColor: Colors.blueGrey[400],
+                          backgroundColor:
+                              pic.isNotEmpty ? Colors.blueGrey[400] : avatarColor(name),
+                          child: pic.isEmpty
+                              ? Text(
+                                  getInitials(name),
+                                  style: const TextStyle(
+                                      color: Colors.white, fontWeight: FontWeight.bold),
+                                )
+                              : null,
                         ),
                         title: Row(
                           mainAxisSize: MainAxisSize.min,

--- a/app_src/lib/explore_screen/profile/profile_screen.dart
+++ b/app_src/lib/explore_screen/profile/profile_screen.dart
@@ -291,7 +291,7 @@ class ProfileScreenState extends State<ProfileScreen> {
                     child: CircleAvatar(
                       radius: 45,
                       backgroundColor: Colors.white,
-                      child: _buildInnerAvatar(),
+                      child: _buildInnerAvatar(userName),
                     ),
                   ),
                   Positioned(bottom: 0, right: 0, child: _avatarCameraIcon()),
@@ -350,7 +350,7 @@ class ProfileScreenState extends State<ProfileScreen> {
   }
 
   // NUEVO: avatar interior con foto o icono
-  Widget _buildInnerAvatar() {
+  Widget _buildInnerAvatar([String name = '']) {
     final bool hasPhoto =
         profileImageUrl != null && profileImageUrl!.isNotEmpty;
     final String? coverUrl =
@@ -361,12 +361,17 @@ class ProfileScreenState extends State<ProfileScreen> {
 
     return CircleAvatar(
       radius: 42,
-      backgroundColor: finalUrl != null ? Colors.transparent : Colors.grey[300],
+      backgroundColor:
+          finalUrl != null ? Colors.transparent : avatarColor(name),
       backgroundImage:
           finalUrl != null ? CachedNetworkImageProvider(finalUrl) : null,
       child: finalUrl != null
           ? null
-          : SvgPicture.asset('assets/usuario.svg', width: 42, height: 42),
+          : Text(
+              getInitials(name),
+              style: const TextStyle(
+                  color: Colors.white, fontWeight: FontWeight.bold, fontSize: 32),
+            ),
     );
   }
 

--- a/app_src/lib/explore_screen/users_grid/users_grid.dart
+++ b/app_src/lib/explore_screen/users_grid/users_grid.dart
@@ -354,6 +354,7 @@ class _UsersGridState extends State<UsersGrid> {
                           buildProfileAvatar(
                             fallbackPhotoUrl,
                             coverUrl: coverPhotoUrl,
+                            userName: name,
                           ),
                           const SizedBox(width: 8),
                           Column(

--- a/app_src/lib/explore_screen/users_grid/users_grid_helpers.dart
+++ b/app_src/lib/explore_screen/users_grid/users_grid_helpers.dart
@@ -3,6 +3,44 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'dart:math' as math;
 
+/// Obtiene las iniciales a partir del [nombre]. Si contiene una sola palabra
+/// se toma la primera letra; si tiene dos o más, se utilizan las dos primeras
+/// iniciales.
+String getInitials(String nombre) {
+  final trimmed = nombre.trim();
+  if (trimmed.isEmpty) return '';
+  final partes = trimmed.split(RegExp(r'\s+')).where((p) => p.isNotEmpty).toList();
+  if (partes.isEmpty) return '';
+  if (partes.length == 1) {
+    final palabra = partes.first;
+    return palabra.isNotEmpty ? palabra.substring(0, 1).toUpperCase() : '';
+  }
+  return (partes[0][0] + partes[1][0]).toUpperCase();
+}
+
+/// Genera un color de fondo a partir del [nombre] para que cada usuario tenga
+/// un color consistente.
+Color avatarColor(String nombre) {
+  final idx = nombre.hashCode.abs() % Colors.primaries.length;
+  return Colors.primaries[idx];
+}
+
+/// Construye un avatar mostrando las iniciales cuando no hay foto disponible.
+Widget buildInitialsAvatar(String nombre, double radius) {
+  return CircleAvatar(
+    radius: radius,
+    backgroundColor: avatarColor(nombre),
+    child: Text(
+      getInitials(nombre),
+      style: TextStyle(
+        color: Colors.white,
+        fontWeight: FontWeight.bold,
+        fontSize: radius * 0.8,
+      ),
+    ),
+  );
+}
+
 /// Placeholder genérico para cuando falle el loading de una imagen.
 Widget buildPlaceholder() {
   return SizedBox(
@@ -23,7 +61,7 @@ Widget buildPlaceholder() {
 /// utilizar la imagen de fondo como alternativa. Si tampoco hay imagen de
 /// fondo, se muestra un placeholder con silueta.
 Widget buildProfileAvatar(String? photoUrl,
-    {String? coverUrl, double radius = 20}) {
+    {String? coverUrl, double radius = 20, String? userName}) {
   String? finalUrl;
   if (photoUrl != null && photoUrl.isNotEmpty) {
     finalUrl = photoUrl;
@@ -36,6 +74,8 @@ Widget buildProfileAvatar(String? photoUrl,
       radius: radius,
       backgroundImage: CachedNetworkImageProvider(finalUrl),
     );
+  } else if (userName != null && userName.trim().isNotEmpty) {
+    return buildInitialsAvatar(userName, radius);
   } else {
     return CircleAvatar(
       radius: radius,

--- a/app_src/lib/explore_screen/users_managing/user_info_check.dart
+++ b/app_src/lib/explore_screen/users_managing/user_info_check.dart
@@ -414,10 +414,15 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
                     radius: 42,
                     backgroundImage:
                         avatarUrl != null ? CachedNetworkImageProvider(avatarUrl) : null,
-                    backgroundColor: Colors.grey[300],
+                    backgroundColor: avatarUrl != null
+                        ? Colors.grey[300]
+                        : avatarColor(userName),
                     child: avatarUrl == null
-                        ? SvgPicture.asset('assets/usuario.svg',
-                            width: 42, height: 42)
+                        ? Text(
+                            getInitials(userName),
+                            style: const TextStyle(
+                                color: Colors.white, fontWeight: FontWeight.bold),
+                          )
                         : null,
                   ),
                 ),


### PR DESCRIPTION
## Resumen
- genera iniciales y color de avatar en `users_grid_helpers`
- usa estas iniciales en tarjetas de planes, perfiles, chats y menú lateral
- actualiza marcadores de mapas sin foto para mostrar iniciales
- corrige cálculo de iniciales para nombres vacíos y la caché en marcadores

## Testing
- `flutter analyze` *(falló: comando no encontrado)*
- `flutter test` *(falló: comando no encontrado)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_687aa7aa52f08332a3e0b7ae7a9b7e29