### PR TITLE
Fix initials on user markers

### DIFF
--- a/app_src/lib/explore_screen/map/plans_in_map_screen.dart
+++ b/app_src/lib/explore_screen/map/plans_in_map_screen.dart
@@ -531,7 +531,9 @@ class PlansInMapScreen {
         );
       } else {
         canvas.drawCircle(center, r, Paint()..color = avatarColor(name));
-        final initials = await getInitials(name);
+        // Evitamos usar la versión con caché para asegurar
+        // que cada marcador muestre las iniciales correctas.
+        final initials = getInitialsSync(name);
         final tp = TextPainter(
           text: TextSpan(
             text: initials,


### PR DESCRIPTION
## Summary
- ensure initials on map markers use the synchronous method without cache

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aba9b4fd883329678ac26582c2fc1