### PR TITLE
Precarga de imágenes en perfil

### DIFF
--- a/app_src/lib/explore_screen/profile/profile_screen.dart
+++ b/app_src/lib/explore_screen/profile/profile_screen.dart
@@ -82,12 +82,24 @@ class ProfileScreenState extends State<ProfileScreen> {
   Future<void> _fetchProfileImage() async {
     final url = await UserImagesManaging.fetchProfileImage(context);
     if (!mounted) return;
+    if (url.isNotEmpty) {
+      try {
+        await precacheImage(CachedNetworkImageProvider(url), context);
+      } catch (_) {}
+    }
     setState(() => profileImageUrl = url);
   }
 
   Future<void> _fetchCoverImages() async {
     final covers = await UserImagesManaging.fetchCoverImages(context);
     if (!mounted) return;
+    for (final url in covers) {
+      if (url.isNotEmpty) {
+        try {
+          await precacheImage(CachedNetworkImageProvider(url), context);
+        } catch (_) {}
+      }
+    }
     setState(() => coverImages = covers);
   }
 


### PR DESCRIPTION
## Summary
- precachear imágenes de perfil y portadas al obtenerlas

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ac1986ddc833283a939902d70e570