### PR TITLE
Implement cached initials lookup

### DIFF
--- a/app_src/lib/explore_screen/map/plans_in_map_screen.dart
+++ b/app_src/lib/explore_screen/map/plans_in_map_screen.dart
@@ -531,9 +531,10 @@ class PlansInMapScreen {
         );
       } else {
         canvas.drawCircle(center, r, Paint()..color = avatarColor(name));
+        final initials = await getInitials(name);
         final tp = TextPainter(
           text: TextSpan(
-            text: getInitials(name),
+            text: initials,
             style: const TextStyle(
                 color: Colors.white, fontWeight: FontWeight.bold, fontSize: 24),
           ),

--- a/app_src/lib/explore_screen/menu_side_bar/menu_side_bar_screen.dart
+++ b/app_src/lib/explore_screen/menu_side_bar/menu_side_bar_screen.dart
@@ -310,7 +310,7 @@ class MainSideBarScreenState extends State<MainSideBarScreen> {
                           radius: 50,
                           backgroundColor: avatarColor(userName),
                           child: Text(
-                            getInitials(userName),
+                            getInitialsSync(userName),
                             style: const TextStyle(
                                 color: Colors.white,
                                 fontWeight: FontWeight.bold,
@@ -351,7 +351,7 @@ class MainSideBarScreenState extends State<MainSideBarScreen> {
                             : avatarColor(userName),
                         child: finalUrl == null
                             ? Text(
-                                getInitials(userName),
+                                getInitialsSync(userName),
                                 style: const TextStyle(
                                     color: Colors.white,
                                     fontWeight: FontWeight.bold,

--- a/app_src/lib/explore_screen/plans_managing/plan_card.dart
+++ b/app_src/lib/explore_screen/plans_managing/plan_card.dart
@@ -513,7 +513,7 @@ class PlanCardState extends State<PlanCard> {
             senderPic.isNotEmpty ? Colors.blueGrey[100] : avatarColor(senderName),
         child: senderPic.isEmpty
             ? Text(
-                getInitials(senderName),
+                getInitialsSync(senderName),
                 style: const TextStyle(
                     color: Colors.white, fontWeight: FontWeight.bold),
               )
@@ -806,7 +806,7 @@ class PlanCardState extends State<PlanCard> {
                     pic.isNotEmpty ? Colors.blueGrey[400] : avatarColor(name),
                 child: pic.isEmpty
                     ? Text(
-                        getInitials(name),
+                        getInitialsSync(name),
                         style: const TextStyle(
                             color: Colors.white, fontWeight: FontWeight.bold),
                       )
@@ -876,7 +876,7 @@ class PlanCardState extends State<PlanCard> {
                       pic1.isNotEmpty ? Colors.blueGrey[400] : avatarColor(p1['name'] ?? ''),
                   child: pic1.isEmpty
                       ? Text(
-                          getInitials(p1['name'] ?? ''),
+                          getInitialsSync(p1['name'] ?? ''),
                           style: const TextStyle(
                               color: Colors.white, fontWeight: FontWeight.bold),
                         )
@@ -893,7 +893,7 @@ class PlanCardState extends State<PlanCard> {
                       pic2.isNotEmpty ? Colors.blueGrey[400] : avatarColor(p2['name'] ?? ''),
                   child: pic2.isEmpty
                       ? Text(
-                          getInitials(p2['name'] ?? ''),
+                          getInitialsSync(p2['name'] ?? ''),
                           style: const TextStyle(
                               color: Colors.white, fontWeight: FontWeight.bold),
                         )
@@ -1029,7 +1029,7 @@ class PlanCardState extends State<PlanCard> {
                               pic.isNotEmpty ? Colors.blueGrey[400] : avatarColor(name),
                           child: pic.isEmpty
                               ? Text(
-                                  getInitials(name),
+                                  getInitialsSync(name),
                                   style: const TextStyle(
                                       color: Colors.white, fontWeight: FontWeight.bold),
                                 )

--- a/app_src/lib/explore_screen/profile/profile_screen.dart
+++ b/app_src/lib/explore_screen/profile/profile_screen.dart
@@ -367,10 +367,18 @@ class ProfileScreenState extends State<ProfileScreen> {
           finalUrl != null ? CachedNetworkImageProvider(finalUrl) : null,
       child: finalUrl != null
           ? null
-          : Text(
-              getInitials(name),
-              style: const TextStyle(
-                  color: Colors.white, fontWeight: FontWeight.bold, fontSize: 32),
+          : FutureBuilder<String>(
+              future: getInitials(name),
+              builder: (context, snapshot) {
+                final initials = snapshot.data ?? getInitialsSync(name);
+                return Text(
+                  initials,
+                  style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 32),
+                );
+              },
             ),
     );
   }

--- a/app_src/lib/explore_screen/users_managing/user_info_check.dart
+++ b/app_src/lib/explore_screen/users_managing/user_info_check.dart
@@ -419,7 +419,7 @@ class _UserInfoCheckState extends State<UserInfoCheck> {
                         : avatarColor(userName),
                     child: avatarUrl == null
                         ? Text(
-                            getInitials(userName),
+                            getInitialsSync(userName),
                             style: const TextStyle(
                                 color: Colors.white, fontWeight: FontWeight.bold),
                           )


### PR DESCRIPTION
## Summary
- add `SharedPreferences` caching for user initials
- expose `getInitialsSync` helper
- update avatar widgets to use new caching logic
- avoid range errors when computing initials

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ab7b31bcc8332aa3b3d490088e33c