### PR TITLE
Fix missing sender name in join request notifications

### DIFF
--- a/app_src/lib/explore_screen/main_screen/notification_screen.dart
+++ b/app_src/lib/explore_screen/main_screen/notification_screen.dart
@@ -495,8 +495,10 @@ class _NotificationScreenState extends State<NotificationScreen> {
                               data['planType'] ?? data['planName'] ?? 'Plan';
                           final planId = data['planId'] ?? '';
                           final senderId = data['senderId'] ?? '';
-                          final senderPhoto = data['senderProfilePic'] ?? '';
-                          final senderName = data['senderName'] ?? '';
+                          final senderPhoto =
+                              data['senderProfilePic'] ?? data['requesterProfilePic'] ?? '';
+                          final senderName =
+                              data['senderName'] ?? data['requesterName'] ?? '';
                           final type = data['type'] as String? ?? '';
                           final timestamp = data['timestamp'];
                           final timeString = _formatTimestamp(timestamp);
@@ -587,6 +589,7 @@ class _NotificationScreenState extends State<NotificationScreen> {
                             child: buildProfileAvatar(
                               senderPhoto,
                               radius: 25,
+                              userName: senderName,
                             ),
                           );
 

--- a/app_src/lib/plan_joining/plan_join_request.dart
+++ b/app_src/lib/plan_joining/plan_join_request.dart
@@ -123,8 +123,8 @@ class JoinPlanRequestScreen {
           .get();
 
       final userData = userDoc.data() ?? {};
-      final String requesterName = userData['name'] ?? 'Sin nombre';
-      final String requesterProfilePic = userData['photoUrl'] ?? '';
+      final String senderName = userData['name'] ?? 'Sin nombre';
+      final String senderProfilePic = userData['photoUrl'] ?? '';
 
       // 5) Crear la notificación "join_request"
       await FirebaseFirestore.instance.collection('notifications').add({
@@ -133,8 +133,8 @@ class JoinPlanRequestScreen {
         'senderId': currentUser.uid,   // Quién envía la solicitud
         'planId': planId,
         'planName': planName,
-        'requesterName': requesterName,
-        'requesterProfilePic': requesterProfilePic,
+        'senderName': senderName,
+        'senderProfilePic': senderProfilePic,
         'timestamp': FieldValue.serverTimestamp(),
       });
 


### PR DESCRIPTION
## Summary
- fix join request notification fields to use `senderName` and `senderProfilePic`
- ensure notification screen reads old `requester*` fields as fallback
- show initials when sender has no profile picture

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aba60cf048332a4a39acfabd2c70a